### PR TITLE
Update formative_memories.py

### DIFF
--- a/concordia/associative_memory/formative_memories.py
+++ b/concordia/associative_memory/formative_memories.py
@@ -213,7 +213,7 @@ class FormativeMemoryFactory:
         terminators=[],
     )
 
-    episodes = aggregated_result.split('\n\n\n')
+    episodes = aggregated_result.split('\n\n')
 
     if len(episodes) != len(list(agent_config.formative_ages)):
       logger.warning(


### PR DESCRIPTION
Going to win awards for the smallest contribution on the planet!!! - I will be back with a bigger contribution soon though ;)! 

It seems splitting lines over "\n\n\n" isn't robust enough to ensure the aggregated formative episodes split into individual episodes, to then be zipped into memories. 

When I run it with a "\n\n" separator, my experiments including the example "three_key_questions" run without the warning from episodes == DEFAULT_FORMATIVE_AGES.

Of course, given how sensitive this is, it may make sense to implement a more robust fix. This works repeatedly for me.