### PR TITLE
Fix calendar example

### DIFF
--- a/concordia/components/agent/observation.py
+++ b/concordia/components/agent/observation.py
@@ -17,6 +17,7 @@
 
 from collections.abc import Callable, Sequence
 import datetime
+
 from concordia.associative_memory import associative_memory
 from concordia.document import interactive_document
 from concordia.language_model import language_model
@@ -83,7 +84,7 @@ class Observation(component.Component):
 
   def observe(self, observation: str):
     self._memory.add(
-        f'[observation] {observation}',
+        f'[observation] {observation.strip()}',
         tags=['observation'],
     )
 

--- a/concordia/components/agent/v2/observation.py
+++ b/concordia/components/agent/v2/observation.py
@@ -59,7 +59,7 @@ class Observation(action_spec_ignored.ActionSpecIgnored):
       observation: str,
   ) -> str:
     self._memory.add(
-        f'[observation] {observation}',
+        f'[observation] {observation.strip()}',
         tags=['observation'],
     )
     return ''

--- a/concordia/thought_chains/thought_chains.py
+++ b/concordia/thought_chains/thought_chains.py
@@ -234,10 +234,10 @@ def result_to_who_what_where(
   chain_of_thought.statement(event)
   causal_statement = chain_of_thought.open_question(
       'Rewrite the statements above to be one sentence and to better highlight'
-      ' who the event is about, where and what they did, and what happened as a'
-      ' result. Do not express uncertainty (e.g. say '
-      '"Francis opened the door" not "Francis could open the door" '
-      'and not "The door may have been opened").\n',
+      ' the main person the event is about, where and what they did, and what'
+      ' happened as a result. Do not express uncertainty (e.g. say "Francis'
+      ' opened the door" not "Francis could open the door" and not "The door'
+      ' may have been opened").\n',
       max_tokens=1500,
   )
   return causal_statement

--- a/examples/phone/calendar.ipynb
+++ b/examples/phone/calendar.ipynb
@@ -17,7 +17,7 @@
         "id": "bIgfldBE9FUe"
       },
       "source": [
-        "\u003ca href=\"https://colab.research.google.com/github/google-deepmind/concordia/blob/main/examples/phone/calendar.ipynb\" target=\"_parent\"\u003e\u003cimg src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/\u003e\u003c/a\u003e"
+        "<a href=\"https://colab.research.google.com/github/google-deepmind/concordia/blob/main/examples/phone/calendar.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -37,7 +37,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install --ignore-requires-python git+https://github.com/google-deepmind/concordia.git"
+        "%pip install --ignore-requires-python git+https://github.com/google-deepmind/concordia.git"
       ]
     },
     {
@@ -48,7 +48,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -r https://raw.githubusercontent.com/google-deepmind/concordia/main/examples/requirements.txt"
+        "%pip install -r https://raw.githubusercontent.com/google-deepmind/concordia/main/examples/requirements.txt"
       ]
     },
     {
@@ -63,7 +63,9 @@
         "\n",
         "import concurrent.futures\n",
         "import datetime\n",
+        "import os\n",
         "import random\n",
+        "import sys\n",
         "\n",
         "from IPython import display\n",
         "import sentence_transformers\n",
@@ -80,6 +82,11 @@
         "from concordia.environment import game_master\n",
         "from concordia.language_model import gpt_model\n",
         "from concordia.utils import html as html_lib\n",
+        "\n",
+        "# Add the project root to the Python path\n",
+        "project_root = os.path.abspath(os.path.join(os.getcwd(), '..', '..'))\n",
+        "if project_root not in sys.path:\n",
+        "    sys.path.append(project_root)\n",
         "\n",
         "from examples.phone.components import apps\n",
         "from examples.phone.components import triggering"
@@ -186,10 +193,10 @@
         "#@title Make the clock\n",
         "SETUP_TIME = datetime.datetime(hour=8, year=2024, month=9, day=1)\n",
         "\n",
-        "START_TIME = datetime.datetime(hour=9, year=2024, month=10, day=1)\n",
+        "START_TIME = datetime.datetime(hour=8, year=2024, month=10, day=1)\n",
         "clock = game_clock.MultiIntervalClock(\n",
         "    start=SETUP_TIME,\n",
-        "    step_sizes=[datetime.timedelta(hours=1), datetime.timedelta(seconds=10)])\n"
+        "    step_sizes=[datetime.timedelta(minutes=15), datetime.timedelta(seconds=10)])"
       ]
     },
     {
@@ -245,12 +252,17 @@
         "  somatic_state = components.somatic_state.SomaticState(\n",
         "      model, mem, agent_config.name, clock.now\n",
         "  )\n",
-        "  identity = components.identity.SimIdentity(model, mem, agent_config.name)\n",
+        "  identity = components.identity.SimIdentity(\n",
+        "    model=model,\n",
+        "    memory=mem,\n",
+        "    agent_name=agent_config.name,\n",
+        "    clock_now=clock.now,\n",
+        "  )\n",
         "  goal_component = components.constant.ConstantComponent(state=agent_config.goal)\n",
         "  plan = components.plan.SimPlan(\n",
-        "      model,\n",
-        "      mem,\n",
-        "      agent_config.name,\n",
+        "      model=model,\n",
+        "      memory=mem,\n",
+        "      agent_name=agent_config.name,\n",
         "      clock_now=clock.now,\n",
         "      components=[identity],\n",
         "      goal=goal_component,\n",
@@ -269,10 +281,11 @@
         "      clock_now=clock.now,\n",
         "      memory=mem,\n",
         "      timeframe_delta_from=datetime.timedelta(hours=4),\n",
-        "      timeframe_delta_until=datetime.timedelta(hours=1),\n",
+        "      timeframe_delta_until=datetime.timedelta(minutes=15),\n",
         "      components=[identity],\n",
         "      component_name='summary of observations',\n",
         "  )\n",
+        "\n",
         "  agent = basic_agent.BasicAgent(\n",
         "      model=model,\n",
         "      agent_name=agent_config.name,\n",
@@ -302,9 +315,8 @@
       "outputs": [],
       "source": [
         "NUM_PLAYERS = 2\n",
-        "victim = 'Alice'\n",
         "\n",
-        "def make_random_big_five()-\u003estr:\n",
+        "def make_random_big_five()->str:\n",
         "  return str({\n",
         "      'extraversion': random.randint(1, 10),\n",
         "      'neuroticism': random.randint(1, 10),\n",
@@ -491,7 +503,7 @@
         "# @title Expect about 2-3 minutes per step.\n",
         "episode_length = 12  # @param {type: 'integer'}\n",
         "for _ in range(episode_length):\n",
-        "  env.step()\n"
+        "  env.step()"
       ]
     },
     {
@@ -552,7 +564,7 @@
         "  all_player_mem = ['Summary:', summary, 'Memories:'] + all_player_mem\n",
         "  player_html = html_lib.PythonObjectToHTMLConverter(all_player_mem).convert()\n",
         "  player_logs.append(player_html)\n",
-        "  player_log_names.append(f'{name}')\n"
+        "  player_log_names.append(f'{name}')"
       ]
     },
     {
@@ -561,7 +573,7 @@
         "id": "UmPOvjVxddye"
       },
       "source": [
-        "#Build and display HTML log of the experiment"
+        "## Build and display HTML log of the experiment"
       ]
     },
     {
@@ -614,7 +626,7 @@
         "id": "HX-M9Im_dneG"
       },
       "source": [
-        "#Interact with a specific player"
+        "## Interact with a specific player"
       ]
     },
     {
@@ -643,9 +655,18 @@
       },
       "outputs": [],
       "source": [
-        "utterence_from_user = 'Did you schedule a meeting with Bob?'  # @param {type:\"string\"}\n",
+        "utterance_from_user = (\n",
+        "    \"Hey Alice, I know you had planned to set up a meeting with Bob this morning \"\n",
+        "    \"between 8:00 and 8:30, but I wanted to double-check something. Did you \"\n",
+        "    \"actually open your calendar app and create the event today? I'm not asking \"\n",
+        "    \"about your intention or plan, but specifically whether you remember \"\n",
+        "    \"physically using your phone to schedule it. Can you think back and tell me \"\n",
+        "    \"if you concretely remember doing that action this morning? If you did, what \"\n",
+        "    \"exact time did you do it? And if not, that's okay too - I just want to make \"\n",
+        "    \"sure we're clear on whether it's been scheduled or if it's still on your to-do list.\"\n",
+        ") # @param {type:\"string\"}\n",
         "\n",
-        "interrogation += f'{user_identity}: {utterence_from_user}'\n",
+        "interrogation += f'{user_identity}: {utterance_from_user}'\n",
         "player_says = selected_player.say(interrogation)\n",
         "interrogation += f'\\n{sim_to_interact}: {player_says}\\n'\n",
         "print(interrogation)"
@@ -690,7 +711,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.4"
     }
   },
   "nbformat": 4,

--- a/examples/phone/calendar.ipynb
+++ b/examples/phone/calendar.ipynb
@@ -711,16 +711,7 @@
       "name": "python3"
     },
     "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.4"
+      "name": "python"
     }
   },
   "nbformat": 4,

--- a/examples/phone/components/scene.py
+++ b/examples/phone/components/scene.py
@@ -15,32 +15,32 @@
 """A GameMaster that simulates a player's interaction with their phone."""
 
 import textwrap
+
 from concordia.agents import basic_agent
 from concordia.associative_memory import blank_memories
 from concordia.clocks import game_clock
 from concordia.document import interactive_document
 from concordia.environment import game_master as game_master_lib
-from examples.phone.components import apps
-from examples.phone.components import logging
 from concordia.language_model import language_model
 from concordia.thought_chains import thought_chains
 from concordia.typing import agent
 from concordia.typing import component
+from concordia.typing.entity import OutputType
 
+from examples.phone.components import apps
+from examples.phone.components import logging
 
 _PHONE_CALL_TO_ACTION = textwrap.dedent("""\
-  What actions would {agent_name} perform with their phone 
-  now to best achieve their goal? 
-  Consider their plan, but deviate from it if necessary.
-  Give a specific activity that can be performed using a
-  single app on the phone. For example, {agent_name} uses 
-  the Chat app to send a message to George saying 'hi, what's up?".
+  What action is {name} currently performing or has just performed
+  with their smartphone to best achieve their goal?
+  Consider their plan, but deviate if necessary.
+  Give a specific activity using one app. For example:
+  {name} uses/used the Chat app to send "hi, what's up?" to George.
   """)
 
 _PHONE_ACTION_SPEC = agent.ActionSpec(
-    _PHONE_CALL_TO_ACTION, 'FREE', tag='phone'
+    _PHONE_CALL_TO_ACTION, OutputType.FREE, tag='phone'
 )
-
 
 def build(
     player: basic_agent.BasicAgent,
@@ -101,7 +101,8 @@ class _PhoneComponent(component.Component):
     chain_of_thought.statement(f'Interaction with phone:\n{self._state}')
 
     did_conclude = chain_of_thought.yes_no_question(
-        'Is the user finished using their phone?'
+        'Has the user achieved their goal with their phone or are they still'
+        ' actively in the process of completing a phone task?'
     )
     return did_conclude
 
@@ -114,7 +115,6 @@ class _PhoneComponent(component.Component):
         'In the above transcript, what app did the user use?',
         answers=self._phone.app_names(),
     )
-
     app = self._phone.apps[app_index]
     action_names = [a.name for a in app.actions()]
     chain_of_thought.statement(app.description())

--- a/examples/phone/components/triggering.py
+++ b/examples/phone/components/triggering.py
@@ -16,17 +16,19 @@
 """A component that runs the phone scene when a phone action is detected."""
 
 from collections.abc import Sequence
+
 from concordia.agents import basic_agent
 from concordia.associative_memory import associative_memory
 from concordia.associative_memory import blank_memories
 from concordia.clocks import game_clock
 from concordia.document import interactive_document
-from examples.phone.components import apps
-from examples.phone.components import logging
-from examples.phone.components import scene
 from concordia.language_model import language_model
 from concordia.typing import component
 from concordia.utils import helper_functions
+
+from examples.phone.components import apps
+from examples.phone.components import logging
+from examples.phone.components import scene
 
 
 class SceneTriggeringComponent(component.Component):
@@ -60,7 +62,17 @@ class SceneTriggeringComponent(component.Component):
     document.statement(f'Event: {event_statement}')
 
     return document.yes_no_question(
-        'Did a player interact with their smartphone as part of this event?'
+        'Did a player engage in any activity typically associated with'
+        ' smartphone use during this event? Consider not only explicit mentions'
+        ' of phone interaction, but also actions commonly performed using'
+        ' mobile apps or smartphone features. This includes, but is not limited'
+        ' to:\n- Communicating (e.g., messaging, calling, emailing)\n-'
+        ' Accessing information (e.g., browsing the internet, checking social'
+        ' media)\n- Using utility apps (e.g., calendar, notes, calculator)\n-'
+        ' Navigation or location services\n- Taking photos or videos\n- Using'
+        ' mobile payment systems\n- Playing mobile gamesEven if a phone is not'
+        ' explicitly mentioned, consider whether the described actions strongly'
+        ' imply smartphone use in modern contexts.'
     )
 
   def _get_player_from_event(
@@ -76,8 +88,18 @@ class SceneTriggeringComponent(component.Component):
       is_player_using_phone = helper_functions.filter_copy_as_statement(
           document
       ).yes_no_question(
-          f'Does the event description explicitly state that {player.name}'
-          ' interacted with their phone?'
+          f'Does the event description indicate that {player.name} engaged in'
+          ' any activity typically associated with smartphone use? Consider'
+          ' both explicit mentions of phone interaction and actions commonly'
+          ' performed using mobile apps or smartphone features, including but'
+          ' not limited to:\n- Communicating (e.g., messaging, calling,'
+          ' emailing)\n- Accessing information (e.g., browsing the internet,'
+          ' checking social media)\n- Using utility apps (e.g., calendar,'
+          ' notes, calculator)\n- Navigation or location services\n- Taking'
+          ' photos or videos\n- Using mobile payment systems\n- Playing mobile'
+          f' gamesEven if {player.name} is not explicitly described as using a'
+          ' phone, consider whether their actions strongly imply smartphone'
+          ' use in modern contexts.'
       )
       if is_player_using_phone:
         return player


### PR DESCRIPTION
Fixes #66 

Some of these changes are definitely bugs preventing intended behavior from working, while others are improvements to the existing code to prevent edge cases I discovered. I separated the changes to `examples/phone` from the other changes in two separate commits in case you'd only like the former.

## `phone/components/scene.py`

- Fix `_PHONE_CALL_TO_ACTION` format variable to `name` instead of `agent_name` (this caused phone episodes to always fail before executing any phone actions)
- Fix `_PHONE_ACTION_SPEC` to use `OutputType.FREE` instead of `'FREE'` (which has no matching condition in `player.act()`)
- Update `did_conclude` chain of thought to be more descriptive (I was seeing it unable to understand that a task was complete and therefore running for the full 20 steps)
- Update `_PHONE_CALL_TO_ACTION` so it considers the most recent observation (I was seeing that if the most recent event was "Alice schedules meeting with Bob using smartphone", this prompt sees that as already done, so picks something else to do instead.) I think this wasn't needed previously because another bug was causing phone triggering events to never be observed?

## `phone/components/apps.py`

- Add `_print` method to `PhoneApp`
- Add `_print` statement to `ToyCalendar.add_meeting`
- Add check for unexpected arguments to `PhoneApp.invoke_action` (to prevent errors in `return getattr(self, action.name)(**args)` if a unexpected arg is provided)
- Update `Phone.description` to: "has *only* the following apps available" (since I was getting events like "Bob uses the Camera app to take photographs", which triggered the phone scene, but then scheduled an irrelevant meeting)
- Add `ToyCalendar.check_calendar` app action (since previously I was seeing that an event like, "Alice uses the Calendar app to check her schedule for the day and confirm her appointment with Bob." could only route to `add_meeting`, so it would repeat adding the same meeting). There's probably a better way to check to see if none of the app actions make sense in the context of the event and do nothing instead.

## `phone/components/triggering.py`

- Make phone triggering `yes_no_question` clearer in `_is_phone_event` and `_get_player_from_event` (I was seeing events like, "Alice sent a message to bob to schedule meeting" not being recognized as a phone action)

## `phone/calendar.ipynb`

- Add project root to python path to fix `examples.phone.components` import issue
- Fix `START_TIME` to be at `SETUP_TIME` instead of one hour after (since Alice's plan typically mentions scheduling the meeting at `SETUP_TIME` [8 AM], but the simulation was starting at 9 AM, so she seemed to think she already did that and no longer needs to)
- Change major clock step size to be 15 minutes instead of 1 hour (since Alice's plan typically involves taking 15 minutes to schedule the meeting, so if step size is much larger than that, she seems to skip this activity and instead choose plans with longer durations [like eating breakfast])
- Add missing `clock_now` to `SimIdentity`
- Remove unused `victim` variable
- Update `utterance_from_user` to be more explicit (since Alice was giving false positive confirmation by confusing plans for events)
- Change `ObservationSummary.timeframe_delta_until` to 15 minutes to match clock step size

**Note:** During the interrogation phase, since after 12 episodes, the `current observations` will not be far enough back in time to recall scheduling the meeting, and the `summary of observations` may skip this detail, Alice may answer that she doesn't recall whether she has successfully scheduled the meeting. Although not ideal, this seems better in my opinion than her just assuming she scheduled it because it's in her `plan`, as was previously happening.

**Reminder:** Need to comment out the pip installs in this notebook to preserve the below changes (the `thought_chains` modification appeared necessary in my testing to prevent edge cases)

## `observation.py`

- in `pre_observe` and `observe`, strip whitespace from observation to improve "[observation]" formatting

## `thought_chains.py`

- Changed `thought_chains.result_to_who_what_where`'s `open_question` from "who the event is about" to "the main person the event is about" (since I was previously seeing outputs like, e.g., "Bob is eating breakfast while Alice is scheduling a meeting", which resulted in triggering a 2nd phone event for Alice, even though Alice had already just scheduled the event and bob is the one currently acting)
