### PR TITLE
Fix issue with premise of buyer in haggling environment

### DIFF
--- a/examples/modular/environment/haggling.py
+++ b/examples/modular/environment/haggling.py
@@ -433,7 +433,7 @@ def configure_scenes(
                 this_game_players[0].name: [(
                     f'{scene_opening} {this_game_players[0].name} is trying to'
                     f' buy some fruit from {this_game_players[1].name}. They'
-                    f' are negotiating a price. {this_game_players[1].name} can'
+                    f' are negotiating a price. {this_game_players[0].name} can'
                     f' sell the fruit for {buyer_base_reward} coins back in her'
                     ' home town.'
                 )],


### PR DESCRIPTION
There is an mistake in the premise of the buyer in the haggling environment.

Currently it says:
"_Buyer_ is trying to buy some fruit from _Seller_. They are negotiating a price. **_Seller_** can sell the fruit for `buyer_base_reward` coins back in her home town."

It would make more sense if it would say this:
"_Buyer_ is trying to buy some fruit from _Seller_. They are negotiating a price. **_Buyer_** can sell the fruit for `buyer_base_reward` coins back in her home town."

The buyer intends to sell the fruit (which she bought from the seller) in her home town.
This fits with the score of the buyer being the `buyer_base_reward` -  the price they paid to buy the fruit:
https://github.com/google-deepmind/concordia/blob/c35440e58c56554b8fa7351e500c62f043e8a1e0/concordia/contrib/components/game_master/bargain_payoffs.py#L186-L189