### PR TITLE
Update agent_components_tutorial.ipynb

### DIFF
--- a/examples/tutorials/agent_components_tutorial.ipynb
+++ b/examples/tutorials/agent_components_tutorial.ipynb
@@ -350,7 +350,7 @@
         "        limit=5,\n",
         "        scoring_fn=legacy_associative_memory.RetrieveRecent(),\n",
         "    )\n",
-        "    recent_memories = \" \".join(memory[0] for memory in recent_memories_list)\n",
+        "    recent_memories = \" \".join(memory.text for memory in recent_memories_list)\n",
         "    print(f\"*****\\nDEBUG: Recent memories:\\n  {recent_memories}\\n*****\")\n",
         "    return recent_memories"
       ]


### PR DESCRIPTION
Access memory text via memory.text instead of memory[0], as memory is not a subscriptable list and gives an error.