### PR TITLE
Fix conditional error in SendEventToRelevantPlayers

### DIFF
--- a/concordia/components/game_master/event_resolution.py
+++ b/concordia/components/game_master/event_resolution.py
@@ -394,12 +394,12 @@ class SendEventToRelevantPlayers(
           result = action_attempt.replace(
               self._map_names_to_previous_observations[active_entity_name], ''
           )
-        if self._optional_make_observation_component_key:
-          make_observation = self.get_entity().get_component(
-              self._optional_make_observation_component_key,
-              type_=make_observation_component.MakeObservation,
-          )
-          make_observation.add_to_queue(active_entity_name, result)
+          if self._optional_make_observation_component_key:
+            make_observation = self.get_entity().get_component(
+                self._optional_make_observation_component_key,
+                type_=make_observation_component.MakeObservation,
+            )
+            make_observation.add_to_queue(active_entity_name, result)
 
         self._map_names_to_previous_observations[active_entity_name] += result
 


### PR DESCRIPTION
While reading through the code, I noticed some odd logic. Checking through the commit history, it looks like a cut/paste error from an earlier migration:

https://github.com/google-deepmind/concordia/commit/301fe0a5e2583cfafd843ad7b48138ccd4d2b063