### PR TITLE
Add api_base parameter to gpt_model

### DIFF
--- a/concordia/language_model/gpt_model.py
+++ b/concordia/language_model/gpt_model.py
@@ -50,10 +50,7 @@ class GptLanguageModel(BaseGPTModel):
     if api_key is None:
       api_key = os.environ['OPENAI_API_KEY']
     self._api_key = api_key
-    if api_base is None:
-      client = openai.OpenAI(api_key=self._api_key)
-    else:
-      client = openai.OpenAI(api_key=self._api_key, base_url=api_base)
+    client = openai.OpenAI(api_key=self._api_key, base_url=api_base)
     super().__init__(model_name=model_name,
                      client=client,
                      measurements=measurements,


### PR DESCRIPTION
Added optional api_base parameter to specify a custom API endpoint. 

This should be useful for anyone attempting to access an LLM through any service that exposes an OpenAI-compatible API endpoint. It should also facilitate the use of locally hosted LLMs served using libraries such as vLLM or sgLang.