### PR TITLE
added get_pre_act_label() and get_pre_act_value() to inventory

### DIFF
--- a/concordia/components/game_master/inventory.py
+++ b/concordia/components/game_master/inventory.py
@@ -14,7 +14,9 @@
 
 """A game master component to represent each player's inventory."""
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable
+from collections.abc import Mapping
+from collections.abc import Sequence
 import copy
 import dataclasses
 import datetime
@@ -32,7 +34,6 @@ from concordia.utils import concurrency
 from concordia.utils import helper_functions
 import numpy as np
 import termcolor
-
 
 _DEFAULT_CHAIN_OF_THOUGHT_PREFIX = (
     'This is a social science experiment. It is structured as a '
@@ -398,6 +399,20 @@ class Inventory(
   def get_state(self) -> entity_component.ComponentState:
     """Returns the state of the component."""
     return {'inventories': self._inventories}
+
+  ############### NEW FUNCTIONS ################
+
+  def get_pre_act_label(self) -> str:
+    """Returns the pre act label of the component."""
+    return self._pre_act_label
+
+  def get_pre_act_value(self) -> str:
+    """Returns the pre act value of the component."""
+    with self._lock:
+      return str(self._inventories)
+
+
+################################################
 
 
 class Score(entity_component.ContextComponent,


### PR DESCRIPTION
When I tried adding the `inventory.py` component to the situated-in-time-and-place gamemaster and running a toy simulation, I got this error:

`AttributeError: 'Inventory' object has no attribute ‘get_pre_act_label’`. 

I added that function and then I was able to add inventory.py as a component to that GM (in a similar way as, say, make_observatIon or world_state are components), and then it ran my toy simulation successfully.