### PR TITLE
enable payoff matrix to process simultaneous actions, adapt GM, add example

### DIFF
--- a/examples/iterated_prisoners_dilemma.ipynb
+++ b/examples/iterated_prisoners_dilemma.ipynb
@@ -1,0 +1,385 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7b54ded4",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/google-deepmind/concordia/blob/main/examples/alice.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70f774d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Colab-specific setup (use a CodeSpace to avoid the need for this).\n",
+    "try:\n",
+    "  %env COLAB_RELEASE_TAG\n",
+    "except:\n",
+    "  pass  # Not running in colab.\n",
+    "else:\n",
+    "  %pip install --ignore-requires-python --requirement 'https://raw.githubusercontent.com/google-deepmind/concordia/main/examples/requirements.in' 'git+https://github.com/google-deepmind/concordia.git#egg=gdm-concordia'\n",
+    "  %pip list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51dfe77a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Imports\n",
+    "\n",
+    "from concordia.contrib import language_models as language_model_utils\n",
+    "import concordia.prefabs.entity as entity_prefabs\n",
+    "import concordia.prefabs.game_master as game_master_prefabs\n",
+    "from concordia.prefabs.simulation import generic as simulation\n",
+    "from concordia.typing import prefab as prefab_lib\n",
+    "from concordia.typing import entity as entity_lib\n",
+    "from concordia.typing import scene as scene_lib\n",
+    "from concordia.utils import helper_functions\n",
+    "from IPython import display\n",
+    "import numpy as np\n",
+    "import sentence_transformers\n",
+    "from concordia.environment.engines import simultaneous"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6739ce18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Language Model Selection: provide key or select DISABLE_LANGUAGE_MODEL\n",
+    "\n",
+    "# By default this colab uses models via an external API so you must provide an\n",
+    "# API key. TogetherAI offers open weights models from all sources.\n",
+    "\n",
+    "API_KEY = ''  # @param {type: 'string'}\n",
+    "# See concordia/language_model/utils.py\n",
+    "API_TYPE = 'openai'  # e.g. 'together_ai' or 'openai'.\n",
+    "MODEL_NAME = (  # for API_TYPE = 'together_ai', we recommend MODEL_NAME = 'google/gemma-3-27b-it'\n",
+    "    'gpt-5'\n",
+    ")\n",
+    "# To debug without spending money on API calls, set DISABLE_LANGUAGE_MODEL=True\n",
+    "DISABLE_LANGUAGE_MODEL = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cada3b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Use the selected language model\n",
+    "\n",
+    "# Note that it is also possible to use local models or other API models,\n",
+    "# simply replace this cell with the correct initialization for the model\n",
+    "# you want to use.\n",
+    "\n",
+    "if not DISABLE_LANGUAGE_MODEL and not API_KEY:\n",
+    "  raise ValueError('API_KEY is required.')\n",
+    "\n",
+    "model = language_model_utils.language_model_setup(\n",
+    "    api_type=API_TYPE,\n",
+    "    model_name=MODEL_NAME,\n",
+    "    api_key=API_KEY,\n",
+    "    disable_language_model=DISABLE_LANGUAGE_MODEL,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d39cf628",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Setup sentence encoder\n",
+    "\n",
+    "if DISABLE_LANGUAGE_MODEL:\n",
+    "  embedder = lambda _: np.ones(3)\n",
+    "else:\n",
+    "  st_model = sentence_transformers.SentenceTransformer(\n",
+    "      'sentence-transformers/all-mpnet-base-v2')\n",
+    "  embedder = lambda x: st_model.encode(x, show_progress_bar=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "945c9020",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = model.sample_text(\n",
+    "    'Is societal and technological progress like getting a clearer picture of '\n",
+    "    'something true and deep?')\n",
+    "print(test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f83d55c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Load prefabs from packages to make the specific palette to use here.\n",
+    "\n",
+    "prefabs = {\n",
+    "    **helper_functions.get_package_classes(entity_prefabs),\n",
+    "    **helper_functions.get_package_classes(game_master_prefabs),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bf10894",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#@title Print menu of prefabs\n",
+    "\n",
+    "display.display(\n",
+    "    display.Markdown(helper_functions.print_pretty_prefabs(prefabs)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db8ac873",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Define payoff functions for prisoner's dilemma\n",
+    "\n",
+    "def ipd_action_to_scores(joint_action):\n",
+    "    \"\"\"Map joint action to scores using standard PD payoffs: T=5, R=3, P=1, S=0.\"\"\"\n",
+    "    alice_action = joint_action.get('Alice', 'defect')\n",
+    "    bob_action = joint_action.get('Bob', 'defect')\n",
+    "\n",
+    "    if alice_action == 'cooperate' and bob_action == 'cooperate':\n",
+    "        return {'Alice': 3.0, 'Bob': 3.0}  # Reward (R)\n",
+    "    elif alice_action == 'defect' and bob_action == 'defect':\n",
+    "        return {'Alice': 1.0, 'Bob': 1.0}  # Punishment (P)\n",
+    "    elif alice_action == 'cooperate' and bob_action == 'defect':\n",
+    "        return {'Alice': 0.0, 'Bob': 5.0}  # Sucker (S) / Temptation (T)\n",
+    "    else:  # alice defects, bob cooperates\n",
+    "        return {'Alice': 5.0, 'Bob': 0.0}  # Temptation (T) / Sucker (S)\n",
+    "\n",
+    "def ipd_scores_to_observation(scores):\n",
+    "    \"\"\"Convert cumulative scores to observations for each player.\"\"\"\n",
+    "    return {\n",
+    "        name: f\"{name}'s cumulative score is now {score:.1f} points.\"\n",
+    "        for name, score in scores.items()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "022d7da2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Define the scene for prisoner's dilemma decisions\n",
+    "\n",
+    "player_names = ['Alice', 'Bob']\n",
+    "\n",
+    "# Define the decision scene with binary choice\n",
+    "decision_scene = scene_lib.SceneTypeSpec(\n",
+    "    name='decision',\n",
+    "    game_master_name='default rules',\n",
+    "    action_spec=entity_lib.choice_action_spec(\n",
+    "        call_to_action='Does {name} cooperate or defect?',\n",
+    "        options=['cooperate', 'defect'],\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# Create the scene specification for 4 rounds of iterated prisoner's dilemma\n",
+    "scenes = [\n",
+    "    scene_lib.SceneSpec(\n",
+    "        scene_type=decision_scene,\n",
+    "        participants=player_names,\n",
+    "        num_rounds=4,\n",
+    "        premise={\n",
+    "            name: [\n",
+    "                (\n",
+    "                    f\"{name} is playing an iterated prisoner's dilemma game. \"\n",
+    "                    \"In each round, both players simultaneously choose to either cooperate or defect. \"\n",
+    "                    \"The payoffs are: both cooperate = 3 points each, \"\n",
+    "                    \"both defect = 1 point each, \"\n",
+    "                    \"one cooperates while other defects = 0 points for cooperator, 5 points for defector. \"\n",
+    "                    \"The goal is to maximize cumulative points over all rounds.\"\n",
+    "                ),\n",
+    "            ]\n",
+    "            for name in player_names\n",
+    "        },\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f72d9851",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Configure instances using library components\n",
+    "\n",
+    "instances = [\n",
+    "    prefab_lib.InstanceConfig(\n",
+    "        prefab='basic__Entity',\n",
+    "        role=prefab_lib.Role.ENTITY,\n",
+    "        params={\n",
+    "            'name': 'Alice',\n",
+    "        },\n",
+    "    ),\n",
+    "    prefab_lib.InstanceConfig(\n",
+    "        prefab='basic__Entity',\n",
+    "        role=prefab_lib.Role.ENTITY,\n",
+    "        params={\n",
+    "            'name': 'Bob',\n",
+    "        },\n",
+    "    ),\n",
+    "    prefab_lib.InstanceConfig(\n",
+    "        prefab='game_theoretic_and_dramaturgic__GameMaster',\n",
+    "        role=prefab_lib.Role.GAME_MASTER,\n",
+    "        params={\n",
+    "            'name': 'default rules',\n",
+    "            'scenes': scenes,\n",
+    "            'action_to_scores': ipd_action_to_scores,\n",
+    "            'scores_to_observation': ipd_scores_to_observation,\n",
+    "            'acting_order': 'simultaneous',\n",
+    "        },\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd049423",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = prefab_lib.Config(\n",
+    "    default_premise=(\n",
+    "        \"Two agents, Alice and Bob, are playing an iterated prisoner's dilemma game. \"\n",
+    "        \"In each round, both players simultaneously choose to either cooperate or defect, \"\n",
+    "        \"without knowing what the other player will do. The payoffs are as follows: \"\n",
+    "        \"If both cooperate, each gets 3 points (mutual cooperation reward). \"\n",
+    "        \"If both defect, each gets 1 point (mutual defection punishment). \"\n",
+    "        \"If one cooperates while the other defects, the cooperator gets 0 points (sucker's payoff) \"\n",
+    "        \"and the defector gets 5 points (temptation payoff). \"\n",
+    "        \"The game will be played for a few rounds, and cumulative payoffs will be tracked.\"\n",
+    "    ),\n",
+    "    default_max_steps=4,  # Match number of steps needed for scene to complete\n",
+    "    prefabs=prefabs,\n",
+    "    instances=instances,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08100865",
+   "metadata": {},
+   "source": [
+    "# The simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ada90a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Initialize the simulation\n",
+    "runnable_simulation = simulation.Simulation(\n",
+    "    config=config,\n",
+    "    model=model,\n",
+    "    embedder=embedder,\n",
+    "    engine=simultaneous.Simultaneous()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8ba6f45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Run the simulation\n",
+    "raw_log = []\n",
+    "results_log = runnable_simulation.play(\n",
+    "    max_steps=4,  # Match number of steps needed for scene to complete\n",
+    "    raw_log=raw_log\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3da29aca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Display the log\n",
+    "display.HTML(results_log)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b6ece59",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "\n",
+    "Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "you may not use this file except in compliance with the License.\n",
+    "You may obtain a copy of the License at\n",
+    "\n",
+    "    https://www.apache.org/licenses/LICENSE-2.0\n",
+    "\n",
+    "Unless required by applicable law or agreed to in writing, software\n",
+    "distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "See the License for the specific language governing permissions and\n",
+    "limitations under the License.\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "debug_sentence_transf",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Problem

Currently it is not possible to use the `PayoffMatrix` component to model simultaneous-move games (e.g. Prisoner’s Dilemma), since this component does not support players that act in parallel. (`PayoffMatrix` requires `EventResolution`, which in turn calls `get_currently_active_player()`, which is incompatible with the `Simultaneous` engine)

When using the `Sequential` engine, `PlayerB` observes whether `PlayerA` cooperated before it has to choose its action, changing the nature of the game.

---

### Solution

This pull request adds explicit support for simultaneous actions with `PayoffMatrix`:

- Implements a new component `NextActingAllEntitiesFromSceneSpec ` 
- **Main change:** Provides `PayoffMatrix` with a new parameter `acting_order `. Default behaviour remains unchanged, but if set to `simultaneous` it processes multiple actions in the same round (without calling `EventResolution`)
- Adapt `game_theoretic_and_dramaturgic` game master to have a new parameter `acting_order`. Use parallel actions if `acting_order== simultaneous`.
- Add new notebook with example usage `examples/iterated_prisoners_dilemma.ipynb`