### PR TITLE
Replace bare except with except Exception in concurrency.py

### DIFF
--- a/concordia/utils/concurrency.py
+++ b/concordia/utils/concurrency.py
@@ -58,7 +58,7 @@ def _run_task(key: str, fn: Callable[[], _T]) -> Callable[[], _T]:
   """Returns fn() and logs any error."""
   try:
     return fn()
-  except:
+  except Exception:
     logging.exception('Error in task %s', key)
     raise
 


### PR DESCRIPTION
Replaced bare except with except Exception to follow PEP 8 best practices and avoid catching system exceptions like KeyboardInterrupt and SystemExit.
Fixes #201
