### PR TITLE
Fix invalid Python devcontainer image tag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json
 {
   "name": "Concordia",
-  "image": "mcr.microsoft.com/devcontainers/python:0-3.12",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
   "postCreateCommand": "bin/install.sh",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
This PR fixes an invalid Python devcontainer image tag.

The previous image `mcr.microsoft.com/devcontainers/python:0-3.12` does not exist and caused the dev container to fail to build.

Updated to `mcr.microsoft.com/devcontainers/python:3.12` and verified locally using VS Code Dev Containers. Python 3.12.12 starts successfully inside the container.

Closes #178
