### PR TITLE
Enforce strict type checking and remove suppressions

### DIFF
--- a/concordia/agents/deprecated/simple_llm_agent.py
+++ b/concordia/agents/deprecated/simple_llm_agent.py
@@ -21,8 +21,7 @@ from concordia.language_model import language_model
 from concordia.typing.deprecated import agent
 from concordia.typing.deprecated import entity
 
-# TODO: b/313715068 - remove disable once pytype bug is fixed.
-# pytype: disable=override-error
+
 
 
 class SimpleLLMAgent(agent.GenerativeAgent):

--- a/concordia/agents/entity_agent.py
+++ b/concordia/agents/entity_agent.py
@@ -28,8 +28,7 @@ from concordia.typing import entity
 from concordia.typing import entity_component
 from concordia.utils import concurrency
 
-# TODO: b/313715068 - remove disable once pytype bug is fixed.
-# pytype: disable=override-error
+
 
 
 class EntityAgent(entity_component.EntityWithComponents):

--- a/concordia/environment/engine.py
+++ b/concordia/environment/engine.py
@@ -42,7 +42,11 @@ class Engine(metaclass=abc.ABCMeta):
       self,
       game_master: entity_lib.Entity,
       entities: Sequence[entity_lib.Entity],
-  ) -> tuple[entity_lib.Entity, entity_lib.ActionSpec]:
+  ) -> (
+      tuple[entity_lib.Entity, entity_lib.ActionSpec]
+      | Sequence[entity_lib.Entity]
+      | tuple[Sequence[entity_lib.Entity], Sequence[entity_lib.ActionSpec]]
+  ):
     """Return the next entity or entities to act."""
 
   @abc.abstractmethod

--- a/concordia/environment/engines/parallel_questionnaire.py
+++ b/concordia/environment/engines/parallel_questionnaire.py
@@ -82,7 +82,7 @@ class ParallelQuestionnaireEngine(engine_lib.Engine):
       self,
       game_master: entity_lib.Entity,
       entities: Sequence[entity_lib.Entity],
-  ) -> Sequence[entity_lib.Entity]:  # pytype: disable=signature-mismatch
+  ) -> Sequence[entity_lib.Entity]:
     """Returns entities that should act next."""
     entities_by_name = {entity.name: entity for entity in entities}
 

--- a/concordia/environment/engines/sequential_questionnaire.py
+++ b/concordia/environment/engines/sequential_questionnaire.py
@@ -80,7 +80,7 @@ class SequentialQuestionnaireEngine(engine_lib.Engine):
       self,
       game_master: entity_lib.Entity,
       entities: Sequence[entity_lib.Entity],
-  ) -> Sequence[entity_lib.Entity]:  # pytype: disable=signature-mismatch
+  ) -> Sequence[entity_lib.Entity]:
     """Returns entities that should act next."""
     entities_by_name = {entity.name: entity for entity in entities}
 

--- a/concordia/environment/engines/simultaneous.py
+++ b/concordia/environment/engines/simultaneous.py
@@ -105,7 +105,7 @@ class Simultaneous(engine_lib.Engine):
       log: list[Mapping[str, Any]] | None = None,
   ) -> tuple[
       Sequence[entity_lib.Entity], Sequence[entity_lib.ActionSpec]
-  ]:  # pytype: disable=signature-mismatch
+  ]:
     """Return the next action spec for an entity."""
     entities_by_name = {entity.name: entity for entity in entities}
     next_object_names_string = game_master.act(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ testpaths = ["concordia", "examples"]
 [tool.pytype]
 inputs = ["concordia", "examples"]
 # Keep going past errors to analyze as many files as possible.
-keep_going = true
+# Keep going past errors to analyze as many files as possible.
+# keep_going = true
 # Run N jobs in parallel. When 'auto' is used, this will be equivalent to the
 # number of CPUs on the host system.
 jobs = "auto"


### PR DESCRIPTION
### Issue 
Enable strict type checking and resolve pytype workarounds  #206 


### **Description:**
This PR enforces strict type checking by removing the lenient configuration and cleaning up explicit suppressions in the codebase.

### **Changes:**

1.  **Strict Configuration**:
    *   Updated [pyproject.toml](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/pyproject.toml:0:0-0:0) to remove `keep_going = true`. This ensures `pytype` fails immediately on errors, enforcing a "zero tolerance" policy for new type violations.

2.  **Engine Interface Fix**:
    *   Widened the return type of `Engine.next_acting` in [concordia/environment/engine.py](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/concordia/environment/engine.py:0:0-0:0) to correctly support parallel engines that return lists of entities instead of just single tuples.
    *   *Old signature*: `tuple[Entity, ActionSpec]`
    *   *New signature*: `tuple[...] | Sequence[Entity] | tuple[Sequence[Entity], ...]`

3.  **Removed Suppressions**:
    *   Removed `pytype: disable=signature-mismatch` from 3 engine implementations ([parallel_questionnaire.py](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/concordia/environment/engines/parallel_questionnaire.py:0:0-0:0), [sequential_questionnaire.py](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/concordia/environment/engines/sequential_questionnaire.py:0:0-0:0), [simultaneous.py](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/concordia/environment/engines/simultaneous.py:0:0-0:0)) as they now comply with the widened base class interface.
    *   Removed `pytype: disable=override-error` from [entity_agent.py](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/concordia/agents/entity_agent.py:0:0-0:0) and [simple_llm_agent.py](cci:7://file:///c:/Users/has20/Projects/openSource/concordia/concordia/concordia/agents/deprecated/simple_llm_agent.py:0:0-0:0).

### **Verification:**
Ran full test suite (`pytest --pyargs concordia`). All tests passed,(Will work with the tempory fix from #211 or in some time  ) confirming that the interface widening did not introduce runtime regressions.