### PR TITLE
fix: prevent ZeroDivisionError when scene has no participants

### DIFF
--- a/concordia/components/game_master/next_acting.py
+++ b/concordia/components/game_master/next_acting.py
@@ -399,6 +399,8 @@ class NextActingFromSceneSpec(
     result = ''
     if action_spec.output_type == entity_lib.OutputType.NEXT_ACTING:
       scene_participants = self._get_current_scene_participants()
+      if not scene_participants:
+        return ''
       idx = self._counter % len(scene_participants)
       result = scene_participants[idx]
       self._counter += 1


### PR DESCRIPTION
Fixes #220

Add validation to check for empty `scene_participants` list before performing modulo operation.

## Problem
The `NextActingFromSceneSpec.pre_act` method performs a modulo operation without checking if `scene_participants` is empty, leading to `ZeroDivisionError` when a scene has no participants.

## Impact
- Runtime crash when scene is configured with no participants
- Simulation fails unexpectedly

## Solution
Add a guard clause to return early when `scene_participants` is empty.

## Testing
Existing tests should pass. This fix prevents a crash condition that would otherwise terminate the simulation.