### PR TITLE
fix: use context manager for ThreadPoolExecutor to prevent resource leak

### DIFF
--- a/concordia/agents/entity_agent.py
+++ b/concordia/agents/entity_agent.py
@@ -264,9 +264,8 @@ class EntityAgent(entity_component.EntityWithComponents):
       raise RuntimeError('Agent must be in PRE_ACT phase for stateless_act')
 
     # 1. PRE_ACT to gather context
-    executor = futures.ThreadPoolExecutor()
-    contexts = self._parallel_call_('pre_act', action_spec, executor=executor)
-    executor.shutdown(wait=True)
+    with futures.ThreadPoolExecutor() as executor:
+      contexts = self._parallel_call_('pre_act', action_spec, executor=executor)
     self._context_processor.pre_act(types.MappingProxyType(contexts))
 
     # 2. Get action from ActComponent


### PR DESCRIPTION
Fixes #221

Replace manual `ThreadPoolExecutor` creation and shutdown with context manager pattern.

## Problem
The executor is created without a context manager. If an exception occurs between creation and `shutdown()`, the executor won't be cleaned up, leaving threads running in the background.

## Impact
- Resource leak in long-running simulations
- Can lead to thread starvation over time

## Solution
Use Python's `with` statement to ensure proper cleanup even when exceptions occur.

## Testing
Existing tests should pass. The context manager ensures the same cleanup behavior while being more robust to exceptions.