### PR TITLE
fix: use timezone-aware datetime in GameClock initialization

### DIFF
--- a/concordia/clocks/game_clock.py
+++ b/concordia/clocks/game_clock.py
@@ -58,7 +58,7 @@ class FixedIntervalClock(GameClock):
       step_size: The step size of the clock.
     """
     if start is None:
-      self._start = datetime.datetime.now()
+      self._start = datetime.datetime.now(datetime.timezone.utc)
     else:
       self._start = start
     self._step_size = step_size


### PR DESCRIPTION
Fixes #222

Use timezone-aware `datetime.now()` with UTC timezone instead of naive datetime.

## Problem
The `GameClock.__init__` method uses `datetime.datetime.now()` without specifying a timezone, creating a naive datetime object. Python's datetime documentation recommends using timezone-aware datetimes to avoid ambiguity.

## Impact
- Potential bugs when comparing timestamps across different environments
- Issues when serializing/deserializing clock state
- Ambiguity in distributed systems

## Solution
Use `datetime.datetime.now(datetime.timezone.utc)` to create a timezone-aware datetime.

## Testing
Existing tests should pass. This makes the datetime handling more robust without changing the core behavior.