### PR TITLE
fix: validate entity name from LLM to prevent KeyError in sequential engine

### DIFF
--- a/concordia/environment/engines/sequential.py
+++ b/concordia/environment/engines/sequential.py
@@ -133,6 +133,14 @@ class Sequential(engine_lib.Engine):
       assert hasattr(game_master, 'get_last_log')  # Assertion for pytype
       log_entry['next_action_spec'] = game_master.get_last_log()
     next_action_spec = engine_lib.action_spec_parser(next_action_spec_string)
+
+    # Validate entity name from LLM to prevent KeyError
+    if next_object_name not in entities_by_name:
+      raise ValueError(
+          f"Game master returned invalid entity name '{next_object_name}'. "
+          f"Valid options: {list(entities_by_name.keys())}"
+      )
+
     return (entities_by_name[next_object_name], next_action_spec)
 
   def resolve(self,


### PR DESCRIPTION
Fixes #229

Add validation to ensure the game master returns a valid entity name before accessing the entities_by_name dictionary.

## Problem
The sequential engine crashes with `KeyError` when the LLM returns an invalid entity name. There's no validation before dictionary access.

## Impact
- **Critical bug** that crashes the entire game loop
- No graceful error handling
- Difficult to debug (KeyError doesn't explain LLM returned invalid name)

## Solution
Add validation with descriptive error message:
- Check if `next_object_name` exists in `entities_by_name`
- Raise `ValueError` with helpful message listing valid options
- Helps developers debug LLM hallucinations

## Testing
Existing tests should pass. This adds defensive programming without changing core behavior.