### PR TITLE
fix: strip whitespace and validate entity names in simultaneous engine

### DIFF
--- a/concordia/environment/engines/simultaneous.py
+++ b/concordia/environment/engines/simultaneous.py
@@ -116,7 +116,7 @@ class Simultaneous(engine_lib.Engine):
             options=tuple(entities_by_name.keys()),
         )
     )
-    next_entity_names = next_object_names_string.split(',')
+    next_entity_names = [name.strip() for name in next_object_names_string.split(',')]
     if log is not None and hasattr(game_master, 'get_last_log'):
       assert hasattr(game_master, 'get_last_log')  # Assertion for pytype
       log_entry['next_acting'] = game_master.get_last_log()
@@ -138,6 +138,14 @@ class Simultaneous(engine_lib.Engine):
       if log is not None and hasattr(game_master, 'get_last_log'):
         assert hasattr(game_master, 'get_last_log')  # Assertion for pytype
         log_entry['next_action_spec'] = game_master.get_last_log()
+
+    # Validate all entity names from LLM to prevent KeyError
+    invalid_names = [name for name in next_entity_names if name not in entities_by_name]
+    if invalid_names:
+      raise ValueError(
+          f"Game master returned invalid entity names: {invalid_names}. "
+          f"Valid options: {list(entities_by_name.keys())}"
+      )
 
     return (
         [entities_by_name[entity_name] for entity_name in next_entity_names],


### PR DESCRIPTION
Fixes #231

Fix two related bugs in the simultaneous game engine that cause KeyError crashes.

## Problems Fixed

### 1. Whitespace Not Stripped
LLM outputs like `"Alice, Bob"` (with space after comma) were split into `["Alice", " Bob"]`, causing KeyError on dictionary lookup because `" Bob" != "Bob"`.

### 2. No Validation of Entity Names
Direct dictionary access without validation allowed invalid LLM-generated names to crash the game.

## Solution
1. **Strip whitespace**: Change `split(',')` to `[name.strip() for name in split(',')]`
2. **Validate names**: Check all names exist in `entities_by_name` before access
3. **Descriptive errors**: Raise `ValueError` with helpful message listing invalid names

## Impact
- **Fixes critical crash** in simultaneous game mode
- Handles common LLM formatting (spaces after commas)
- Better error messages for debugging LLM hallucinations

## Testing
Existing tests should pass. Adds defensive programming without changing core behavior.