### PR TITLE
Fix phase validation bypass in entity_agent exception handlers

### DIFF
--- a/concordia/agents/entity_agent.py
+++ b/concordia/agents/entity_agent.py
@@ -187,7 +187,7 @@ class EntityAgent(entity_component.EntityWithComponents):
       except Exception:
         # Ensure correct error handling in the case of multiple threads
         # using the same entity by setting the phase to ready before raising.
-        self.set_phase(entity_component.Phase.READY)
+        self._set_phase(entity_component.Phase.READY)
         raise
 
   @override
@@ -209,7 +209,7 @@ class EntityAgent(entity_component.EntityWithComponents):
       except Exception:
         # Ensure correct error handling in the case of multiple threads
         # using the same entity by setting the phase to ready before raising.
-        self.set_phase(entity_component.Phase.READY)
+        self._set_phase(entity_component.Phase.READY)
         raise
 
   def set_state(


### PR DESCRIPTION
Bug Description:
The act() and observe() methods in EntityAgent have exception handlers that call self.set_phase() to reset the agent to READY state during error recovery. However, this bypasses critical phase transition validation.

Root Cause:
- _set_phase() (line 97-100): Validates transitions via check_successor()
- set_phase() (line 266-268): Directly sets phase WITHOUT validation
- Exception handlers at lines 190 and 212 incorrectly called set_phase()

Impact:
During error handling, the agent could be forced into an invalid phase state, violating the phase transition state machine. This could lead to:
1. Invalid agent state after exception recovery
2. Potential downstream errors from invalid phase transitions
3. Race conditions in multi-threaded scenarios

Fix:
Changed exception handlers to call _set_phase() instead of set_phase(), ensuring phase transitions are validated even during error recovery.

Files Changed:
- concordia/agents/entity_agent.py:190 (act method)
- concordia/agents/entity_agent.py:212 (observe method)