### PR TITLE
fix: deadlock in Measurements.close()

### DIFF
--- a/concordia/utils/measurements.py
+++ b/concordia/utils/measurements.py
@@ -101,6 +101,4 @@ class Measurements:
   def close(self) -> None:
     """Closes all channels."""
     with self._channels_lock:
-      for channel in self._channels:
-        self.close_channel(channel)
       self._channels.clear()

--- a/concordia/utils/measurements_test.py
+++ b/concordia/utils/measurements_test.py
@@ -1,0 +1,45 @@
+# Copyright 2023 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from absl.testing import absltest
+from concordia.utils import measurements
+
+
+class TestMeasurements(unittest.TestCase):
+
+  def test_publish_and_retrieve(self):
+    m = measurements.Measurements()
+    m.publish_datum('score', 42)
+    self.assertEqual(m.get_last_datum('score'), 42)
+
+  def test_close_does_not_deadlock(self):
+    """Regression: close() used to call close_channel() while holding the lock,
+    causing a deadlock with non-reentrant threading.Lock."""
+    m = measurements.Measurements()
+    m.publish_datum('a', 1)
+    m.publish_datum('b', 2)
+    m.close()
+    self.assertEqual(m.available_channels(), set())
+
+  def test_close_channel(self):
+    m = measurements.Measurements()
+    m.publish_datum('x', 'hello')
+    m.close_channel('x')
+    self.assertNotIn('x', m.available_channels())
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
`close()` holds `_channels_lock` and then calls `close_channel()`, which tries to acquire the same lock again. Since `threading.Lock` is not reentrant this deadlocks immediately.

Also, iterating `self._channels` while `close_channel` deletes from it raises `RuntimeError: dictionary changed size during iteration`.

Fix: replace the loop with a direct `self._channels.clear()` inside the existing lock, which is both correct and simpler. Added tests including a regression for the deadlock.