### PR TITLE
fix: TypeError in deep_compare_components when skip_keys not provided

### DIFF
--- a/concordia/utils/helper_functions.py
+++ b/concordia/utils/helper_functions.py
@@ -309,7 +309,7 @@ def find_data_in_nested_structure(
   return results
 
 
-def deep_compare_components(comp1, comp2, test_case, skip_keys=None):
+def deep_compare_components(comp1, comp2, test_case, skip_keys=()):
   """Recursively compares attributes of two components."""
   test_case.assertEqual(type(comp1), type(comp2))
 
@@ -334,7 +334,7 @@ def deep_compare_components(comp1, comp2, test_case, skip_keys=None):
     )
 
 
-def deep_compare_values(val1, val2, test_case, key_path='', skip_keys=None):
+def deep_compare_values(val1, val2, test_case, key_path='', skip_keys=()):
   """Recursively compares values."""
   test_case.assertEqual(type(val1), type(val2), f'Type mismatch at {key_path}')
 

--- a/concordia/utils/helper_functions_test.py
+++ b/concordia/utils/helper_functions_test.py
@@ -55,5 +55,30 @@ class TestPrettyPrintFunction(unittest.TestCase):
     )
 
 
+class TestDeepCompareComponents(unittest.TestCase):
+
+  def test_no_skip_keys_does_not_crash(self):
+    """Regression: calling with skip_keys=None (old default) raised TypeError."""
+
+    class Foo:
+      pass
+
+    a, b = Foo(), Foo()
+    a.x = 1
+    b.x = 1
+    # Should not raise TypeError: argument of type 'NoneType' is not iterable
+    helper_functions.deep_compare_components(a, b, self)
+
+  def test_skip_keys_excludes_field(self):
+
+    class Bar:
+      pass
+
+    a, b = Bar(), Bar()
+    a.x = 1
+    b.x = 99  # would fail if compared
+    helper_functions.deep_compare_components(a, b, self, skip_keys=('x',))
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
`deep_compare_components` and `deep_compare_values` default `skip_keys` to `None`, but then use it with `in` — raising `TypeError: argument of type 'NoneType' is not iterable` whenever the function is called without that argument.

Fix: change the default to `()` (empty tuple), which is the correct sentinel for "nothing to skip" and is safely iterable. Added regression tests.