### PR TITLE
Fix: Only pass reasoning_effort to models that support it

### DIFF
--- a/concordia/components/game_master/world_state.py
+++ b/concordia/components/game_master/world_state.py
@@ -292,13 +292,14 @@ class Locations(
     location = location.strip().rstrip('.')
     if self._valid_locations is None:
       return location
-    if location in self._valid_locations:
+    valid_locations = self._valid_locations
+    if location in valid_locations:
       return location
     location_lower = location.lower()
-    for valid in self._valid_locations:
+    for valid in valid_locations:
       if valid.lower() == location_lower:
         return valid
-    for valid in self._valid_locations:
+    for valid in valid_locations:
       if valid.lower() in location_lower:
         return valid
     return ''

--- a/concordia/contrib/language_models/openai/base_gpt_model.py
+++ b/concordia/contrib/language_models/openai/base_gpt_model.py
@@ -90,16 +90,22 @@ class BaseGPTModel(language_model.LanguageModel):
         {'role': 'user', 'content': prompt},
     ]
 
-    response = self._client.chat.completions.create(
+    kwargs = dict(
         model=self._model_name,
         messages=messages,
         temperature=temperature,
         max_completion_tokens=max_tokens,
         timeout=timeout,
         seed=seed,
-        reasoning_effort=reasoning_effort,
-        verbosity=verbosity,
     )
+    # reasoning_effort and verbosity are only supported by reasoning
+    # models (o-series, GPT-5). Skip for others to avoid 400 errors.
+    _REASONING_PREFIXES = ('o1', 'o3', 'o4', 'gpt-5')
+    if any(self._model_name.startswith(p) for p in _REASONING_PREFIXES):
+      kwargs['reasoning_effort'] = reasoning_effort
+      kwargs['verbosity'] = verbosity
+
+    response = self._client.chat.completions.create(**kwargs)
 
     if self._measurements is not None:
       self._measurements.publish_datum(


### PR DESCRIPTION
## Summary

- `reasoning_effort` and `verbosity` are only supported by OpenAI reasoning models (o-series, GPT-5 family). Passing them to non-reasoning models like `gpt-4o-mini` causes a `400 BadRequestError`: `"Unrecognized request argument supplied: reasoning_effort"`
- This change conditionally includes these parameters only when the model name indicates a reasoning model (o1, o3, o4, gpt-5 prefixes)

## References

Per [OpenAI's reasoning guide](https://developers.openai.com/docs/guides/reasoning), `reasoning_effort` controls how many reasoning tokens a model generates, and supported values are "model-dependent." The [gpt-4o-mini model page](https://developers.openai.com/docs/models/gpt-4o-mini) confirms it is not a reasoning model and does not support this parameter.

## Test plan

- [x] Verified `gpt-4o-mini` no longer returns `400 BadRequestError` when used with Concordia
- [x] Reasoning model prefixes (`o1`, `o3`, `o4`, `gpt-5`) will still pass `reasoning_effort` and `verbosity` as before