### PR TITLE
fix(contrib): guard against empty choices and message=None in Groq/Mistral models

### DIFF
--- a/concordia/contrib/language_models/groq/groq_model.py
+++ b/concordia/contrib/language_models/groq/groq_model.py
@@ -90,6 +90,9 @@ class GroqModel(language_model.LanguageModel):
         seed=seed,
     )
 
+    if not response.choices or response.choices[0].message is None:
+      raise language_model.InvalidResponseError(
+          'LLM returned empty or filtered response')
     text = response.choices[0].message.content
 
     if self._measurements is not None:

--- a/concordia/contrib/language_models/mistral/mistral_model.py
+++ b/concordia/contrib/language_models/mistral/mistral_model.py
@@ -130,6 +130,9 @@ class MistralLanguageModel(language_model.LanguageModel):
           logging.warning('  Exception: %s', err)
         continue
       else:
+        if not response.choices or response.choices[0].message is None:
+          raise language_model.InvalidResponseError(
+              'LLM returned empty or filtered response')
         result = response.choices[0].message.content
         break
 
@@ -198,6 +201,9 @@ class MistralLanguageModel(language_model.LanguageModel):
           logging.warning('  Exception: %s', err)
         continue
       else:
+        if not response.choices or response.choices[0].message is None:
+          raise language_model.InvalidResponseError(
+              'LLM returned empty or filtered response')
         return response.choices[0].message.content
 
     raise language_model.InvalidResponseError(


### PR DESCRIPTION
## What

Add guards in the Groq and Mistral contrib language model backends before accessing `response.choices[0].message.content`.

## Why

`client.chat.completions.create()` (and Mistral's equivalent) can return two empty-response shapes:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures  
2. **`choices[0].message = None`** — some OpenAI-compatible providers return HTTP 200 with the message field absent on filtered responses

Both crash with `IndexError` or `AttributeError`. The guards raise `InvalidResponseError` (using the existing exception class already used in these files) so the retry machinery in callers handles the case the same way as other transient failures.

## Files changed

| File | Fix |
|------|-----|
| `concordia/contrib/language_models/groq/groq_model.py` | Guard before `choices[0].message.content` in `sample_text()` |
| `concordia/contrib/language_models/mistral/mistral_model.py` | Guard at both access sites in `sample_text()` (chat loop) and `sample_choice()` |

```python
# Before
text = response.choices[0].message.content

# After
if not response.choices or response.choices[0].message is None:
    raise language_model.InvalidResponseError(
        'LLM returned empty or filtered response')
text = response.choices[0].message.content
```

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.8k violations in 800+ repos.