### PR TITLE
test: add AssociativeMemoryBank coverage

### DIFF
--- a/concordia/associative_memory/basic_associative_memory_test.py
+++ b/concordia/associative_memory/basic_associative_memory_test.py
@@ -1,0 +1,127 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for basic associative memory."""
+
+from collections.abc import Callable, Mapping, Sequence
+
+from absl.testing import absltest
+from concordia.associative_memory import basic_associative_memory
+import numpy as np
+
+
+def _make_embedder(
+    embeddings: Mapping[str, Sequence[float]],
+) -> Callable[[str], np.ndarray]:
+  """Returns a deterministic embedder backed by a local mapping."""
+
+  def embed(text: str) -> np.ndarray:
+    return np.asarray(embeddings[text], dtype=np.float64)
+
+  return embed
+
+
+class AssociativeMemoryBankTest(absltest.TestCase):
+
+  def test_add_suppresses_duplicates_by_default(self):
+    embedder = _make_embedder({'same memory': [1.0, 0.0]})
+    memory = basic_associative_memory.AssociativeMemoryBank(embedder)
+
+    memory.add('same memory')
+    memory.add('same memory')
+
+    self.assertLen(memory, 1)
+    self.assertEqual(memory.get_all_memories_as_text(), ['same memory'])
+
+  def test_add_retains_duplicates_when_allowed(self):
+    embedder = _make_embedder({'same memory': [1.0, 0.0]})
+    memory = basic_associative_memory.AssociativeMemoryBank(
+        embedder, allow_duplicates=True
+    )
+
+    memory.add('same memory')
+    memory.add('same memory')
+
+    self.assertLen(memory, 2)
+    self.assertEqual(
+        memory.get_all_memories_as_text(), ['same memory', 'same memory']
+    )
+
+  def test_add_normalizes_newlines(self):
+    embedder = _make_embedder({'line one line two line three': [1.0, 0.0]})
+    memory = basic_associative_memory.AssociativeMemoryBank(embedder)
+
+    memory.add('line one\nline two\nline three')
+
+    self.assertEqual(
+        memory.get_all_memories_as_text(),
+        ['line one line two line three'],
+    )
+
+  def test_retrieve_associative_orders_by_similarity(self):
+    embedder = _make_embedder({
+        'find northern memories': [1.0, 0.0],
+        'north market': [0.9, 0.1],
+        'east library': [0.2, 0.8],
+        'south garden': [0.7, 0.3],
+    })
+    memory = basic_associative_memory.AssociativeMemoryBank(embedder)
+    memory.extend(['east library', 'north market', 'south garden'])
+
+    self.assertEqual(
+        memory.retrieve_associative('find northern memories', k=2),
+        ['north market', 'south garden'],
+    )
+
+  def test_retrieve_recent_returns_most_recent_window_in_insertion_order(self):
+    embedder = _make_embedder({
+        'first': [1.0, 0.0],
+        'second': [0.0, 1.0],
+        'third': [1.0, 1.0],
+    })
+    memory = basic_associative_memory.AssociativeMemoryBank(embedder)
+    memory.extend(['first', 'second', 'third'])
+
+    self.assertEqual(memory.retrieve_recent(k=2), ['second', 'third'])
+
+  def test_retrieve_validates_limit(self):
+    embedder = _make_embedder({'query': [1.0, 0.0]})
+    memory = basic_associative_memory.AssociativeMemoryBank(embedder)
+
+    with self.assertRaisesRegex(ValueError, 'Limit must be positive.'):
+      memory.retrieve_recent(k=0)
+
+    with self.assertRaisesRegex(ValueError, 'Limit must be positive.'):
+      memory.retrieve_associative('query', k=0)
+
+  def test_get_state_and_set_state_preserve_pending_memories(self):
+    embedder = _make_embedder({
+        'first': [1.0, 0.0],
+        'second': [0.0, 1.0],
+    })
+    memory = basic_associative_memory.AssociativeMemoryBank(embedder)
+    memory.extend(['first', 'second'])
+
+    restored = basic_associative_memory.AssociativeMemoryBank(embedder)
+    restored.set_state(memory.get_state())
+
+    self.assertLen(restored, 2)
+    self.assertEqual(restored.get_all_memories_as_text(), ['first', 'second'])
+    self.assertEqual(restored.retrieve_recent(k=2), ['first', 'second'])
+    restored.add('first')
+    self.assertEqual(restored.get_all_memories_as_text(), ['first', 'second'])
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/components/game_master/interrupt_resolution_test.py
+++ b/concordia/components/game_master/interrupt_resolution_test.py
@@ -140,6 +140,7 @@ class TimerUpdateTest(absltest.TestCase):
 
     timer = scheduler.get_timer('Alice')
     self.assertIsNotNone(timer)
+    assert timer is not None
     self.assertEqual(
         timer.expiry,
         _START + datetime.timedelta(minutes=30),
@@ -329,6 +330,7 @@ class TimerAbsoluteTest(absltest.TestCase):
 
     timer = scheduler.get_timer('Alice')
     self.assertIsNotNone(timer)
+    assert timer is not None
     # _START is 09:00 on 2026-01-01; "14:00" should be same-day 14:00.
     self.assertEqual(
         timer.expiry,
@@ -354,6 +356,7 @@ class TimerAbsoluteTest(absltest.TestCase):
 
     timer = scheduler.get_timer('Alice')
     self.assertIsNotNone(timer)
+    assert timer is not None
     # Fallback: _START + 1h = 10:00.
     self.assertEqual(
         timer.expiry,

--- a/concordia/components/game_master/interrupt_scheduling_test.py
+++ b/concordia/components/game_master/interrupt_scheduling_test.py
@@ -209,6 +209,7 @@ class EntitySchedulerTest(absltest.TestCase):
     s = self._make_scheduler(hour=9)
     timer = s.get_timer('Alice')
     self.assertIsNotNone(timer)
+    assert timer is not None
     self.assertEqual(timer.expiry, datetime.datetime(2026, 1, 1, 9, 0))
 
   def test_set_timer_replaces(self):
@@ -246,6 +247,7 @@ class EntitySchedulerTest(absltest.TestCase):
     )
     next_timer = s.get_next_timer()
     self.assertIsNotNone(next_timer)
+    assert next_timer is not None
     self.assertEqual(next_timer.entity_name, 'Bob')
 
   def test_get_next_timer_skips_none(self):
@@ -261,6 +263,7 @@ class EntitySchedulerTest(absltest.TestCase):
     )
     next_timer = s.get_next_timer()
     self.assertIsNotNone(next_timer)
+    assert next_timer is not None
     self.assertEqual(next_timer.entity_name, 'Bob')
 
   def test_get_next_timer_all_none_returns_none(self):
@@ -420,6 +423,7 @@ class EntitySchedulerTest(absltest.TestCase):
     )
     alice_timer = s2.get_timer('Alice')
     self.assertIsNotNone(alice_timer)
+    assert alice_timer is not None
     self.assertEqual(alice_timer.description, 'test timer')
     queue = s2.peek_event_queue()
     self.assertLen(queue, 1)


### PR DESCRIPTION
## Summary

Adds focused unit coverage for `AssociativeMemoryBank` without changing production behavior.

Covered behavior:
- duplicate suppression by default
- duplicate retention with `allow_duplicates=True`
- newline normalization during `add`
- associative retrieval ordering with deterministic embeddings
- recent retrieval window ordering
- non-positive retrieval limit validation
- `get_state` / `set_state` preserving pending memories and duplicate hashes

Part of #205.

## Testing

- `PYTHONPATH=. python -m pytest -q concordia/associative_memory/basic_associative_memory_test.py`
- `PYTHONPATH=. python -m pylint --errors-only concordia/associative_memory/basic_associative_memory_test.py`
- `python -m pyink --check concordia/associative_memory/basic_associative_memory_test.py`
- `PYTHONPATH=. python -m pytype concordia/associative_memory/basic_associative_memory.py concordia/associative_memory/basic_associative_memory_test.py`

