### PR TITLE
fix(sampling): escalate temperature at the exact retry midpoint

### DIFF
--- a/concordia/utils/sampling.py
+++ b/concordia/utils/sampling.py
@@ -49,6 +49,6 @@ def dynamically_adjust_temperature(
   temperature = 0.0
   if attempts > 1 and attempts < (max_attempts / 2.0):
     temperature = 0.5
-  elif attempts > (max_attempts / 2.0):
+  elif attempts >= (max_attempts / 2.0):
     temperature = 0.75
   return temperature

--- a/concordia/utils/sampling_test.py
+++ b/concordia/utils/sampling_test.py
@@ -1,0 +1,58 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.utils import sampling
+
+
+class ExtractChoiceResponseTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      ('a', 'a'),
+      ('a)', 'a'),
+      ('(a)', 'a'),
+      ('foo(a)bar', 'a'),
+  )
+  def test_extracts_choice(self, response, expected):
+    self.assertEqual(sampling.extract_choice_response(response), expected)
+
+
+class DynamicallyAdjustTemperatureTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      # (attempts, max_attempts, expected_temperature)
+      (1, 10, 0.0),  # first attempt: no temperature bump
+      (2, 10, 0.5),  # early retries: moderate temperature
+      (4, 10, 0.5),  # still below the midpoint
+      (5, 10, 0.75),  # exact midpoint must escalate, not reset to 0.0
+      (6, 10, 0.75),  # past the midpoint
+      (10, 10, 0.75),
+  )
+  def test_temperature_schedule(self, attempts, max_attempts, expected):
+    self.assertEqual(
+        sampling.dynamically_adjust_temperature(attempts, max_attempts),
+        expected,
+    )
+
+  def test_midpoint_does_not_reset_temperature(self):
+    # Regression: at attempts == max_attempts / 2 (even max_attempts), both the
+    # `< max/2` and `> max/2` checks were false, so the temperature silently
+    # dropped back to 0.0 instead of escalating.
+    self.assertEqual(sampling.dynamically_adjust_temperature(3, 6), 0.75)
+    self.assertEqual(sampling.dynamically_adjust_temperature(4, 8), 0.75)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

`dynamically_adjust_temperature` (in `concordia/utils/sampling.py`) returns `0.0` when `attempts == max_attempts / 2`, which is reachable whenever `max_attempts` is even.

```python
temperature = 0.0
if attempts > 1 and attempts < (max_attempts / 2.0):
    temperature = 0.5
elif attempts > (max_attempts / 2.0):
    temperature = 0.75
return temperature
```

Both branches are strictly exclusive (`< max/2` and `> max/2`), so the **exact midpoint** falls through to the default `0.0`. For example with `max_attempts=10`, `attempts=5` returns `0.0` — dropping the choice-sampling temperature back to zero for that retry instead of escalating it, which defeats the retry-diversity intent at exactly the point where it should be ramping up.

## Fix

Make the upper branch inclusive so the midpoint escalates:

```python
elif attempts >= (max_attempts / 2.0):
    temperature = 0.75
```

- `attempts=5, max=10` now returns `0.75` (was `0.0`).
- **All other attempt counts are unchanged** (verified for every `attempts` over `max_attempts` in 2..20).
- Odd `max_attempts` (no integer midpoint) are unaffected.

## Tests

Adds `concordia/utils/sampling_test.py` — the first unit tests for this module — covering the temperature schedule (incl. the midpoint regression) and `extract_choice_response`. All 11 tests pass.
