### PR TITLE
Fix typos in document docstrings and package description

### DIFF
--- a/concordia/document/document.py
+++ b/concordia/document/document.py
@@ -54,7 +54,7 @@ class Document:
     Args:
       contents: Initial contents of the document.
     """
-    # TODO: b/311191572 - be more efficient if contents is a tupel iter.
+    # TODO: b/311191572 - be more efficient if contents is a tuple iter.
     self._contents = tuple(contents)
 
   # TODO: b/311191905 - implement __iadd__, __add__?
@@ -128,9 +128,9 @@ class Document:
   def edit(self: T) -> Iterator[T]:
     """Edits the current document.
 
-    Creates a edit based on the current document. Once the context is completed,
-    the edit will be committed to the document. If you wish not to commit the
-    edit call edit.clear() before leavign the context.
+    Creates an edit based on the current document. Once the context is
+    completed, the edit will be committed to the document. If you wish not to
+    commit the edit call edit.clear() before leaving the context.
 
     Yields:
       The document being edited.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     author='DeepMind',
     author_email='noreply@google.com',
     description=(
-        'A library for building a generative model of social interacions.'
+        'A library for building a generative model of social interactions.'
     ),
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fixes small typos in docstrings and the package description:
- setup.py: "interacions" → "interactions"
- concordia/document/document.py: "tupel" → "tuple", "a edit" → "an edit", "leavign" → "leaving"