### PR TITLE
Add per-run score fingerprinting for contest reproduction

### DIFF
--- a/examples/games/fingerprint_run.py
+++ b/examples/games/fingerprint_run.py
@@ -1,0 +1,202 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Computes a tamper-evident fingerprint of one or more completed game runs.
+
+`run.py` writes a `simulation_scores_{game}_{scenario}.json` file for each
+run, containing the per-agent focal/background scores plus run metadata
+(model name, timestamp, command). This script reads a set of those score
+files and produces two hashes:
+
+- `content_hash`: a SHA-256 Merkle root over every (scenario, role, agent,
+  score) tuple across all supplied runs. Two runs with identical
+  `content_hash` produced identical per-scenario per-agent outcomes, even if
+  they differ in when/how/on-what-model they were run. This is what makes
+  model drift detectable: matching aggregate scores can hide different
+  per-scenario outcomes, but they can't produce the same `content_hash`.
+- `bundle_hash`: a SHA-256 hash over the `content_hash` plus each run's
+  identity (game, scenario, model name, timestamp, command). Two runs with
+  the same scores but different provenance share a `content_hash` but not a
+  `bundle_hash`.
+
+Usage:
+  python -m examples.games.fingerprint_run \
+      --scores /tmp/simulation_scores_*.json
+  python -m examples.games.fingerprint_run \
+      --scores /tmp/simulation_scores_haggling_fruitville.json \
+      --output /tmp/fingerprint.json
+"""
+
+import argparse
+import glob
+import hashlib
+import json
+import pathlib
+import sys
+
+
+def _leaf_hash(scenario: str, role: str, agent: str, score: float) -> str:
+  """Hashes a single (scenario, role, agent, score) outcome."""
+  canonical = f"{scenario}|{role}|{agent}|{score!r}"
+  return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _merkle_root(leaves: list[str]) -> str:
+  """Computes a SHA-256 Merkle root over a list of leaf hashes.
+
+  Args:
+    leaves: Leaf hashes. The caller is responsible for sorting them into a
+      canonical order first, so that the resulting root is independent of
+      input ordering.
+
+  Returns:
+    The hex-encoded Merkle root. An empty input yields the hash of the
+    empty string, so that "no data" is distinguishable from any real run.
+  """
+  if not leaves:
+    return hashlib.sha256(b"").hexdigest()
+  level = list(leaves)
+  while len(level) > 1:
+    next_level = []
+    for i in range(0, len(level), 2):
+      left = level[i]
+      # Duplicate the last node when the level has an odd size.
+      right = level[i + 1] if i + 1 < len(level) else left
+      next_level.append(
+          hashlib.sha256((left + right).encode("utf-8")).hexdigest()
+      )
+    level = next_level
+  return level[0]
+
+
+def collect_leaves(runs: list[dict]) -> list[str]:
+  """Builds the sorted list of leaf hashes for a set of runs."""
+  leaves = []
+  for run in runs:
+    scenario = run.get("scenario", "")
+    for role, key in (
+        ("focal", "focal_scores"),
+        ("background", "background_scores"),
+    ):
+      for agent, score in run.get(key, {}).items():
+        leaves.append(_leaf_hash(scenario, role, agent, float(score)))
+  return sorted(leaves)
+
+
+def build_content_hash(runs: list[dict]) -> str:
+  """Computes the content_hash: a Merkle root over all scored outcomes."""
+  return _merkle_root(collect_leaves(runs))
+
+
+def build_bundle_hash(content_hash: str, runs: list[dict]) -> str:
+  """Computes the bundle_hash: content_hash plus run identity/provenance."""
+  identity = sorted(
+      (
+          {
+              "game": run.get("game"),
+              "scenario": run.get("scenario"),
+              "model_name": run.get("model_name"),
+              "api_type": run.get("api_type"),
+              "timestamp": run.get("timestamp"),
+              "command": run.get("command"),
+          }
+          for run in runs
+      ),
+      key=lambda entry: (entry["game"] or "", entry["scenario"] or ""),
+  )
+  payload = json.dumps(
+      {"content_hash": content_hash, "runs": identity}, sort_keys=True
+  )
+  return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_fingerprint(runs: list[dict]) -> dict:
+  """Builds the full fingerprint report for a set of runs."""
+  content_hash = build_content_hash(runs)
+  bundle_hash = build_bundle_hash(content_hash, runs)
+  return {
+      "content_hash": content_hash,
+      "bundle_hash": bundle_hash,
+      "num_runs": len(runs),
+      "scenarios": sorted({run.get("scenario", "") for run in runs}),
+  }
+
+
+def load_score_files(paths: list[str]) -> list[dict]:
+  """Loads and parses each score JSON file in `paths`."""
+  runs = []
+  for path in paths:
+    with open(path, "r", encoding="utf-8") as f:
+      runs.append(json.load(f))
+  return runs
+
+
+def resolve_paths(patterns: list[str]) -> list[str]:
+  """Expands a list of literal paths and/or glob patterns into file paths."""
+  paths = []
+  for pattern in patterns:
+    matched = sorted(glob.glob(pattern))
+    if not matched and pathlib.Path(pattern).is_file():
+      matched = [pattern]
+    if not matched:
+      print(f"Warning: no files matched '{pattern}'", file=sys.stderr)
+    paths.extend(matched)
+  return paths
+
+
+def main(argv: list[str] | None = None) -> None:
+  parser = argparse.ArgumentParser(
+      description=(
+          "Compute a tamper-evident fingerprint over one or more completed "
+          "game runs, from the score files written by run.py."
+      )
+  )
+  parser.add_argument(
+      "--scores",
+      nargs="+",
+      required=True,
+      help=(
+          "One or more paths and/or glob patterns to "
+          "simulation_scores_{game}_{scenario}.json files."
+      ),
+  )
+  parser.add_argument(
+      "--output",
+      type=str,
+      default=None,
+      help="Optional path to write the fingerprint report as JSON.",
+  )
+  args = parser.parse_args(argv)
+
+  paths = resolve_paths(args.scores)
+  if not paths:
+    print("Error: no score files found.", file=sys.stderr)
+    sys.exit(1)
+
+  runs = load_score_files(paths)
+  fingerprint = build_fingerprint(runs)
+
+  print(f"Runs included: {fingerprint['num_runs']}")
+  print(f"Scenarios: {', '.join(fingerprint['scenarios'])}")
+  print(f"content_hash: {fingerprint['content_hash']}")
+  print(f"bundle_hash:  {fingerprint['bundle_hash']}")
+
+  if args.output:
+    with open(args.output, "w", encoding="utf-8") as f:
+      json.dump(fingerprint, f, indent=2)
+    print(f"Fingerprint report written to {args.output}")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/games/fingerprint_run_test.py
+++ b/examples/games/fingerprint_run_test.py
@@ -1,0 +1,240 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for fingerprint_run."""
+
+import io
+import json
+import os
+import tempfile
+from unittest import mock
+
+from absl.testing import absltest
+from examples.games import fingerprint_run
+
+
+def _run(
+    game='haggling',
+    scenario='fruitville',
+    model_name='gpt-4o',
+    api_type='openai',
+    timestamp='2026-01-01T00:00:00+00:00',
+    command='run.py --game=haggling',
+    focal_scores=None,
+    background_scores=None,
+):
+  return {
+      'game': game,
+      'scenario': scenario,
+      'model_name': model_name,
+      'api_type': api_type,
+      'timestamp': timestamp,
+      'command': command,
+      'focal_scores': focal_scores or {'alice': 1.5},
+      'background_scores': background_scores or {'bob': -0.5},
+  }
+
+
+class ContentHashTest(absltest.TestCase):
+
+  def test_deterministic_for_same_input(self):
+    runs = [_run()]
+    self.assertEqual(
+        fingerprint_run.build_content_hash(runs),
+        fingerprint_run.build_content_hash(runs),
+    )
+
+  def test_independent_of_run_list_order(self):
+    run_a = _run(scenario='fruitville')
+    run_b = _run(scenario='fruitville_multi', game='haggling_multi_item')
+    self.assertEqual(
+        fingerprint_run.build_content_hash([run_a, run_b]),
+        fingerprint_run.build_content_hash([run_b, run_a]),
+    )
+
+  def test_independent_of_dict_key_order(self):
+    run_a = _run(focal_scores={'alice': 1.5, 'carol': 2.0})
+    run_b = _run(focal_scores={'carol': 2.0, 'alice': 1.5})
+    self.assertEqual(
+        fingerprint_run.build_content_hash([run_a]),
+        fingerprint_run.build_content_hash([run_b]),
+    )
+
+  def test_differs_when_a_single_agent_score_changes(self):
+    baseline = fingerprint_run.build_content_hash(
+        [_run(focal_scores={'alice': 1.5})]
+    )
+    drifted = fingerprint_run.build_content_hash(
+        [_run(focal_scores={'alice': 1.50001})]
+    )
+    self.assertNotEqual(baseline, drifted)
+
+  def test_matching_aggregate_but_different_per_agent_split_differs(self):
+    # Two runs with the same *total* score across two agents, but a
+    # different per-agent split -- this is exactly the "aggregate Elo
+    # matches, but per-scenario outcomes differ" case #271 is about.
+    run_a = _run(focal_scores={'alice': 3.0, 'bob': 1.0})
+    run_b = _run(focal_scores={'alice': 2.0, 'bob': 2.0})
+    self.assertNotEqual(
+        fingerprint_run.build_content_hash([run_a]),
+        fingerprint_run.build_content_hash([run_b]),
+    )
+
+  def test_differs_when_scenario_changes_but_scores_identical(self):
+    run_a = _run(scenario='fruitville')
+    run_b = _run(scenario='london', game='pub_coordination')
+    self.assertNotEqual(
+        fingerprint_run.build_content_hash([run_a]),
+        fingerprint_run.build_content_hash([run_b]),
+    )
+
+  def test_focal_and_background_scores_are_distinguished(self):
+    # Same agent name, same score, but as a focal player vs a background
+    # player -- these must not collide.
+    focal = _run(focal_scores={'alice': 1.0}, background_scores={})
+    background = _run(focal_scores={}, background_scores={'alice': 1.0})
+    self.assertNotEqual(
+        fingerprint_run.build_content_hash([focal]),
+        fingerprint_run.build_content_hash([background]),
+    )
+
+  def test_empty_runs_list_is_well_defined(self):
+    self.assertEqual(
+        fingerprint_run.build_content_hash([]),
+        fingerprint_run.build_content_hash([]),
+    )
+
+  def test_missing_score_dicts_do_not_raise(self):
+    minimal_run = {'game': 'haggling', 'scenario': 'fruitville'}
+    self.assertEqual(
+        fingerprint_run.build_content_hash([minimal_run]),
+        fingerprint_run.build_content_hash([]),
+    )
+
+
+class BundleHashTest(absltest.TestCase):
+
+  def test_same_scores_different_provenance_share_content_but_not_bundle(self):
+    run_a = _run(model_name='gpt-4o', timestamp='2026-01-01T00:00:00+00:00')
+    run_b = _run(
+        model_name='gpt-4o-2026-06-01', timestamp='2026-06-01T00:00:00+00:00'
+    )
+
+    content_a = fingerprint_run.build_content_hash([run_a])
+    content_b = fingerprint_run.build_content_hash([run_b])
+    self.assertEqual(content_a, content_b)
+
+    bundle_a = fingerprint_run.build_bundle_hash(content_a, [run_a])
+    bundle_b = fingerprint_run.build_bundle_hash(content_b, [run_b])
+    self.assertNotEqual(bundle_a, bundle_b)
+
+  def test_independent_of_run_list_order(self):
+    run_a = _run(scenario='fruitville')
+    run_b = _run(scenario='london', game='pub_coordination')
+    content_hash = fingerprint_run.build_content_hash([run_a, run_b])
+    self.assertEqual(
+        fingerprint_run.build_bundle_hash(content_hash, [run_a, run_b]),
+        fingerprint_run.build_bundle_hash(content_hash, [run_b, run_a]),
+    )
+
+  def test_deterministic_for_same_input(self):
+    runs = [_run()]
+    content_hash = fingerprint_run.build_content_hash(runs)
+    self.assertEqual(
+        fingerprint_run.build_bundle_hash(content_hash, runs),
+        fingerprint_run.build_bundle_hash(content_hash, runs),
+    )
+
+
+class BuildFingerprintTest(absltest.TestCase):
+
+  def test_reports_scenarios_and_run_count(self):
+    runs = [
+        _run(scenario='fruitville'),
+        _run(scenario='london', game='pub_coordination'),
+    ]
+    report = fingerprint_run.build_fingerprint(runs)
+    self.assertEqual(report['num_runs'], 2)
+    self.assertEqual(report['scenarios'], ['fruitville', 'london'])
+    self.assertIn('content_hash', report)
+    self.assertIn('bundle_hash', report)
+
+
+class LoadAndResolvePathsTest(absltest.TestCase):
+
+  def test_load_score_files_round_trips_json(self):
+    run = _run()
+    with tempfile.TemporaryDirectory() as tmpdir:
+      path = os.path.join(tmpdir, 'scores.json')
+      with open(path, 'w', encoding='utf-8') as f:
+        json.dump(run, f)
+      loaded = fingerprint_run.load_score_files([path])
+    self.assertEqual(loaded, [run])
+
+  def test_resolve_paths_expands_glob(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      path_a = os.path.join(
+          tmpdir, 'simulation_scores_haggling_fruitville.json'
+      )
+      path_b = os.path.join(
+          tmpdir, 'simulation_scores_pub_coordination_london.json'
+      )
+      for path in (path_a, path_b):
+        with open(path, 'w', encoding='utf-8') as f:
+          json.dump(_run(), f)
+      resolved = fingerprint_run.resolve_paths(
+          [os.path.join(tmpdir, 'simulation_scores_*.json')]
+      )
+    self.assertCountEqual(resolved, [path_a, path_b])
+
+  def test_resolve_paths_accepts_literal_path(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      path = os.path.join(tmpdir, 'scores.json')
+      with open(path, 'w', encoding='utf-8') as f:
+        json.dump(_run(), f)
+      resolved = fingerprint_run.resolve_paths([path])
+    self.assertEqual(resolved, [path])
+
+  def test_resolve_paths_warns_on_no_match(self):
+    with mock.patch('sys.stderr', new_callable=io.StringIO) as mock_stderr:
+      resolved = fingerprint_run.resolve_paths(['/nonexistent/path/*.json'])
+    self.assertEmpty(resolved)
+    self.assertIn('Warning', mock_stderr.getvalue())
+
+
+class MainTest(absltest.TestCase):
+
+  def test_main_writes_report_and_exits_cleanly(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      scores_path = os.path.join(tmpdir, 'scores.json')
+      output_path = os.path.join(tmpdir, 'fingerprint.json')
+      with open(scores_path, 'w', encoding='utf-8') as f:
+        json.dump(_run(), f)
+
+      fingerprint_run.main(['--scores', scores_path, '--output', output_path])
+
+      with open(output_path, 'r', encoding='utf-8') as f:
+        report = json.load(f)
+      self.assertEqual(report['num_runs'], 1)
+      self.assertIn('content_hash', report)
+      self.assertIn('bundle_hash', report)
+
+  def test_main_exits_nonzero_when_no_files_found(self):
+    with self.assertRaises(SystemExit) as cm:
+      fingerprint_run.main(['--scores', '/nonexistent/path/*.json'])
+    self.assertEqual(cm.exception.code, 1)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/examples/games/run.py
+++ b/examples/games/run.py
@@ -28,7 +28,9 @@ Usage:
 """
 
 import argparse
+import datetime
 import importlib
+import json
 import sys
 
 from concordia.contrib import language_models
@@ -194,6 +196,30 @@ def main() -> None:
       print("\nBackground player scores:")
       for name, score in background_scores.items():
         print(f"  {name}: {score:.2f}")
+
+    # Persist scores alongside the structured log so that a completed run
+    # can be fingerprinted later (see fingerprint_run.py) without needing
+    # to re-parse stdout.
+    if focal_scores or background_scores:
+      scores_file = f"/tmp/simulation_scores_{game}_{scenario}.json"
+      with open(scores_file, "w") as f:
+        json.dump(
+            {
+                "game": game,
+                "scenario": scenario,
+                "model_name": args.model_name,
+                "api_type": args.api_type,
+                "timestamp": (
+                    datetime.datetime.now(datetime.timezone.utc).isoformat()
+                ),
+                "command": " ".join(sys.argv),
+                "focal_scores": focal_scores,
+                "background_scores": background_scores,
+            },
+            f,
+            indent=2,
+        )
+      print(f"Scores written to {scores_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Addresses #271.

\`run.py\` writes a full structured event log per run, but the actual per-agent \`focal_scores\`/\`background_scores\` dict is only printed to stdout and then discarded — there's no durable, parseable record of exactly what a completed run scored. That makes the concern raised in #271 concrete: two runs can land on the same aggregate Elo while actually differing per-scenario per-agent, and there's currently no way to tell those cases apart after the fact.

## Changes

- \`run.py\` now also writes \`simulation_scores_{game}_{scenario}.json\` alongside the existing HTML/JSON structured log, containing the per-agent focal/background scores plus run identity (game, scenario, model name, api type, UTC timestamp, and the exact command invoked).
- New \`fingerprint_run.py\`, a companion script that reads one or more of those score files and computes:
  - \`content_hash\`: a SHA-256 Merkle root over every \`(scenario, role, agent, score)\` tuple across the supplied runs. This is what makes drift detectable at a finer grain than aggregate Elo — two runs with the same total score but a different per-agent split, or the same scores under a different scenario, produce different \`content_hash\` values.
  - \`bundle_hash\`: \`content_hash\` combined with each run's identity (model, timestamp, command), so two runs with identical scores but different provenance are distinguishable from runs that are genuinely identical.

## Usage

    python -m examples.games.run --game=haggling --scenario=fruitville ...
    # writes /tmp/simulation_scores_haggling_fruitville.json

    python -m examples.games.fingerprint_run \
        --scores /tmp/simulation_scores_*.json \
        --output /tmp/fingerprint.json

## Test plan

- \`examples/games/fingerprint_run_test.py\`: 19 tests covering Merkle-root determinism/order-independence, sensitivity to per-agent score changes and to scenario changes, the "matching aggregate but different per-agent split" case #271 specifically calls out, focal/background collision-avoidance, bundle vs content hash independence from provenance, glob/path resolution, and the CLI end to end (via \`main()\` with a temp dir, no simulation run required).
- \`python -m pytest examples/games/fingerprint_run_test.py -q\` → 19 passed.
- Manually exercised the CLI end-to-end against a synthetic score file (no LLM/API keys required) and confirmed the output JSON report.
- \`python -m pyink --check\` on all changed/new files → clean.

## Open questions from the issue

The issue itself left a few questions for maintainers unanswered (whether the original 2024 contest logs exist to compute a reference hash against, and whether this belongs in #265 instead). I didn't block on those — this PR is scoped to the mechanism itself (computing and persisting the fingerprint), which is useful regardless of how those get resolved. Happy to adjust the file layout/integration point based on maintainer feedback.