### PR TITLE
Fix unsynchronized call counter in CallLimitLanguageModel

### DIFF
--- a/concordia/language_model/call_limit_wrapper.py
+++ b/concordia/language_model/call_limit_wrapper.py
@@ -15,6 +15,7 @@
 """Wrapper to limit calls to an underlying language model."""
 
 from collections.abc import Collection, Mapping, Sequence
+import threading
 from typing import Any, override
 
 from absl import logging
@@ -44,6 +45,7 @@ class CallLimitLanguageModel(language_model.LanguageModel):
     self._model = model
     self._max_calls = max_calls
     self._calls = 0
+    self._calls_lock = threading.Lock()
 
   @override
   def sample_text(
@@ -58,17 +60,17 @@ class CallLimitLanguageModel(language_model.LanguageModel):
       timeout: float = language_model.DEFAULT_TIMEOUT_SECONDS,
       seed: int | None = None,
   ) -> str:
-    if self._calls >= self._max_calls:
-      logging.warning(
-          'Call limit of %s reached. All further sample_text calls will be'
-          ' replaced with empty strings and sample_choice calls with the first'
-          ' response',
-          self._max_calls,
-      )
+    with self._calls_lock:
+      if self._calls >= self._max_calls:
+        logging.warning(
+            'Call limit of %s reached. All further sample_text calls will be'
+            ' replaced with empty strings and sample_choice calls with the'
+            ' first response',
+            self._max_calls,
+        )
+        return ''
+      self._calls += 1
 
-      return ''
-
-    self._calls += 1
     return self._model.sample_text(
         prompt,
         max_tokens=max_tokens,
@@ -88,14 +90,15 @@ class CallLimitLanguageModel(language_model.LanguageModel):
       *,
       seed: int | None = None,
   ) -> tuple[int, str, Mapping[str, Any]]:
-    if self._calls >= self._max_calls:
-      logging.warning(
-          'Call limit of %s reached. All further sample_text calls will be'
-          ' replaced with empty strings and sample_choice calls with the first'
-          ' response',
-          self._max_calls,
-      )
-      return 0, responses[0], {}
+    with self._calls_lock:
+      if self._calls >= self._max_calls:
+        logging.warning(
+            'Call limit of %s reached. All further sample_text calls will be'
+            ' replaced with empty strings and sample_choice calls with the'
+            ' first response',
+            self._max_calls,
+        )
+        return 0, responses[0], {}
+      self._calls += 1
 
-    self._calls += 1
     return self._model.sample_choice(prompt, responses, seed=seed)

--- a/concordia/language_model/call_limit_wrapper_test.py
+++ b/concordia/language_model/call_limit_wrapper_test.py
@@ -1,0 +1,115 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for CallLimitLanguageModel."""
+
+import threading
+
+from absl.testing import absltest
+from concordia.language_model import call_limit_wrapper
+from concordia.language_model import language_model
+
+
+class _CountingModel(language_model.LanguageModel):
+  """A model that counts how many times it was actually invoked."""
+
+  def __init__(self):
+    self.sample_text_calls = 0
+    self.sample_choice_calls = 0
+    self._lock = threading.Lock()
+
+  def sample_text(self, prompt, **kwargs):
+    del prompt, kwargs
+    with self._lock:
+      self.sample_text_calls += 1
+    return 'response'
+
+  def sample_choice(self, prompt, responses, **kwargs):
+    del prompt, kwargs
+    with self._lock:
+      self.sample_choice_calls += 1
+    return 0, responses[0], {}
+
+
+class CallLimitLanguageModelTest(absltest.TestCase):
+
+  def test_calls_pass_through_under_the_limit(self):
+    model = _CountingModel()
+    wrapped = call_limit_wrapper.CallLimitLanguageModel(model, max_calls=3)
+    for _ in range(3):
+      self.assertEqual(wrapped.sample_text('prompt'), 'response')
+    self.assertEqual(model.sample_text_calls, 3)
+
+  def test_sample_text_returns_empty_string_once_limit_reached(self):
+    model = _CountingModel()
+    wrapped = call_limit_wrapper.CallLimitLanguageModel(model, max_calls=1)
+    self.assertEqual(wrapped.sample_text('prompt'), 'response')
+    self.assertEqual(wrapped.sample_text('prompt'), '')
+    self.assertEqual(wrapped.sample_text('prompt'), '')
+    # The underlying model must not be called once the limit is reached.
+    self.assertEqual(model.sample_text_calls, 1)
+
+  def test_sample_choice_returns_first_response_once_limit_reached(self):
+    model = _CountingModel()
+    wrapped = call_limit_wrapper.CallLimitLanguageModel(model, max_calls=1)
+    wrapped.sample_choice('prompt', ['a', 'b', 'c'])
+    result = wrapped.sample_choice('prompt', ['x', 'y', 'z'])
+    self.assertEqual(result, (0, 'x', {}))
+    self.assertEqual(model.sample_choice_calls, 1)
+
+  def test_sample_text_and_sample_choice_share_the_same_budget(self):
+    model = _CountingModel()
+    wrapped = call_limit_wrapper.CallLimitLanguageModel(model, max_calls=2)
+    wrapped.sample_text('prompt')
+    wrapped.sample_choice('prompt', ['a', 'b'])
+    # Budget is now exhausted; further calls of either kind should not reach
+    # the underlying model.
+    wrapped.sample_text('prompt')
+    wrapped.sample_choice('prompt', ['a', 'b'])
+    self.assertEqual(model.sample_text_calls, 1)
+    self.assertEqual(model.sample_choice_calls, 1)
+
+  def test_call_limit_is_enforced_exactly_under_concurrency(self):
+    # Regression test: the call counter used to be an unsynchronized
+    # `self._calls += 1` shared across every thread that calls the wrapped
+    # model. EntityAgent runs component calls concurrently via a
+    # ThreadPoolExecutor and typically shares one language model instance
+    # across an entire simulation, so this counter is genuinely
+    # multi-threaded in normal use: an unsynchronized read-modify-write on a
+    # shared counter is a data race regardless of whether any particular
+    # CPython build's GIL happens to hide it, and it's an outright bug on
+    # free-threaded (no-GIL) Python builds. With the counter under a lock,
+    # exactly `max_calls` of many more concurrent attempts must get through.
+    num_threads = 200
+    max_calls = 37
+    model = _CountingModel()
+    wrapped = call_limit_wrapper.CallLimitLanguageModel(
+        model, max_calls=max_calls
+    )
+
+    def worker():
+      wrapped.sample_text('prompt')
+
+    threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
+
+    self.assertEqual(model.sample_text_calls, max_calls)
+    self.assertEqual(wrapped._calls, max_calls)  # pylint: disable=protected-access
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

\`CallLimitLanguageModel\` (used to hard-cap the number of calls made to an underlying language model, e.g. to bound API spend) checked and incremented its counter with no synchronization:

    if self._calls >= self._max_calls:
      return ...
    self._calls += 1

A single wrapped model instance is normally shared across an entire simulation, and \`EntityAgent\` dispatches component calls concurrently through a \`ThreadPoolExecutor\` (see \`entity_agent.py\`'s \`_parallel_call_\`), so \`sample_text\`/\`sample_choice\` on this shared instance can genuinely be called from many threads at once. That makes the check-then-increment an unsynchronized read-modify-write on shared state — the same class of bug I found (and fixed, in a merged PR) in \`Measurements.close()\`, except there this codebase's own convention is normally to guard exactly this pattern with a lock (\`Measurements\`, \`ProfilerContext\`, \`AssociativeMemoryBank\`, etc. all do). This class was the one outlier that didn't.

**Being upfront about what I could and couldn't demonstrate:** I stress-tested the original code extensively (hundreds of trials, hundreds of threads each, against a dummy model) and was not able to force a standard CPython build to actually exceed the configured limit — the GIL happens to make this specific narrow check-then-increment hard to interleave in practice on this build. So I want to be precise about the claim: this is not a bug I observed causing a limit overrun in current CPython. It's a genuine synchronization bug by the threading model's own contract (nothing guarantees `+=` on an attribute is atomic across threads), and it's a real, not-hidden-by-anything bug on free-threaded (no-GIL) CPython builds, which PEP 703 made an officially supported build target starting with 3.13. Since the entire purpose of `max_calls` is to hard-cap spend/rate-limit exposure, an unenforced limit under a future Python build silently defeats that.

## Fix

Adds a lock around the check-and-increment only. The actual (potentially slow) call to the underlying model stays outside the lock, so concurrent calls still execute in parallel once past the counter check — this doesn't serialize LLM calls, just the counter.

## Test plan

New \`concordia/language_model/call_limit_wrapper_test.py\` (previously no coverage at all):
- Calls pass through under the limit; \`sample_text\` returns \`''\` and \`sample_choice\` returns the first response once the limit is reached, without invoking the underlying model.
- \`sample_text\` and \`sample_choice\` share a single budget.
- A concurrency test: 200 threads racing a budget of 37 must produce *exactly* 37 underlying calls, not "close to" 37 — this is deterministic and passes reliably with the lock in place.

\`python -m pytest concordia/language_model/ -q\` → 14 passed.
\`python -m pyink --check\` on both changed/new files → clean.