### PR TITLE
Guard NextActingInFixedOrder's turn state with its own lock

### DIFF
--- a/concordia/components/game_master/next_acting.py
+++ b/concordia/components/game_master/next_acting.py
@@ -305,20 +305,22 @@ class NextActingInFixedOrder(entity_component.ContextComponent):
   ) -> str:
     result = ''
     if action_spec.output_type == entity_lib.OutputType.NEXT_ACTING:
-      idx = self._currently_active_player_idx
-      if idx is None:
-        idx = 0
-      else:
-        idx = (idx + 1) % len(self._sequence)
-      result = self._sequence[idx]
-      self._currently_active_player_idx = idx
+      with self._lock:
+        idx = self._currently_active_player_idx
+        if idx is None:
+          idx = 0
+        else:
+          idx = (idx + 1) % len(self._sequence)
+        result = self._sequence[idx]
+        self._currently_active_player_idx = idx
 
     return result
 
   def get_currently_active_player(self) -> str | None:
-    if self._currently_active_player_idx is None:
-      return None
-    return self._sequence[self._currently_active_player_idx]
+    with self._lock:
+      if self._currently_active_player_idx is None:
+        return None
+      return self._sequence[self._currently_active_player_idx]
 
   def get_state(self) -> entity_component.ComponentState:
     """Returns the state of the component."""

--- a/concordia/components/game_master/next_acting_test.py
+++ b/concordia/components/game_master/next_acting_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NextActingInFixedOrder."""
+
+import threading
+
+from absl.testing import absltest
+from concordia.components.game_master import next_acting
+from concordia.typing import entity as entity_lib
+
+
+def _next_acting_spec(options=('alice', 'bob', 'carol')):
+  return entity_lib.ActionSpec(
+      call_to_action='Who is next?',
+      output_type=entity_lib.OutputType.NEXT_ACTING,
+      options=options,
+  )
+
+
+_NON_NEXT_ACTING_SPEC = entity_lib.ActionSpec(
+    call_to_action='Do something.',
+    output_type=entity_lib.OutputType.FREE,
+)
+
+
+class NextActingInFixedOrderTest(absltest.TestCase):
+
+  def test_get_currently_active_player_starts_as_none(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    self.assertIsNone(component.get_currently_active_player())
+
+  def test_pre_act_cycles_through_sequence_in_order(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    turns = [component.pre_act(_next_acting_spec()) for _ in range(5)]
+    self.assertEqual(turns, ['alice', 'bob', 'carol', 'alice', 'bob'])
+
+  def test_pre_act_ignores_non_next_acting_action_specs(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    result = component.pre_act(_NON_NEXT_ACTING_SPEC)
+    self.assertEqual(result, '')
+    self.assertIsNone(component.get_currently_active_player())
+
+  def test_get_currently_active_player_reflects_last_pre_act(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    component.pre_act(_next_acting_spec())
+    self.assertEqual(component.get_currently_active_player(), 'alice')
+    component.pre_act(_next_acting_spec())
+    self.assertEqual(component.get_currently_active_player(), 'bob')
+
+  def test_remove_actor_from_sequence(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    component.remove_actor_from_sequence('bob')
+    turns = [component.pre_act(_next_acting_spec()) for _ in range(3)]
+    self.assertEqual(turns, ['alice', 'carol', 'alice'])
+
+  def test_remove_unknown_actor_raises(self):
+    component = next_acting.NextActingInFixedOrder(['alice'])
+    with self.assertRaises(ValueError):
+      component.remove_actor_from_sequence('nobody')
+
+  def test_add_actor_to_sequence(self):
+    component = next_acting.NextActingInFixedOrder(['alice'])
+    component.add_actor_to_sequence('bob')
+    turns = [component.pre_act(_next_acting_spec()) for _ in range(3)]
+    self.assertEqual(turns, ['alice', 'bob', 'alice'])
+
+  def test_get_state_and_set_state_round_trip(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    component.pre_act(_next_acting_spec())  # advances to 'alice', idx 0
+
+    state = component.get_state()
+    restored = next_acting.NextActingInFixedOrder(['someone_else'])
+    restored.set_state(state)
+
+    self.assertEqual(restored.get_currently_active_player(), 'alice')
+    # The next turn after restoring should continue the original sequence.
+    self.assertEqual(restored.pre_act(_next_acting_spec()), 'bob')
+
+  def test_concurrent_pre_act_and_sequence_mutation_do_not_raise(self):
+    # NextActingInFixedOrder.pre_act() reads len(self._sequence) and then
+    # indexes into it, while remove_actor_from_sequence()/
+    # add_actor_to_sequence() mutate that same list. Both are guarded by
+    # the same lock so this should never raise, even when driven
+    # concurrently from multiple threads.
+    names = [f'player_{i}' for i in range(200)]
+    component = next_acting.NextActingInFixedOrder(list(names))
+    errors = []
+
+    def cycle():
+      for _ in range(500):
+        try:
+          component.pre_act(_next_acting_spec())
+          component.get_currently_active_player()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          errors.append(e)
+
+    def mutate():
+      for name in names[:150]:
+        try:
+          component.remove_actor_from_sequence(name)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          errors.append(e)
+      for name in names[:150]:
+        try:
+          component.add_actor_to_sequence(name)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          errors.append(e)
+
+    threads = [
+        threading.Thread(target=cycle),
+        threading.Thread(target=cycle),
+        threading.Thread(target=mutate),
+    ]
+    for t in threads:
+      t.start()
+    for t in threads:
+      t.join()
+
+    self.assertEmpty(errors)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
## Summary

While auditing this codebase's lock usage after the \`Measurements.close()\` deadlock fix (#282) and the \`CallLimitLanguageModel\` counter fix (#285), I found \`NextActingInFixedOrder\` (in \`concordia/components/game_master/next_acting.py\`) is inconsistent with its own locking discipline:

- \`remove_actor_from_sequence()\`, \`add_actor_to_sequence()\`, \`get_state()\`, and \`set_state()\` all take \`self._lock\` before touching \`self._sequence\`/\`self._currently_active_player_idx\`.
- \`pre_act()\` and \`get_currently_active_player()\` did not, despite reading and mutating exactly that same state.

Concretely: \`pre_act()\` reads \`len(self._sequence)\` and then indexes into \`self._sequence\`, while \`remove_actor_from_sequence()\` (which does take the lock) mutates that same list. If these ever run on different threads at the same time, \`pre_act()\` can compute an index against the old length and then index into a list that's since been shortened.

**Being precise about confidence here, same as in #285:** within a single \`EntityAgent.act()\` call, phases are sequenced and (from what I could trace) only one component's \`action_spec.output_type\` condition is normally true at a time, so I could not identify a call path where this is reachable today, and I could not force an \`IndexError\` out of it even under heavy synthetic thread contention (many threads racing \`pre_act\`/\`get_currently_active_player\` against \`remove_actor_from_sequence\`/\`add_actor_to_sequence\`). So I'm not claiming this is an observed live bug. What I can say confidently: this class was the one inconsistent case, both among its own methods and relative to every sibling class using this same locking pattern elsewhere in the codebase (\`Measurements\`, \`ObservationQueue\` in this same file, etc.), that left this particular state unprotected.

## Fix

Takes \`self._lock\` in \`pre_act()\` (only around the read-index-and-mutate block, not the whole method) and in \`get_currently_active_player()\`, matching the rest of the class.

## Test plan

New \`concordia/components/game_master/next_acting_test.py\` (previously no coverage at all):
- Sequence cycling and wraparound order.
- Non-\`NEXT_ACTING\` action specs are ignored.
- \`remove_actor_from_sequence\`/\`add_actor_to_sequence\`, including the \`ValueError\` case for an unknown actor.
- \`get_state\`/\`set_state\` round-tripping, including that a restored component continues the original sequence correctly.
- A concurrency test driving \`pre_act\`/\`get_currently_active_player\` against \`remove_actor_from_sequence\`/\`add_actor_to_sequence\` from multiple threads and asserting no exception is raised.

\`python -m pytest concordia/components/game_master/ -q\` → 177 passed (full directory, no regressions).
\`python -m pyink --check\` on the new test file → clean. (\`next_acting.py\` itself has substantial pre-existing formatting drift unrelated to this change in classes I didn't touch; I left that alone to keep this diff focused.)