### PR TITLE
Fix interrupt duration parsing

### DIFF
--- a/concordia/components/game_master/interrupt_time_model.py
+++ b/concordia/components/game_master/interrupt_time_model.py
@@ -49,21 +49,11 @@ def parse_duration_seconds(duration_str: str) -> int:
   duration_str = duration_str.strip()
   if not duration_str or duration_str == '0':
     return 0
-  hours = 0
-  minutes = 0
-  parsed = False
-  if 'h' in duration_str:
-    parts = duration_str.split('h', 1)
-    hours = int(parts[0])
-    rest = parts[1]
-    parsed = True
-  else:
-    rest = duration_str
-  if rest.endswith('m'):
-    minutes = int(rest[:-1])
-    parsed = True
-  if not parsed:
+  match = re.fullmatch(r'(?:(\d+)h)?(?:(\d+)m)?', duration_str)
+  if match is None or not any(match.groups()):
     return 3600  # Default fallback: 1 hour.
+  hours = int(match.group(1) or 0)
+  minutes = int(match.group(2) or 0)
   return hours * 3600 + minutes * 60
 
 

--- a/concordia/components/game_master/interrupt_time_model_test.py
+++ b/concordia/components/game_master/interrupt_time_model_test.py
@@ -26,6 +26,8 @@ class ParseDurationSecondsTest(parameterized.TestCase):
 
   @parameterized.parameters(
       ('0m', 0),
+      ('0h', 0),
+      ('0h0m', 0),
       ('0', 0),
       ('5m', 300),
       ('2h', 7200),
@@ -40,9 +42,17 @@ class ParseDurationSecondsTest(parameterized.TestCase):
         expected,
     )
 
-  def test_unparseable_defaults_to_one_hour(self):
+  @parameterized.parameters(
+      'abc',
+      '1hour',
+      '1h30mx',
+      '1hgarbage',
+      'h',
+      'm',
+  )
+  def test_unparseable_defaults_to_one_hour(self, input_str):
     self.assertEqual(
-        interrupt_time_model.parse_duration_seconds('abc'),
+        interrupt_time_model.parse_duration_seconds(input_str),
         3600,
     )
 


### PR DESCRIPTION
## Summary

Parse interrupt durations with a strict full-string pattern.

The previous split-based parser raised `ValueError` for malformed numeric fields and accepted some inputs with trailing garbage, despite documenting a one-hour fallback for unparseable values. Invalid strings now consistently use that fallback while valid hour/minute combinations retain their behavior.

## Tests

- Added malformed hour and minute cases
- Added zero-valued duration forms
