### PR TITLE
Keep absolute interrupt times in the future

### DIFF
--- a/concordia/components/game_master/interrupt_time_model.py
+++ b/concordia/components/game_master/interrupt_time_model.py
@@ -312,8 +312,9 @@ class GenerativeTimeModel(TimeModel):
 
     Prompts the LLM to convert the entity's absolute time specification into
     a number of seconds from now, then adds that offset to ``current_time``.
-    If the result is not strictly after ``current_time``, one simulated day
-    (86400 seconds) is added on the assumption the entity meant "tomorrow".
+    A non-positive offset is reduced modulo one simulated day. Exact multiples
+    of a day map to the following day, so the result is strictly after
+    ``current_time``.
 
     Args:
       time_str: An absolute time string, e.g. ``'8:00'``.
@@ -346,10 +347,11 @@ class GenerativeTimeModel(TimeModel):
       raise ValueError(
           f'Cannot parse LLM absolute-time response: {response!r}'
       ) from e
-    result = current_time + offset
-    if result <= current_time:
-      result += 86400  # Assume "tomorrow".
-    return result
+    if offset <= 0:
+      offset %= 86400
+      if offset == 0:
+        offset = 86400
+    return current_time + offset
 
   def format_time(self, time: int) -> str:
     """Formats a timestamp using the LLM. Results are cached."""

--- a/concordia/components/game_master/interrupt_time_model_test.py
+++ b/concordia/components/game_master/interrupt_time_model_test.py
@@ -144,7 +144,7 @@ class DatetimeTimeModelTest(absltest.TestCase):
     self.assertEqual(t1, t1)
 
 
-class GenerativeTimeModelTest(absltest.TestCase):
+class GenerativeTimeModelTest(parameterized.TestCase):
 
   def _make_model(self, format_response='narrated time'):
     """Creates a GenerativeTimeModel with a mock LLM."""
@@ -217,6 +217,19 @@ class GenerativeTimeModelTest(absltest.TestCase):
     model = self._make_model(format_response='-500')
     result = model.parse_absolute_time('8:00', 1000)
     self.assertEqual(result, 86900)  # 1000 + (-500) + 86400
+
+  @parameterized.parameters(
+      (-86400, 87400),
+      (-172800, 87400),
+      (-172900, 87300),
+  )
+  def test_parse_absolute_time_large_negative_offset_is_future(
+      self, offset, expected
+  ):
+    model = self._make_model(format_response=str(offset))
+    result = model.parse_absolute_time('8:00', 1000)
+    self.assertEqual(result, expected)
+    self.assertGreater(result, 1000)
 
   def test_parse_absolute_time_bad_llm_response_raises(self):
     model = self._make_model(format_response='not a number')


### PR DESCRIPTION
## Summary

Normalize non-positive absolute-time offsets to the next occurrence within a simulated day.

Adding one day once was insufficient for offsets more than a day in the past, so `parse_absolute_time()` could still return a timestamp at or before the current time. Modulo normalization now preserves the strictly-future contract for arbitrarily negative offsets.

## Tests

- Added cases for one-day and multi-day negative offsets
- Verified every result is strictly after the current time
