### PR TITLE
Require explicit tool choice answers

### DIFF
--- a/concordia/document/interactive_document_tools.py
+++ b/concordia/document/interactive_document_tools.py
@@ -418,14 +418,25 @@ class InteractiveDocumentWithTools(interactive_document.InteractiveDocument):
 
       if tool_call is None:
         # Not a tool call - try to parse as answer choice
-        # Look for a letter choice in the response
         response_lower = response.lower().strip()
-        for letter in options.keys():
-          if letter in response_lower:
-            self._model_response(f'({letter})\n')
-            # Find the original index
-            letter_idx = list(options.keys()).index(letter)
-            return original_indices[letter_idx]
+        option_letters = ''.join(options)
+        standalone_choice = re.fullmatch(
+            rf'([{option_letters}])', response_lower
+        )
+        parenthesized_choices = set(
+            re.findall(rf'\(([{option_letters}])\)', response_lower)
+        )
+        if standalone_choice is not None:
+          letter = standalone_choice.group(1)
+        elif len(parenthesized_choices) == 1:
+          letter = parenthesized_choices.pop()
+        else:
+          letter = None
+        if letter is not None:
+          self._model_response(f'({letter})\n')
+          # Find the original index
+          letter_idx = list(options.keys()).index(letter)
+          return original_indices[letter_idx]
 
         # Couldn't parse - treat as final response and use sample_choice
         self._model_response(response + '\n')

--- a/concordia/document/interactive_document_tools_test.py
+++ b/concordia/document/interactive_document_tools_test.py
@@ -322,6 +322,88 @@ class InteractiveDocumentWithToolsTest(parameterized.TestCase):
     self.assertEqual(tool.call_count, 0)
     self.assertEqual(result, 1)
 
+  def test_multiple_choice_standalone_letter_answer(self):
+    model = mock.create_autospec(
+        language_model.LanguageModel, instance=True, spec_set=True
+    )
+    model.sample_text.return_value = ' b '
+    tool = MockTool('search', 'Search', 'result')
+
+    doc = interactive_document_tools.InteractiveDocumentWithTools(
+        model, tools=[tool]
+    )
+    result = doc.multiple_choice_question(
+        'What color is the sky?',
+        ['Red', 'Blue', 'Green'],
+        randomize_choices=False,
+    )
+
+    self.assertEqual(result, 1)
+    model.sample_choice.assert_not_called()
+
+  def test_multiple_choice_incidental_letter_uses_sample_choice(self):
+    model = mock.create_autospec(
+        language_model.LanguageModel, instance=True, spec_set=True
+    )
+    model.sample_text.return_value = 'Based on the evidence, Paris.'
+    model.sample_choice.return_value = (2, 'c', {'debug': 'fallback'})
+    tool = MockTool('search', 'Search', 'result')
+
+    doc = interactive_document_tools.InteractiveDocumentWithTools(
+        model, tools=[tool]
+    )
+    result = doc.multiple_choice_question(
+        'What is the capital?',
+        ['London', 'Berlin', 'Paris'],
+        randomize_choices=False,
+    )
+
+    self.assertEqual(result, 2)
+    model.sample_choice.assert_called_once()
+
+  def test_multiple_choice_conflicting_parenthesized_answers_uses_fallback(
+      self,
+  ):
+    model = mock.create_autospec(
+        language_model.LanguageModel, instance=True, spec_set=True
+    )
+    model.sample_text.return_value = (
+        'I considered (a), but my final answer is (b).'
+    )
+    model.sample_choice.return_value = (1, 'b', {'debug': 'fallback'})
+    tool = MockTool('search', 'Search', 'result')
+
+    doc = interactive_document_tools.InteractiveDocumentWithTools(
+        model, tools=[tool]
+    )
+    result = doc.multiple_choice_question(
+        'What color is the sky?',
+        ['Red', 'Blue', 'Green'],
+        randomize_choices=False,
+    )
+
+    self.assertEqual(result, 1)
+    model.sample_choice.assert_called_once()
+
+  def test_multiple_choice_repeated_same_parenthesized_answer(self):
+    model = mock.create_autospec(
+        language_model.LanguageModel, instance=True, spec_set=True
+    )
+    model.sample_text.return_value = 'I choose (b). Final answer: (b).'
+    tool = MockTool('search', 'Search', 'result')
+
+    doc = interactive_document_tools.InteractiveDocumentWithTools(
+        model, tools=[tool]
+    )
+    result = doc.multiple_choice_question(
+        'What color is the sky?',
+        ['Red', 'Blue', 'Green'],
+        randomize_choices=False,
+    )
+
+    self.assertEqual(result, 1)
+    model.sample_choice.assert_not_called()
+
   def test_multiple_choice_max_tool_calls(self):
     """Multiple choice forces answer when tool budget exhausted."""
     model = mock.create_autospec(


### PR DESCRIPTION
## Summary

Only accept unambiguous option letters in tool-enabled multiple-choice responses.

The previous substring search treated any occurrence of an option letter in prose as the answer. Responses now resolve directly only when they are a standalone letter or contain one distinct parenthesized option. Ambiguous or incidental text falls back to the existing `sample_choice` path.

## Tests

- Covered standalone answers and incidental prose
- Covered conflicting and repeated parenthesized choices
