### PR TITLE
fix: initialize logging channel in game master components

### DIFF
--- a/concordia/components/game_master/inventory.py
+++ b/concordia/components/game_master/inventory.py
@@ -124,6 +124,7 @@ class Inventory(
         `pre_act`.
       verbose: whether to print the full update chain of thought or not
     """
+    super().__init__()
     self._pre_act_label = pre_act_label
     self._model = model
     self._observations_component_name = observations_component_name
@@ -436,6 +437,7 @@ class Score(
       pre_act_label: the name of this component to use in pre_act.
       verbose: whether to print the full update chain of thought or not
     """
+    super().__init__()
     self._pre_act_label = pre_act_label
     self._inventory = inventory
     self._player_names = player_names

--- a/concordia/components/game_master/inventory_test.py
+++ b/concordia/components/game_master/inventory_test.py
@@ -1,0 +1,187 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the inventory component."""
+
+import datetime
+from unittest import mock
+
+from absl.testing import absltest
+from concordia.components.game_master import inventory
+from concordia.testing import mock_model
+from concordia.typing import entity as entity_lib
+
+
+def _make_item_type_configs():
+  return [
+      inventory.ItemTypeConfig(name='money', minimum=0.0),
+      inventory.ItemTypeConfig(name='apple', minimum=0.0, force_integer=True),
+  ]
+
+
+def _make_inventory():
+  with mock.patch.object(
+      inventory.helper_functions, 'is_count_noun', return_value=False
+  ):
+    return inventory.Inventory(
+        model=mock_model.MockModel(),
+        item_type_configs=_make_item_type_configs(),
+        player_initial_endowments={
+            'Alice': {'money': 10.0, 'apple': 2},
+            'Bob': {'money': 5.0, 'apple': 1},
+        },
+        clock_now=datetime.datetime.now,
+    )
+
+
+class ItemTypeConfigTest(absltest.TestCase):
+  """Tests for the ItemTypeConfig helper."""
+
+  def test_check_valid_in_range(self):
+    config = inventory.ItemTypeConfig(name='x', minimum=0.0, maximum=10.0)
+    config.check_valid(5.0)
+
+  def test_check_valid_out_of_bounds(self):
+    config = inventory.ItemTypeConfig(name='x', minimum=0.0, maximum=10.0)
+    with self.assertRaises(ValueError):
+      config.check_valid(11.0)
+
+  def test_check_valid_force_integer(self):
+    config = inventory.ItemTypeConfig(name='x', force_integer=True)
+    with self.assertRaises(ValueError):
+      config.check_valid(1.5)
+    config.check_valid(2)
+
+  def test_many_or_much_fn(self):
+    self.assertEqual(inventory._many_or_much_fn(True), 'many')
+    self.assertEqual(inventory._many_or_much_fn(False), 'much')
+
+
+class InventoryTest(absltest.TestCase):
+  """Tests for the Inventory component."""
+
+  def test_get_state_set_state_round_trip(self):
+    component = _make_inventory()
+    state = component.get_state()
+    restored = _make_inventory()
+    restored.set_state(state)
+    self.assertEqual(restored.get_state(), state)
+
+  def test_get_pre_act_value(self):
+    component = _make_inventory()
+    expected = {
+        'Alice': {'money': 10.0, 'apple': 2},
+        'Bob': {'money': 5.0, 'apple': 1},
+    }
+    self.assertEqual(component.get_pre_act_value(), str(expected))
+
+  def test_get_player_inventory_returns_copy(self):
+    component = _make_inventory()
+    alice = component.get_player_inventory('Alice')
+    alice['money'] = 999.0
+    self.assertEqual(component.get_player_inventory('Alice')['money'], 10.0)
+
+  def test_pre_act_free_logs_and_returns_empty(self):
+    component = _make_inventory()
+    logging_channel = mock.MagicMock()
+    component.set_logging_channel(logging_channel)
+    action_spec = entity_lib.ActionSpec(
+        call_to_action='test', output_type=entity_lib.OutputType.FREE
+    )
+    self.assertEqual(component.pre_act(action_spec), '')
+    logging_channel.assert_called_once()
+
+  def test_pre_act_resolve_runs_and_returns_empty(self):
+    with mock.patch.object(
+        inventory.helper_functions, 'is_count_noun', return_value=False
+    ):
+      component = inventory.Inventory(
+          model=mock_model.MockModel(),
+          item_type_configs=_make_item_type_configs(),
+          player_initial_endowments={'Alice': {'money': 10.0}},
+          clock_now=datetime.datetime.now,
+      )
+
+    mock_memory = mock.MagicMock()
+    mock_observation = mock.MagicMock()
+    mock_observation.get_pre_act_value.return_value = (
+        'Alice paid Bob 5 coins.'
+    )
+
+    mock_entity = mock.MagicMock()
+
+    def get_component(name, type_=None):
+      del type_
+      if name == component._memory_component_name:
+        return mock_memory
+      if name == component._observations_component_name:
+        return mock_observation
+      return mock.MagicMock()
+
+    mock_entity.get_component.side_effect = get_component
+    component._entity = mock_entity
+
+    action_spec = entity_lib.ActionSpec(
+        call_to_action='test', output_type=entity_lib.OutputType.RESOLVE
+    )
+    self.assertEqual(component.pre_act(action_spec), '')
+
+
+class ScoreTest(absltest.TestCase):
+  """Tests for the Score component."""
+
+  def _make_score(self):
+    mock_inventory = mock.MagicMock()
+    mock_inventory.get_player_inventory.side_effect = lambda name: {
+        'money': 10,
+        'apple': 3,
+    }
+    mock_inventory.get_state.return_value = {
+        'inventories': {'Alice': {'money': 10}}
+    }
+    score = inventory.Score(
+        inventory=mock_inventory,
+        player_names=['Alice', 'Bob'],
+        targets={'Alice': ['money'], 'Bob': ['apple']},
+    )
+    return score, mock_inventory
+
+  def test_get_scores(self):
+    score, _ = self._make_score()
+    self.assertEqual(score.get_scores(), {'Alice': 10.0, 'Bob': 3.0})
+
+  def test_pre_act_logs_and_returns_empty(self):
+    score, _ = self._make_score()
+    logging_channel = mock.MagicMock()
+    score.set_logging_channel(logging_channel)
+    action_spec = entity_lib.ActionSpec(
+        call_to_action='test', output_type=entity_lib.OutputType.FREE
+    )
+    self.assertEqual(score.pre_act(action_spec), '')
+    logging_channel.assert_called_once()
+
+  def test_state_round_trip(self):
+    score, mock_inventory = self._make_score()
+    state = score.get_state()
+    self.assertEqual(
+        state, {'inventory': {'inventories': {'Alice': {'money': 10}}}}
+    )
+    score.set_state(state)
+    mock_inventory.set_state.assert_called_once_with(
+        {'inventories': {'Alice': {'money': 10}}}
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/components/game_master/world_state.py
+++ b/concordia/components/game_master/world_state.py
@@ -43,6 +43,7 @@ class WorldState(
       pre_act_label: Prefix to add to the output of the component when called
         in `pre_act`.
     """
+    super().__init__()
     self._pre_act_label = pre_act_label
     self._model = model
     self._components = tuple(components)
@@ -192,6 +193,7 @@ class Locations(
         matching is normalized to 'unknown'. When None, free-form behavior is
         used.
     """
+    super().__init__()
     self._pre_act_label = pre_act_label
     self._model = model
     self._entity_names = entity_names
@@ -435,6 +437,7 @@ class GenerativeClock(
       pre_act_label: Prefix to add to the output of the component when called
         in `pre_act`.
     """
+    super().__init__()
     self._pre_act_label = pre_act_label
     self._model = model
     self._format_description_key = format_description_key

--- a/concordia/components/game_master/world_state_test.py
+++ b/concordia/components/game_master/world_state_test.py
@@ -1,0 +1,172 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the world_state component."""
+
+from absl.testing import absltest
+from concordia.components.game_master import world_state
+from concordia.language_model import no_language_model
+from concordia.testing import mock_model
+from concordia.typing import entity as entity_lib
+
+
+class WorldStateTest(absltest.TestCase):
+  """Tests for the WorldState component."""
+
+  def setUp(self):
+    super().setUp()
+    self._model = no_language_model.NoLanguageModel()
+
+  def test_get_pre_act_value_empty(self):
+    component = world_state.WorldState(model=self._model)
+    self.assertEqual(component.get_pre_act_value(), '\n')
+
+  def test_get_pre_act_value_formats_entries(self):
+    component = world_state.WorldState(model=self._model)
+    component.set_state({
+        'state': {'weather': 'sunny', 'time': 'noon'},
+        'latest_action_spec': None,
+    })
+    self.assertEqual(
+        component.get_pre_act_value(), 'weather: sunny\ntime: noon\n'
+    )
+
+  def test_get_pre_act_label(self):
+    component = world_state.WorldState(
+        model=self._model, pre_act_label='\nState'
+    )
+    self.assertEqual(component.get_pre_act_label(), '\nState')
+
+  def test_state_round_trip(self):
+    component = world_state.WorldState(model=self._model)
+    original = {'state': {'a': '1'}, 'latest_action_spec': None}
+    component.set_state(original)
+    self.assertEqual(component.get_state(), original)
+
+  def test_pre_act_records_action_spec_and_returns_state(self):
+    component = world_state.WorldState(model=self._model)
+    component.set_state({'state': {'x': 'y'}, 'latest_action_spec': None})
+    action_spec = entity_lib.ActionSpec(
+        call_to_action='test', output_type=entity_lib.OutputType.RESOLVE
+    )
+    self.assertEqual(component.pre_act(action_spec), 'x: y\n')
+    self.assertEqual(component._latest_action_spec.to_dict(),
+                     action_spec.to_dict())
+
+  def test_action_spec_round_trip(self):
+    component = world_state.WorldState(model=self._model)
+    action_spec = entity_lib.ActionSpec(
+        call_to_action='act', output_type=entity_lib.OutputType.FREE
+    )
+    component.pre_act(action_spec)
+    restored = world_state.WorldState(model=self._model)
+    restored.set_state(component.get_state())
+    self.assertEqual(
+        restored._latest_action_spec.to_dict(), action_spec.to_dict()
+    )
+
+
+class LocationsNormalizeTest(absltest.TestCase):
+  """Tests for the Locations._normalize_location helper."""
+
+  def _make_locations(self, valid_locations):
+    return world_state.Locations(
+        model=mock_model.MockModel(''),
+        entity_names=['Alice', 'Bob'],
+        prompt='a prompt',
+        valid_locations=valid_locations,
+    )
+
+  def test_empty_location_normalizes_to_empty(self):
+    locations = self._make_locations(['Home', 'Work'])
+    self.assertEqual(locations._normalize_location(''), '')
+
+  def test_free_form_when_no_valid_locations(self):
+    locations = self._make_locations(None)
+    self.assertEqual(locations._normalize_location('  Home.  '), 'Home')
+
+  def test_exact_match(self):
+    locations = self._make_locations(['Home', 'Work'])
+    self.assertEqual(locations._normalize_location('Home'), 'Home')
+
+  def test_case_insensitive_match(self):
+    locations = self._make_locations(['Home', 'Work'])
+    self.assertEqual(locations._normalize_location('home'), 'Home')
+
+  def test_substring_match(self):
+    locations = self._make_locations(['Home', 'Work'])
+    self.assertEqual(locations._normalize_location('the Home base'), 'Home')
+
+  def test_unknown_location_normalizes_to_empty(self):
+    locations = self._make_locations(['Home', 'Work'])
+    self.assertEqual(locations._normalize_location('School'), '')
+
+  def test_trailing_period_is_stripped(self):
+    locations = self._make_locations(['Home', 'Work'])
+    self.assertEqual(locations._normalize_location('Home.'), 'Home')
+
+
+class LocationsStateTest(absltest.TestCase):
+  """Tests for the Locations component state handling."""
+
+  def test_initial_locations_default_to_empty(self):
+    locations = world_state.Locations(
+        model=mock_model.MockModel(''),
+        entity_names=['Alice', 'Bob'],
+        prompt='p',
+    )
+    self.assertEqual(locations._entity_locations, {'Alice': '', 'Bob': ''})
+
+  def test_initial_locations_override_defaults(self):
+    locations = world_state.Locations(
+        model=mock_model.MockModel(''),
+        entity_names=['Alice', 'Bob', 'Carol'],
+        prompt='p',
+        initial_locations={'Alice': 'Home', 'Bob': 'Work'},
+    )
+    self.assertEqual(
+        locations._entity_locations,
+        {'Alice': 'Home', 'Bob': 'Work', 'Carol': ''},
+    )
+
+  def test_get_pre_act_value_filters_empty_locations(self):
+    locations = world_state.Locations(
+        model=mock_model.MockModel(''),
+        entity_names=['Alice', 'Bob'],
+        prompt='p',
+    )
+    self.assertEqual(locations.get_pre_act_value(), '\n')
+    locations._entity_locations['Alice'] = 'Home'
+    self.assertEqual(locations.get_pre_act_value(), 'Alice: Home\n')
+
+  def test_state_round_trip(self):
+    locations = world_state.Locations(
+        model=mock_model.MockModel(''),
+        entity_names=['Alice', 'Bob'],
+        prompt='p',
+    )
+    locations._entity_locations['Alice'] = 'Home'
+    state = locations.get_state()
+    restored = world_state.Locations(
+        model=mock_model.MockModel(''),
+        entity_names=['Alice', 'Bob'],
+        prompt='p',
+    )
+    restored.set_state(state)
+    self.assertEqual(restored._entity_locations, locations._entity_locations)
+    self.assertEqual(restored._locations, locations._locations)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/components/game_master/world_state_test.py
+++ b/concordia/components/game_master/world_state_test.py
@@ -61,8 +61,9 @@ class WorldStateTest(absltest.TestCase):
         call_to_action='test', output_type=entity_lib.OutputType.RESOLVE
     )
     self.assertEqual(component.pre_act(action_spec), 'x: y\n')
-    self.assertEqual(component._latest_action_spec.to_dict(),
-                     action_spec.to_dict())
+    self.assertEqual(
+        component.get_state()['latest_action_spec'], action_spec.to_dict()
+    )
 
   def test_action_spec_round_trip(self):
     component = world_state.WorldState(model=self._model)
@@ -73,7 +74,7 @@ class WorldStateTest(absltest.TestCase):
     restored = world_state.WorldState(model=self._model)
     restored.set_state(component.get_state())
     self.assertEqual(
-        restored._latest_action_spec.to_dict(), action_spec.to_dict()
+        restored.get_state()['latest_action_spec'], action_spec.to_dict()
     )
 
 


### PR DESCRIPTION
  ## Problem

  Five game-master components call `self._logging_channel(...)` in `pre_act`
  without ever calling `super().__init__()`:

  - `WorldState`, `Locations`, and `GenerativeClock` in
    `concordia/components/game_master/world_state.py`
  - `Inventory` and `Score` in
    `concordia/components/game_master/inventory.py`

  `_logging_channel` is installed only by `ComponentWithLogging.__init__()`, so it
  is never defined on these components. When they are used with a plain
  `EntityAgent` (which never calls `set_logging_channel`), `pre_act` raises:

  AttributeError: '...' object has no attribute '_logging_channel'

  ## Fix

  Add the missing `super().__init__()` to each of the five `__init__` methods so
  that `ComponentWithLogging` installs the default `NoOpLoggingChannel`. This
  matches the existing pattern in `terminate.py`, `make_observation.py`, and
  `constant.py`.

  ## Tests

  Add unit tests that run without an LLM (using `MockModel` and mocks):

  - `world_state_test.py` (17 tests)
    - `WorldState`: `pre_act`, action-spec and state round-trips, formatted output.
    - `Locations._normalize_location`: exact / case-insensitive / substring /
      unknown / empty / trailing-period handling.
    - `Locations`: initial-location defaults and overrides, empty-location
      filtering, state round-trip.
  - `inventory_test.py` (12 tests)
    - `ItemTypeConfig.check_valid` and `_many_or_much_fn`.
    - `Inventory`: state round-trip, `pre_act` (FREE and RESOLVE paths),
      `get_player_inventory` copy semantics.
    - `Score`: scoring, `pre_act`, state round-trip.

  pytest concordia/components/game_master/ -n 0
  → 197 passed.