### PR TITLE
Fix turn-order corruption when an actor is removed mid-simulation

### DIFF
--- a/concordia/components/game_master/next_acting.py
+++ b/concordia/components/game_master/next_acting.py
@@ -284,14 +284,50 @@ class NextActingInFixedOrder(entity_component.ContextComponent):
 
     self._currently_active_player_idx = None
 
+  def _index_after_removal(self, removed_idx: int) -> int | None:
+    """Returns the active player index after a removal from the sequence.
+
+    Must be called with `self._lock` held, and after the removal has already
+    been applied to `self._sequence`.
+
+    Args:
+      removed_idx: The index the removed actor occupied in the sequence.
+    """
+    idx = self._currently_active_player_idx
+    if idx is None or not self._sequence:
+      return None
+    if removed_idx < idx:
+      # The currently active player shifted one place towards the front.
+      return idx - 1
+    if removed_idx == idx:
+      # The currently active player left mid-turn. Step back one place so that
+      # the next `pre_act` resumes with their successor, who now occupies
+      # `removed_idx` (wrapping to the end when the front was removed).
+      return (removed_idx - 1) % len(self._sequence)
+    return idx
+
   def remove_actor_from_sequence(self, actor_name: str) -> None:
-    """Removes an actor from the sequence."""
+    """Removes an actor from the sequence.
+
+    The index tracking the currently active player is adjusted so that it keeps
+    pointing at the same player. Without this, removing an actor positioned at
+    or before the currently active player leaves the index dangling, which
+    makes `get_currently_active_player` raise `IndexError` and makes `pre_act`
+    skip or repeat a turn.
+
+    Args:
+      actor_name: Name of the actor to remove from the sequence.
+
+    Raises:
+      ValueError: If the actor is not in the sequence.
+    """
     with self._lock:
       logging.info('Removing %s from sequence: %s', actor_name, self._sequence)
-      if actor_name in self._sequence:
-        self._sequence.remove(actor_name)
-      else:
+      if actor_name not in self._sequence:
         raise ValueError(f'Actor {actor_name} not found in sequence.')
+      removed_idx = self._sequence.index(actor_name)
+      self._sequence.remove(actor_name)
+      self._currently_active_player_idx = self._index_after_removal(removed_idx)
       logging.info('Sequence after removal: %s', self._sequence)
 
   def add_actor_to_sequence(self, actor_name: str) -> None:
@@ -305,29 +341,30 @@ class NextActingInFixedOrder(entity_component.ContextComponent):
   ) -> str:
     result = ''
     if action_spec.output_type == entity_lib.OutputType.NEXT_ACTING:
-      idx = self._currently_active_player_idx
-      if idx is None:
-        idx = 0
-      else:
-        idx = (idx + 1) % len(self._sequence)
-      result = self._sequence[idx]
-      self._currently_active_player_idx = idx
+      with self._lock:
+        idx = self._currently_active_player_idx
+        if idx is None:
+          idx = 0
+        else:
+          idx = (idx + 1) % len(self._sequence)
+        result = self._sequence[idx]
+        self._currently_active_player_idx = idx
 
     return result
 
   def get_currently_active_player(self) -> str | None:
-    if self._currently_active_player_idx is None:
-      return None
-    return self._sequence[self._currently_active_player_idx]
+    with self._lock:
+      if self._currently_active_player_idx is None:
+        return None
+      return self._sequence[self._currently_active_player_idx]
 
   def get_state(self) -> entity_component.ComponentState:
     """Returns the state of the component."""
     with self._lock:
-      sequence = copy.copy(self._sequence)
-    return {
-        'currently_active_player_idx': self._currently_active_player_idx,
-        'sequence': sequence,
-    }
+      return {
+          'currently_active_player_idx': self._currently_active_player_idx,
+          'sequence': copy.copy(self._sequence),
+      }
 
   def set_state(self, state: entity_component.ComponentState) -> None:
     """Sets the state of the component."""

--- a/concordia/components/game_master/next_acting_test.py
+++ b/concordia/components/game_master/next_acting_test.py
@@ -1,0 +1,177 @@
+# Copyright 2023 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NextActingInFixedOrder."""
+
+import threading
+
+from absl.testing import absltest
+from concordia.components.game_master import next_acting
+from concordia.typing import entity as entity_lib
+
+
+# NextActingInFixedOrder picks the next player from its own sequence and
+# ignores the options on the action spec, but NEXT_ACTING is a choice-type
+# output so the spec must still carry some.
+_NEXT_ACTING_SPEC = entity_lib.ActionSpec(
+    call_to_action='Who is next?',
+    output_type=entity_lib.OutputType.NEXT_ACTING,
+    options=('alice', 'bob', 'carol'),
+)
+
+_FREE_SPEC = entity_lib.ActionSpec(
+    call_to_action='Do something.',
+    output_type=entity_lib.OutputType.FREE,
+)
+
+
+class NextActingInFixedOrderTest(absltest.TestCase):
+
+  def test_removing_an_earlier_actor_keeps_the_active_player(self):
+    # Regression test: removing an actor positioned before the currently
+    # active player used to leave `_currently_active_player_idx` dangling,
+    # so `get_currently_active_player` raised IndexError and the following
+    # turn repeated the active player instead of advancing to the next one.
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    for _ in range(3):
+      component.pre_act(_NEXT_ACTING_SPEC)
+    self.assertEqual(component.get_currently_active_player(), 'carol')
+
+    component.remove_actor_from_sequence('alice')
+
+    self.assertEqual(component.get_currently_active_player(), 'carol')
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'bob')
+
+  def test_removing_the_active_actor_resumes_with_their_successor(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    component.pre_act(_NEXT_ACTING_SPEC)
+    component.pre_act(_NEXT_ACTING_SPEC)
+    self.assertEqual(component.get_currently_active_player(), 'bob')
+
+    component.remove_actor_from_sequence('bob')
+
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'carol')
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'alice')
+
+  def test_removing_the_active_actor_at_the_front_wraps_around(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'alice')
+
+    component.remove_actor_from_sequence('alice')
+
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'bob')
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'carol')
+
+  def test_removing_a_later_actor_keeps_the_active_player(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    component.pre_act(_NEXT_ACTING_SPEC)
+    self.assertEqual(component.get_currently_active_player(), 'alice')
+
+    component.remove_actor_from_sequence('carol')
+
+    self.assertEqual(component.get_currently_active_player(), 'alice')
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'bob')
+
+  def test_removing_the_last_remaining_actor_clears_the_active_player(self):
+    component = next_acting.NextActingInFixedOrder(['alice'])
+    component.pre_act(_NEXT_ACTING_SPEC)
+
+    component.remove_actor_from_sequence('alice')
+
+    self.assertIsNone(component.get_currently_active_player())
+
+  def test_removal_before_any_turn_leaves_the_active_player_unset(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    component.remove_actor_from_sequence('alice')
+    self.assertIsNone(component.get_currently_active_player())
+    self.assertEqual(component.pre_act(_NEXT_ACTING_SPEC), 'bob')
+
+  def test_get_currently_active_player_starts_as_none(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    self.assertIsNone(component.get_currently_active_player())
+
+  def test_pre_act_cycles_through_the_sequence_in_order(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob', 'carol'])
+    turns = [component.pre_act(_NEXT_ACTING_SPEC) for _ in range(5)]
+    self.assertEqual(turns, ['alice', 'bob', 'carol', 'alice', 'bob'])
+
+  def test_pre_act_ignores_other_action_specs(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    self.assertEqual(component.pre_act(_FREE_SPEC), '')
+    self.assertIsNone(component.get_currently_active_player())
+
+  def test_removing_an_unknown_actor_raises(self):
+    component = next_acting.NextActingInFixedOrder(['alice'])
+    with self.assertRaises(ValueError):
+      component.remove_actor_from_sequence('nobody')
+
+  def test_add_actor_to_sequence(self):
+    component = next_acting.NextActingInFixedOrder(['alice'])
+    component.add_actor_to_sequence('bob')
+    turns = [component.pre_act(_NEXT_ACTING_SPEC) for _ in range(3)]
+    self.assertEqual(turns, ['alice', 'bob', 'alice'])
+
+  def test_get_state_and_set_state_round_trip(self):
+    component = next_acting.NextActingInFixedOrder(['alice', 'bob'])
+    component.pre_act(_NEXT_ACTING_SPEC)
+
+    restored = next_acting.NextActingInFixedOrder(['someone_else'])
+    restored.set_state(component.get_state())
+
+    self.assertEqual(restored.get_currently_active_player(), 'alice')
+    self.assertEqual(restored.pre_act(_NEXT_ACTING_SPEC), 'bob')
+
+  def test_concurrent_turn_taking_and_removal_is_consistent(self):
+    # `pre_act` reads `len(self._sequence)` and then indexes into it, while
+    # `remove_actor_from_sequence` mutates that same list under `self._lock`.
+    # Reading without the lock lets the sequence shrink in between, so the
+    # index can fall off the end.
+    names = [f'player_{i}' for i in range(100)]
+    component = next_acting.NextActingInFixedOrder(list(names))
+    errors = []
+    start = threading.Barrier(3)
+
+    def take_turns():
+      start.wait()
+      for _ in range(200):
+        try:
+          component.pre_act(_NEXT_ACTING_SPEC)
+          component.get_currently_active_player()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          errors.append(e)
+
+    def churn_sequence():
+      start.wait()
+      for name in names[:50]:
+        try:
+          component.remove_actor_from_sequence(name)
+          component.add_actor_to_sequence(name)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+          errors.append(e)
+
+    threads = [
+        threading.Thread(target=take_turns),
+        threading.Thread(target=take_turns),
+        threading.Thread(target=churn_sequence),
+    ]
+    for thread in threads:
+      thread.start()
+    for thread in threads:
+      thread.join()
+
+    self.assertEmpty(errors)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
Follow-up to #286, which @jzleibo closed asking for a clearly demonstrated bug before taking a change of that shape. That was fair — #286 was a locking change with no failing test behind it. This PR leads with the bug instead.

## The bug

`NextActingInFixedOrder.remove_actor_from_sequence` mutates `self._sequence` but never adjusts `_currently_active_player_idx`, so the index is left pointing at the wrong entry or past the end of the list. No threads involved:

```python
c = NextActingInFixedOrder(['alice', 'bob', 'carol'])
c.pre_act(spec)  # 'alice'
c.pre_act(spec)  # 'bob'
c.pre_act(spec)  # 'carol', idx == 2
c.remove_actor_from_sequence('alice')  # sequence -> ['bob', 'carol'], idx still 2
c.get_currently_active_player()        # IndexError: list index out of range
c.pre_act(spec)                        # 'carol' again — bob never acts
```

Two distinct failures: a crash, and silent turn-order corruption in the component whose entire contract is *fixed order*.

This is reachable in the library as it stands. `contrib/components/game_master/death.py:180` removes dead actors from the sequence mid-simulation, and `event_resolution.py:153` then calls `get_currently_active_player()` to name the acting entity. Any fixed-order game master that can kill or retire an actor is exposed.

## The fix

- Adjust the index on removal so it keeps tracking the same player.
- When the removed actor *is* the currently active player, step the index back one place so the next `pre_act` resumes with their successor rather than skipping them.
- Clear the index when the sequence empties.
- Read and write the turn state under `self._lock` — the lock that already exists on this class and already guards `_sequence` in `remove_actor_from_sequence`, `add_actor_to_sequence`, `get_state` and `set_state`. `pre_act` reads `len(self._sequence)` and then indexes into it, so a concurrent removal can shrink the list in between. This part is the surviving hunk from #286, now scoped to finishing locking that is already there rather than introducing a new scheme.

## Tests

New `next_acting_test.py` — the file had no test coverage before. **Four of the tests fail on `main` and pass with this change:**

```
FAILED test_removing_an_earlier_actor_keeps_the_active_player
FAILED test_removing_the_active_actor_resumes_with_their_successor
FAILED test_removing_the_active_actor_at_the_front_wraps_around
FAILED test_removing_the_last_remaining_actor_clears_the_active_player
4 failed, 9 passed
```

With the fix, 13/13 pass, and the full `concordia/components/game_master/` suite is green at 181 passed.
