### PR TITLE
Honor remove_duplicates when searching nested data

### DIFF
--- a/concordia/utils/helper_functions.py
+++ b/concordia/utils/helper_functions.py
@@ -300,10 +300,14 @@ def find_data_in_nested_structure(
     for k, v in data.items():
       if k == key:
         results.append(v)
-      results.extend(find_data_in_nested_structure(v, key))
+      results.extend(
+          find_data_in_nested_structure(v, key, remove_duplicates=False)
+      )
   elif isinstance(data, list):
     for item in data:
-      results.extend(find_data_in_nested_structure(item, key))
+      results.extend(
+          find_data_in_nested_structure(item, key, remove_duplicates=False)
+      )
   if remove_duplicates:
     return remove_duplicate_dicts(results)
   return results

--- a/concordia/utils/helper_functions_test.py
+++ b/concordia/utils/helper_functions_test.py
@@ -55,5 +55,34 @@ class TestPrettyPrintFunction(unittest.TestCase):
     )
 
 
+class FindNestedDataTest(absltest.TestCase):
+
+  def test_preserves_nested_duplicates_when_disabled(self):
+    value = {'name': 'Alice'}
+    data = {'outer': [{'event': value}, {'event': value}]}
+    self.assertEqual(
+        helper_functions.find_data_in_nested_structure(
+            data, 'event', remove_duplicates=False
+        ),
+        [value, value],
+    )
+
+  def test_preserves_nested_scalar_values_when_disabled(self):
+    data = {'outer': [{'event': 'Alice'}, {'event': 'Alice'}]}
+    self.assertEqual(
+        helper_functions.find_data_in_nested_structure(
+            data, 'event', remove_duplicates=False
+        ),
+        ['Alice', 'Alice'],
+    )
+
+  def test_default_removes_duplicates_across_nested_branches(self):
+    value = {'name': 'Alice'}
+    data = {'left': {'event': value}, 'right': [{'event': value}]}
+    self.assertEqual(
+        helper_functions.find_data_in_nested_structure(data, 'event'), [value]
+    )
+
+
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Recursive calls reset `remove_duplicates` to its default, so passing `False` still removes nested matches and can crash on scalar values. Collect matches without deduplicating during recursion, then apply the requested behavior once at the top.

Adds tests for nested duplicates, scalar values, and the default deduplication behavior.
