### PR TITLE
Allow component comparisons without skip_keys

### DIFF
--- a/concordia/utils/helper_functions.py
+++ b/concordia/utils/helper_functions.py
@@ -323,8 +323,7 @@ def deep_compare_components(comp1, comp2, test_case, skip_keys=None):
 
   for key in d1:
 
-    # pyrefly: ignore [not-iterable]
-    if key in skip_keys:
+    if skip_keys and key in skip_keys:
       continue
 
     val1 = d1[key]

--- a/concordia/utils/helper_functions_test.py
+++ b/concordia/utils/helper_functions_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import types
 import unittest
 
 from absl.testing import absltest
@@ -52,6 +53,28 @@ class TestPrettyPrintFunction(unittest.TestCase):
     self.assertEqual(
         helper_functions.print_pretty_prefabs(test_dict),
         EXPECTED_OUTPUT_STANDARD_CASE,
+    )
+
+
+class DeepCompareComponentsTest(absltest.TestCase):
+
+  def test_compares_nested_components_without_skip_keys(self):
+    first = types.SimpleNamespace(child=types.SimpleNamespace(value=1))
+    second = types.SimpleNamespace(child=types.SimpleNamespace(value=1))
+    helper_functions.deep_compare_components(first, second, self)
+
+  def test_reports_value_mismatch_without_skip_keys(self):
+    with self.assertRaises(AssertionError):
+      helper_functions.deep_compare_components(
+          types.SimpleNamespace(value=1), types.SimpleNamespace(value=2), self
+      )
+
+  def test_still_skips_requested_keys(self):
+    helper_functions.deep_compare_components(
+        types.SimpleNamespace(value=1),
+        types.SimpleNamespace(value=2),
+        self,
+        skip_keys={'value'},
     )
 
 


### PR DESCRIPTION
`deep_compare_components()` defaults `skip_keys` to `None` but immediately checks membership in it, raising `TypeError`. Guard the optional set before checking membership.

Adds tests for nested comparisons with the default arguments, mismatches, and explicit skipped keys.
