### PR TITLE
Preserve instance identity in grouped visual editor cards

### DIFF
--- a/concordia/utils/visual_interface.py
+++ b/concordia/utils/visual_interface.py
@@ -24,7 +24,6 @@ from typing import Any
 
 from concordia.typing import prefab as prefab_lib
 
-
 # Color schemes for different roles
 _COLORS = {
     prefab_lib.Role.ENTITY: {
@@ -337,25 +336,33 @@ def visualize_config(
   Returns:
     Tuple of (SVG string, entity data dict for JavaScript).
   """
-  # Group instances by role
-  entities = [i for i in config.instances if i.role == prefab_lib.Role.ENTITY]
+  # Preserve config indices so grouped cards match _build_entity_data IDs.
+  indexed_instances = list(enumerate(config.instances))
+  entities = [
+      (index, instance)
+      for index, instance in indexed_instances
+      if instance.role == prefab_lib.Role.ENTITY
+  ]
   game_masters = [
-      i for i in config.instances if i.role == prefab_lib.Role.GAME_MASTER
+      (index, instance)
+      for index, instance in indexed_instances
+      if instance.role == prefab_lib.Role.GAME_MASTER
   ]
   initializers = [
-      i for i in config.instances if i.role == prefab_lib.Role.INITIALIZER
+      (index, instance)
+      for index, instance in indexed_instances
+      if instance.role == prefab_lib.Role.INITIALIZER
   ]
 
   svg_parts = []
   current_y = _PADDING
-  entity_id_counter = [0]  # Use list for nonlocal mutation
 
   # Calculate grid width
   max_cols = 4
   grid_width = max_cols * (_ENTITY_WIDTH + _GRID_GAP) - _GRID_GAP + 2 * _PADDING
 
   def render_group(
-      instances: list[prefab_lib.InstanceConfig],
+      instances: list[tuple[int, prefab_lib.InstanceConfig]],
       title: str,
       start_y: int,
   ) -> int:
@@ -381,10 +388,9 @@ def visualize_config(
     row_y = start_y
     row_max_height = 0
 
-    for instance in instances:
+    for index, instance in instances:
       x = _PADDING + col * (_ENTITY_WIDTH + _GRID_GAP)
-      entity_id = f"entity_{entity_id_counter[0]}"
-      entity_id_counter[0] += 1
+      entity_id = f"entity_{index}"
       entity_svg, height = _render_entity_svg(instance, x, row_y, entity_id)
       svg_parts.append(entity_svg)
       row_max_height = max(row_max_height, height)

--- a/concordia/utils/visual_interface_test.py
+++ b/concordia/utils/visual_interface_test.py
@@ -1,0 +1,105 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that grouped entity cards identify the same inspector instance."""
+
+import itertools
+import xml.etree.ElementTree as ET
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.typing import prefab as prefab_lib
+from concordia.utils import visual_interface
+
+_ROLES = (
+    prefab_lib.Role.ENTITY,
+    prefab_lib.Role.GAME_MASTER,
+    prefab_lib.Role.INITIALIZER,
+)
+_NS = {"svg": "http://www.w3.org/2000/svg"}
+
+
+class EntityIdentityTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      *itertools.permutations(_ROLES),
+      (_ROLES[2], _ROLES[0], _ROLES[1], _ROLES[0], _ROLES[2], _ROLES[1]),
+      (_ROLES[1], _ROLES[2], _ROLES[0], _ROLES[1], _ROLES[0], _ROLES[2]),
+      *[(role,) for role in _ROLES],
+      (),
+  )
+  def test_card_matches_inspector_after_role_grouping(self, *roles):
+    instances = [
+        prefab_lib.InstanceConfig(
+            prefab=f"prefab_{index}",
+            role=role,
+            params={"name": f"Instance {index}", "goal": f"Goal {index}"},
+        )
+        for index, role in enumerate(roles)
+    ]
+    config = prefab_lib.Config(prefabs={}, instances=instances)
+    checkpoint = {"entities": {}, "game_masters": {}}
+    for instance in instances:
+      group = (
+          "entities"
+          if instance.role == prefab_lib.Role.ENTITY
+          else "game_masters"
+      )
+      checkpoint[group][instance.params["name"]] = {
+          "component_info": {
+              "context_components": {
+                  "Marker": {
+                      "class_name": "Constant",
+                      "state": {
+                          "state": instance.params["goal"],
+                      },
+                  },
+              }
+          },
+      }
+
+    svg, data = visual_interface.visualize_config(config, checkpoint)
+
+    root = ET.fromstring(svg)
+    cards = root.findall("svg:g[@class='entity-card']", _NS)
+    self.assertLen(cards, len(instances))
+    ids = [card.attrib["data-entity-id"] for card in cards]
+    self.assertCountEqual(ids, data)
+    expected_order = [
+        instance
+        for role in _ROLES
+        for instance in instances
+        if instance.role == role
+    ]
+    # The visual role grouping and order within each group must not change.
+    self.assertEqual(
+        [card.attrib["data-entity-name"] for card in cards],
+        [instance.params["name"] for instance in expected_order],
+    )
+    for card, instance in zip(cards, expected_order):
+      inspector = data[card.attrib["data-entity-id"]]
+      self.assertEqual(inspector["name"], card.attrib["data-entity-name"])
+      self.assertEqual(inspector["name"], instance.params["name"])
+      self.assertEqual(inspector["prefab"], instance.prefab)
+      self.assertEqual(inspector["role"], instance.role.value)
+      self.assertEqual(
+          inspector["component_info"]["context_components"]["Marker"]["state"][
+              "state"
+          ],
+          instance.params["goal"],
+      )
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
> **Consolidated into [#314](https://github.com/google-deepmind/concordia/pull/314).** Closed only as a superseded review thread, following [Joel Z. Leibo’s category guidance](https://github.com/google-deepmind/concordia/issues/373#issuecomment-5621250114). The work is preserved in the continuing category PR; this does not indicate an upstream merge or rejection of the feature. Continuing issue: #313; continuing PR: #314. 

---

Closes #307

## User problem

Mixed-role configurations can show the wrong inspector when a card is clicked. A subsequent Save then targets the wrong entity. The existing philosophy-student example exposes the mismatch between its initializer and game master.

## Change

Preserve each instance's original configuration index while grouping SVG cards by role. The inspector data already uses those indices, so card, inspector and existing Save payload agree without changing the state API. Remove the display-order counter; keep grouping, within-role order and geometry unchanged.

Only `concordia/utils/visual_interface.py` and its focused regression test change. No new infrastructure, browser dependency, engine/server change, workflow change or unrelated feature.

## Validation

- Before fix: **7 failing / 5 passing** renderer regression cases. After fix: **12 passing**, covering all six role permutations, two interleaved multi-instance orders, each single role and empty configuration.
- Actual Chromium against the standard `SimulationServer`, standard constructed entities and the existing philosophy configuration: **24 card clicks and 24 dynamic Saves across six configurations**. Every card matched visible inspector name/role/prefab; a before/after state comparison proved only the selected actual entity changed.
- Exact SVG comparison against current upstream, ignoring only card IDs: geometry/content unchanged across all six browser configurations.
- Zero simulation steps and model calls: guarded `Simulation.play`, `Sequential.run_loop` and model methods were not called. The browser check builds entities and exercises only existing inspect/edit APIs.
- Focused `pylint --errors-only`, `pyrefly check` with the project interpreter, import formatting and whitespace checks passed.

Focused regression command:
```sh
python -m pytest -n 0 concordia/utils/visual_interface_test.py -q
```

Manual browser recipe: render the existing philosophy configuration with checkpoint data, bind it using `SimulationServer.set_simulation`, then click each player, game-master and initializer card. Expand a dynamic Constant field, save a distinct value, and confirm only that entity's component state changes. Repeat with role groups reordered and player order reversed. No simulation loop is required.

## Review / ancestry

Targets `main`; no dependency on the unrelated human-play PRs. Implemented and browser-tested on current upstream `9e4173f`. The contributor fork's publication branch contains only the fix atop shared ancestor `44904ec`; the renderer and prefab typing are unchanged across that upstream gap. Crucially, `git merge-tree --write-tree` verified the predicted merge into current `main` is **exactly the tested current-main tree**, and the public three-dot diff exactly matches the reviewed two-file diff. No older server was launched, and no security/workflow changes are introduced.

Known separately scoped baseline issue: the existing server suite previously observed an intermittent rejected-edit connection reset (17 pass/1 fail). This renderer patch does not claim to fix it. Browser Save isolation checks for this change all passed.

## Repository check status

CLA passed. The repository-wide `zizmor-output` gate reports pre-existing PyPI workflow findings outside this two-file renderer diff. This PR does not alter workflows or security settings; the local feature checks above should not be confused with an all-green remote CI result.
