### PR TITLE
Consume rejected editor request bodies before responding

### DIFF
--- a/concordia/utils/simulation_server.py
+++ b/concordia/utils/simulation_server.py
@@ -341,23 +341,26 @@ class SimulationServer:
 
       def _handle_set_component_state(self) -> None:
         """Handle POST /cmd/set_component_state for dynamic editing."""
-        if not server.step_controller.is_paused:
-          self._send_json({
-              'status': 'error',
-              'message': 'Simulation must be paused to edit state.',
-          })
-          return
-
-        if server.simulation is None:
-          self._send_json({
-              'status': 'error',
-              'message': 'No simulation instance available.',
-          })
-          return
-
         try:
           content_length = int(self.headers.get('Content-Length', 0))
           body = self.rfile.read(content_length)
+          # Consume the framed request before replying, even when editing is
+          # unavailable. Closing with unread body bytes can reset the socket
+          # before the client has received the JSON error response.
+          if not server.step_controller.is_paused:
+            self._send_json({
+                'status': 'error',
+                'message': 'Simulation must be paused to edit state.',
+            })
+            return
+
+          if server.simulation is None:
+            self._send_json({
+                'status': 'error',
+                'message': 'No simulation instance available.',
+            })
+            return
+
           data = json.loads(body.decode('utf-8'))
 
           entity_name = data['entity_name']

--- a/concordia/utils/simulation_server_test.py
+++ b/concordia/utils/simulation_server_test.py
@@ -177,6 +177,8 @@ class HttpEndpointsTest(absltest.TestCase):
     self.assertEqual(cm.exception.code, 404)
 
   def test_set_component_state_requires_paused(self):
+    fake_sim = _FakeSimulation()
+    self.server.set_simulation(fake_sim)
     self.server.step_controller.play()
     status, payload = _request(
         self.base_url + '/cmd/set_component_state',
@@ -191,6 +193,45 @@ class HttpEndpointsTest(absltest.TestCase):
     self.assertEqual(status, 200)
     self.assertEqual(payload['status'], 'error')
     self.assertIn('paused', payload['message'])
+    self.assertEmpty(fake_sim.set_calls)
+    self.assertIsNone(self.server.cached_entity_info)
+
+  def test_rejected_malformed_body_preserves_state_error_and_recovers(self):
+    fake_sim = _FakeSimulation()
+    # Read both rejection responses fully, including when the body is too
+    # malformed to decode. State guards still take precedence over parsing.
+    for message in ('No simulation', 'paused'):
+      with self.subTest(message=message):
+        if message == 'paused':
+          self.server.set_simulation(fake_sim)
+          self.server.step_controller.play()
+        req = urllib.request.Request(
+            self.base_url + '/cmd/set_component_state',
+            data=b'not JSON: ' + bytes([255]) * 65536,
+            headers={'Content-Type': 'application/json'},
+        )
+        with urllib.request.urlopen(req, timeout=5) as response:
+          self.assertEqual(response.status, 200)
+          payload = json.loads(response.read().decode('utf-8'))
+        self.assertEqual(payload['status'], 'error')
+        self.assertIn(message, payload['message'])
+        self.assertEmpty(fake_sim.set_calls)
+        self.assertIsNone(self.server.cached_entity_info)
+
+    self.server.step_controller.pause()
+    status, payload = _request(
+        self.base_url + '/cmd/set_component_state',
+        method='POST',
+        data={
+            'entity_name': 'alice',
+            'component_name': 'memory',
+            'key': 'foo',
+            'value': 'bar',
+        },
+    )
+    self.assertEqual(status, 200)
+    self.assertEqual(payload['status'], 'ok')
+    self.assertEqual(fake_sim.set_calls, [('alice', 'memory', 'foo', 'bar')])
 
   def test_set_component_state_requires_simulation(self):
     self.assertTrue(self.server.step_controller.is_paused)


### PR DESCRIPTION
> **Consolidated into [#314](https://github.com/google-deepmind/concordia/pull/314).** Closed only as a superseded review thread, following [Joel Z. Leibo’s category guidance](https://github.com/google-deepmind/concordia/issues/373#issuecomment-5621250114). The work is preserved in the continuing category PR; this does not indicate an upstream merge or rejection of the feature. Continuing issue: #313; continuing PR: #314. 

---

## Summary

Closes #327.

Consume the existing framed POST body before the dynamic editor's paused/bound-simulation guards reply. Unread request bytes can cause TCP reset at close, losing the intended JSON error. Keep original HTTP200/application-status semantics and guard precedence over JSON decoding. Rejected requests still cannot mutate or broadcast state.

This is an independent two-file bug fix based on current upstream main9e4173f, not a Bellwether feature stack. No engine/model execution or service/configuration changes.

## Verification

- Untouched upstream:17tests passed,1existing paused-rejection test failed with ConnectionResetError during response.read on macOS/Python3.12.
- Patched full standard server module:19tests plus2subtests passed twice (6.11s and6.10s).
- New regression reads complete errors for both guards with a malformed65KiBbody, verifies no changes/broadcast, then succeeds after pause.
- Changed-lines pyink, test-file pyink, and git diff --check pass.
- Pylint reports two existing line-too-long warnings (server223,test15), verified byte-identical to upstream; no new findings.

Run: `python -m pytest -o addopts='' concordia/utils/simulation_server_test.py -q`

## Limits

This repairs valid Content-Length request completion; it does not redesign framing, streaming limits, legacy status codes, or runtime quiescence. Existing authenticated player/API listeners are not changed. No claim of exhaustive network-stack coverage.
