### PR TITLE
Own checkpoint data before restoring mutable component state

### DIFF
--- a/concordia/prefabs/simulation/checkpoint_test.py
+++ b/concordia/prefabs/simulation/checkpoint_test.py
@@ -14,14 +14,17 @@
 
 """Tests for simulation checkpoint save and restore."""
 
+import copy
 import json
 import os
 import tempfile
 from typing import cast
+from unittest import mock
 
 from absl.testing import absltest
 from absl.testing import parameterized
 from concordia.agents import entity_agent_with_logging
+from concordia.components.agent import memory as memory_lib
 from concordia.language_model import no_language_model
 from concordia.prefabs.entity import minimal as minimal_entity
 from concordia.prefabs.game_master import generic as generic_gm
@@ -224,6 +227,99 @@ class CheckpointTest(parameterized.TestCase):
         )
       self.assertIn('test_channel', captured)
       self.assertEqual(captured['test_channel']['Value'], 'hello')
+
+
+class CheckpointOwnershipTest(parameterized.TestCase):
+  """Restore tests on real components; no simulation/engine execution."""
+
+  def setUp(self):
+    super().setUp()
+    for owner, method in (
+        (simulation_lib.Simulation, 'play'),
+        (no_language_model.NoLanguageModel, 'sample_text'),
+        (no_language_model.NoLanguageModel, 'sample_choice'),
+    ):
+      guard = mock.patch.object(
+          owner, method, side_effect=AssertionError('No run or model call')
+      )
+      guard.start()
+      self.addCleanup(guard.stop)
+
+  def make_simulation(self, *, empty=False):
+    config = _make_config()
+    if empty:
+      config.instances = []
+    return simulation_lib.Simulation(
+        config=config,
+        model=no_language_model.NoLanguageModel(),
+        embedder=lambda _: np.ones(3),
+    )
+
+  def memory(self, sim):
+    actor = cast(
+        entity_agent_with_logging.EntityAgentWithLogging, sim.entities[0]
+    )
+    return actor.get_component('__memory__', type_=memory_lib.AssociativeMemory)
+
+  @parameterized.named_parameters(
+      ('existing_entities', False), ('new_entities', True)
+  )
+  def test_two_restores_isolate_pending_memory_and_input(self, empty):
+    original = self.make_simulation()
+    self.memory(original).add('Pending when checkpointed')
+    checkpoint = original.make_checkpoint_data()
+    before = copy.deepcopy(checkpoint)
+    left = self.make_simulation(empty=empty)
+    right = self.make_simulation(empty=empty)
+    left.load_from_checkpoint(checkpoint)
+    right.load_from_checkpoint(checkpoint)
+
+    self.memory(left).add('Left branch only')
+    self.memory(right).update()
+    self.assertEqual(
+        list(self.memory(right).get_all_memories_as_text()),
+        ['Pending when checkpointed'],
+    )
+    self.memory(left).update()
+    self.assertCountEqual(
+        self.memory(left).get_all_memories_as_text(),
+        ['Pending when checkpointed', 'Left branch only'],
+    )
+    self.assertEqual(checkpoint, before)
+    self.assertEqual(
+        self.memory(original).get_state()['buffer'],
+        ['Pending when checkpointed'],
+    )
+
+  def test_nested_raw_logs_are_owned_by_each_restore(self):
+    original = self.make_simulation()
+    checkpoint = original.make_checkpoint_data()
+    checkpoint['raw_log'] = [{'step': 1, 'events': [{'text': 'captured'}]}]
+    left = self.make_simulation()
+    right = self.make_simulation()
+    left.load_from_checkpoint(checkpoint)
+    right.load_from_checkpoint(checkpoint)
+    checkpoint['raw_log'][0]['events'][0]['text'] = 'caller changed input'
+    self.assertEqual(left.get_raw_log()[0]['events'][0]['text'], 'captured')
+    # Mimic a writer updating a nested engine log record without running an
+    # engine: the public accessor deliberately returns a defensive copy.
+    left._raw_log[0]['events'][0]['text'] = 'left only'  # pylint: disable=protected-access
+    self.assertEqual(right.get_raw_log()[0]['events'][0]['text'], 'captured')
+    self.assertEqual(
+        checkpoint['raw_log'][0]['events'][0]['text'], 'caller changed input'
+    )
+
+  def test_parameter_fallback_does_not_change_supplied_snapshot(self):
+    source = self.make_simulation()
+    checkpoint = source.make_checkpoint_data()
+    del checkpoint['entities']['Alice']['entity_params']['custom_instructions']
+    before = copy.deepcopy(checkpoint)
+    restored = self.make_simulation()
+    restored.load_from_checkpoint(checkpoint)
+    self.assertEqual(checkpoint, before)
+    self.assertCountEqual(
+        [entity.name for entity in restored.entities], ['Alice', 'Bob']
+    )
 
 
 if __name__ == '__main__':

--- a/concordia/prefabs/simulation/generic.py
+++ b/concordia/prefabs/simulation/generic.py
@@ -547,7 +547,14 @@ class Simulation(simulation_lib.Simulation):
       self,
       checkpoint: dict[str, Any],
   ):
-    """Loads entity and game master states from a checkpoint dict."""
+    """Loads entity and game master states from an owned checkpoint copy.
+
+    Component setters may retain nested mutable state, and parameter fallback
+    may modify dictionaries. Keep both isolated from the caller and other
+    restores of the same checkpoint. This does not restore engine cursors or
+    make arbitrary components, shared external services or models deterministic.
+    """
+    checkpoint = copy.deepcopy(checkpoint)
 
     # Load entities
     entity_states = checkpoint.get("entities", {})


### PR DESCRIPTION
## Summary

Closes #331.

`Simulation.load_from_checkpoint` now takes an owned deep copy before component setters or prefab-parameter fallback can retain/mutate nested data. One production-code statement reuses the existing copy import; the added API documentation explicitly limits the guarantee.

Independent current-main9e4173f two-file fix, not a Bellwether feature/dependency stack. No merges requested. The hosted human games and their disabled checkpoint/branch operations are unchanged.

## Reproduced failures and verification

Four new tests failed before this fix (six existing checkpoint checks passed):

- pending A-only memory was committed by B after both restored the same checkpoint; both existing-entity and new-entity construction paths reproduced it;
- caller mutation changed restored nested raw logs;
- parameter fallback changed the caller's input snapshot.

All ten checkpoint tests now pass. Real minimal actors and standard GM, public memory add/update/retrieve APIs; nested-log writer uses a documented white-box update because public log reads are defensive copies. New tests hard-fail any Simulation.play or model sampling, so no continuation/model runs are claimed. Existing measurement roundtrips still pass.

`python -m pytest -o addopts='' concordia/prefabs/simulation/checkpoint_test.py -q`

Changed-region/test formatting, import sorting and diff checks pass; pyrefly zero errors(seven existing suppressions). Pylint reports seven existing findings on byte-identical upstream lines, no new findings; left unrelated cleanup out.

## Explicit limits

Ownership of canonical checkpoint data is not atomic restoration or full continuation: engine cursors/RNG, arbitrary component compatibility, shared external services and hosted-model determinism remain separate contracts. No general claim of independent scientific counterfactuals. The same registry/measurement fallback behavior remains available. No new serializer or engine.

Audited broader issue#275 and contest-reproduction PR265; this is the distinct mutable-input defect, with no file overlap with265.
