### PR TITLE
Explain human roles and preview Bellwether attempts without effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ __pycache__/
 
 # Test cache
 .pytest_cache
+
+# Generated adventure logs and browser artifacts.
+/runs/

--- a/concordia/command_line_interface/concordia_session.py
+++ b/concordia/command_line_interface/concordia_session.py
@@ -1,0 +1,79 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attach noninteractively to the same operation API used by the editor.
+
+No engine or domain behavior lives here. JSON output is always machine-readable.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+
+def main(argv=None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--url', required=True, help='Trusted local service URL')
+  parser.add_argument('command', choices=('discover', 'state', 'call', 'watch'))
+  parser.add_argument(
+      '--input', default='-', help='JSON request file or - for stdin'
+  )
+  parser.add_argument('--timeout', type=float, default=15)
+  args = parser.parse_args(argv)
+  endpoint = {
+      'discover': 'operations',
+      'state': 'state',
+      'call': 'dispatch',
+      'watch': 'events',
+  }[args.command]
+  try:
+    data = None
+    if args.command == 'call':
+      raw = (
+          sys.stdin.read()
+          if args.input == '-'
+          else pathlib.Path(args.input).read_text(encoding='utf-8')
+      )
+      data = json.dumps(json.loads(raw), ensure_ascii=False).encode()
+    request = urllib.request.Request(
+        args.url.rstrip('/') + '/api/' + endpoint,
+        data=data,
+        headers={'Content-Type': 'application/json'},
+    )
+    with urllib.request.urlopen(request, timeout=args.timeout) as response:
+      if args.command == 'watch':
+        for line in response:
+          if line.startswith(b'data: '):
+            print(line[6:].decode().strip(), flush=True)
+      else:
+        print(response.read().decode())
+    return 0
+  except urllib.error.HTTPError as error:
+    print(error.read().decode(), file=sys.stderr)
+    return 2
+  except (OSError, ValueError) as error:
+    print(
+        json.dumps(
+            {'error': {'code': 'transport_or_input', 'message': str(error)}}
+        ),
+        file=sys.stderr,
+    )
+    return 3
+
+
+if __name__ == '__main__':
+  raise SystemExit(main())

--- a/concordia/components/agent/__init__.py
+++ b/concordia/components/agent/__init__.py
@@ -19,6 +19,7 @@ from concordia.components.agent import all_similar_memories
 from concordia.components.agent import concat
 from concordia.components.agent import concat_act_component
 from concordia.components.agent import constant
+from concordia.components.agent import human_act_component
 from concordia.components.agent import instructions
 from concordia.components.agent import memory
 from concordia.components.agent import observation

--- a/concordia/components/agent/concat.py
+++ b/concordia/components/agent/concat.py
@@ -20,6 +20,38 @@ from concordia.components.agent import action_spec_ignored
 from concordia.typing import entity_component
 
 
+def validate_component_order(
+    component_order: Sequence[str] | None,
+) -> tuple[str, ...] | None:
+  """Snapshot an acting component's order, rejecting duplicate keys."""
+  order = tuple(component_order) if component_order is not None else None
+  if order is not None and len(set(order)) != len(order):
+    raise ValueError(
+        'The component order contains duplicate components: ' + ', '.join(order)
+    )
+  return order
+
+
+def concat_contexts(
+    contexts: entity_component.ComponentContextMapping,
+    component_order: Sequence[str] | None = None,
+) -> str:
+  """Assemble pre-act contexts using ConcatAct's ordering and whitespace rules.
+
+  None uses mapping iteration order. An explicit order (including an empty
+  sequence) appends unspecified keys in sorted order. Empty values are omitted;
+  labels, whitespace and line breaks inside other values are kept verbatim.
+  Explicit keys absent from contexts raise KeyError. Constructors validate and
+  snapshot the order with validate_component_order.
+  """
+  if component_order is None:
+    return '\n'.join(context for context in contexts.values() if context)
+  order = tuple(component_order) + tuple(
+      sorted(set(contexts.keys()) - set(component_order))
+  )
+  return '\n'.join(contexts[name] for name in order if contexts[name])
+
+
 class Concatenate(
     action_spec_ignored.ActionSpecIgnored, entity_component.ComponentWithLogging
 ):

--- a/concordia/components/agent/concat_act_component.py
+++ b/concordia/components/agent/concat_act_component.py
@@ -15,8 +15,10 @@
 """A simple acting component that aggregates contexts from components."""
 
 from collections.abc import Sequence
+from typing import cast
 from typing import override
 
+from concordia.components.agent import concat
 from concordia.document import interactive_document
 from concordia.language_model import language_model
 from concordia.typing import entity as entity_lib
@@ -52,9 +54,8 @@ class ConcatActComponent(
         assembled in the iteration order of the `ComponentContextMapping` passed
         to `get_action_attempt`. If the component order is specified, but does
         not contain all the components passed to `get_action_attempt`, the
-        missing components will be appended at the end in the iteration order of
-        the `ComponentContextMapping` passed to `get_action_attempt`. The same
-        component cannot appear twice in the component order. All components in
+        missing components will be appended at the end in sorted key order.
+        The same component cannot appear twice in the component order. All components in
         the component order must be in the `ComponentContextMapping` passed to
         `get_action_attempt`.
       prefix_entity_name: Whether to prefix the entity name to the output of
@@ -70,28 +71,13 @@ class ConcatActComponent(
     self._model = model
     self._prefix_entity_name = prefix_entity_name
     self._randomize_choices = randomize_choices
-    if component_order is None:
-      self._component_order = None
-    else:
-      self._component_order = tuple(component_order)
-    if self._component_order is not None:
-      if len(set(self._component_order)) != len(self._component_order):
-        raise ValueError(
-            'The component order contains duplicate components: '
-            + ', '.join(self._component_order)
-        )
+    self._component_order = concat.validate_component_order(component_order)
 
   def _context_for_action(
       self,
       contexts: entity_component.ComponentContextMapping,
   ) -> str:
-    if self._component_order is None:
-      return '\n'.join(context for context in contexts.values() if context)
-    else:
-      order = self._component_order + tuple(
-          sorted(set(contexts.keys()) - set(self._component_order))
-      )
-      return '\n'.join(contexts[name] for name in order if contexts[name])
+    return concat.concat_contexts(contexts, self._component_order)
 
   @override
   def get_action_attempt(
@@ -179,8 +165,8 @@ class ConcatActComponent(
 
   def set_state(self, state: entity_component.ComponentState) -> None:
     if 'component_order' in state:
-      order = state['component_order']
-      self._component_order = tuple(order) if order else None  # pyrefly: ignore[bad-argument-type]
+      order = cast(Sequence[str] | None, state['component_order'])
+      self._component_order = tuple(order) if order else None
     if 'prefix_entity_name' in state:
       self._prefix_entity_name = state['prefix_entity_name']  # pyrefly: ignore[bad-assignment]
     if 'randomize_choices' in state:

--- a/concordia/components/agent/context_order_test.py
+++ b/concordia/components/agent/context_order_test.py
@@ -1,0 +1,136 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Human and LLM acting share Concat's exact established context semantics."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.agents import entity_agent_with_logging
+from concordia.components.agent import concat_act_component
+from concordia.components.agent import human_act_component
+from concordia.language_model import no_language_model
+from concordia.typing import entity as entity_lib
+
+
+class ContextOrderTest(parameterized.TestCase):
+
+  def policies(self, order):
+    reader = mock.Mock(return_value='LOOK')
+    model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+    model.sample_text.return_value = 'LOOK'
+    human = human_act_component.HumanActComponent(reader, component_order=order)
+    llm = concat_act_component.ConcatActComponent(model, component_order=order)
+    for policy in (human, llm):
+      entity_agent_with_logging.EntityAgentWithLogging('Ilyra', policy)
+    return human, llm, reader, model
+
+  @parameterized.named_parameters(
+      ('mapping_order', None, {'z': 'Z', 'a': 'A'}, 'Z\nA'),
+      ('empty_order_sorts', [], {'z': 'Z', 'a': 'A'}, 'A\nZ'),
+      (
+          'partial_order_sorts_remainder',
+          ['b'],
+          {'z': 'Z', 'b': 'B', 'a': 'A'},
+          'B\nA\nZ',
+      ),
+      ('explicit_order', ['b', 'a'], {'a': 'A', 'b': 'B'}, 'B\nA'),
+      (
+          'preserve_labels_and_whitespace',
+          ['z', 'empty'],
+          {'empty': '', 'z': '\nLabel:\n Z\n', 'a': ' A '},
+          '\nLabel:\n Z\n\n A ',
+      ),
+      ('empty_context', None, {}, ''),
+  )
+  def test_exact_context_matches_concat_prompt(self, order, contexts, expected):
+    human, llm, reader, model = self.policies(order)
+    spec = entity_lib.free_action_spec(call_to_action='Your move, {name}?')
+    human.get_action_attempt(contexts, spec)
+    llm.get_action_attempt(contexts, spec)
+    request = reader.call_args.args[0]
+    self.assertEqual(request.context, expected)
+    self.assertEqual(llm._context_for_action(contexts), expected)
+    self.assertEqual(
+        human.get_context_concat_order(), llm.get_context_concat_order()
+    )
+    prompt = model.sample_text.call_args.kwargs['prompt']
+    self.assertTrue(prompt.startswith(expected + '\n'), repr(prompt))
+    self.assertEqual(
+        human.get_entity().get_last_log()['__act__']['Context'], expected
+    )
+
+  @parameterized.parameters(
+      human_act_component.HumanActComponent,
+      concat_act_component.ConcatActComponent,
+  )
+  def test_duplicate_order_is_rejected(self, policy):
+    with self.assertRaisesRegex(ValueError, 'duplicate components: x, x'):
+      policy(mock.Mock(), component_order=['x', 'x'])
+
+  def test_explicit_missing_key_raises_without_asking_human_or_llm(self):
+    human, llm, reader, model = self.policies(['missing'])
+    for policy in (human, llm):
+      with self.assertRaises(KeyError):
+        policy.get_action_attempt(
+            {'present': 'value'}, entity_lib.DEFAULT_ACTION_SPEC
+        )
+    reader.assert_not_called()
+    model.sample_text.assert_not_called()
+
+  def test_order_and_request_context_are_snapshots_and_retries_keep_string(
+      self,
+  ):
+    order = ['b', 'a']
+    human, llm, reader, _ = self.policies(order)
+    order.reverse()
+    self.assertEqual(human.get_context_concat_order(), ('b', 'a'))
+    self.assertEqual(llm.get_context_concat_order(), ('b', 'a'))
+    contexts = {'a': 'A', 'b': 'B'}
+    requests = []
+
+    def read(request):
+      requests.append(request)
+      contexts['b'] = 'changed'
+      return '' if len(requests) == 1 else 'LOOK'
+
+    reader.side_effect = read
+    human.get_action_attempt(contexts, entity_lib.DEFAULT_ACTION_SPEC)
+    self.assertEqual([r.context for r in requests], ['B\nA', 'B\nA'])
+    self.assertEqual(requests[1].contexts['b'], 'B')
+
+  @parameterized.parameters((None,), ([],), (['b', 'a'],))
+  def test_order_state_format_and_partial_restore_match_concat(self, order):
+    human, llm, _, _ = self.policies(order)
+    self.assertEqual(
+        human.get_state()['component_order'], llm.get_state()['component_order']
+    )
+    # Retain Concat's legacy empty-sequence serialization/restore semantics.
+    for state in (
+        human.get_state(),
+        {},
+        {'component_order': []},
+        {'component_order': ['a']},
+    ):
+      human.set_state(state)
+      llm.set_state(state)
+      self.assertEqual(
+          human.get_context_concat_order(), llm.get_context_concat_order()
+      )
+    self.assertNotIn('input_reader', human.get_state())
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/components/agent/human_act_component.py
+++ b/concordia/components/agent/human_act_component.py
@@ -1,0 +1,215 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An acting component that asks a human instead of a language model."""
+
+from collections.abc import Sequence
+import dataclasses
+import json
+import math
+import types
+from typing import cast
+from typing import override
+import uuid
+
+from concordia.components.agent import concat
+from concordia.typing import entity as entity_lib
+from concordia.typing import entity_component
+from concordia.typing import human_input
+
+
+def validate_response(
+    response: str, action_spec: entity_lib.ActionSpec
+) -> None:
+  """Validate human input, including the sequential engine's GM contracts.
+
+  This is also available to adapters for immediate feedback before submission.
+  HumanActComponent always validates again at the component boundary.
+
+  Unlike language model sampling, human input must not silently fall back to
+  an invented action, a different choice, or NaN. Choices are exact option
+  values (not indices); free text and numbers are returned without rewriting.
+
+  Raises:
+    ValueError: If the human can correct an invalid response.
+    NotImplementedError: If the output type is unsupported.
+  """
+  if not isinstance(response, str):
+    raise ValueError('The response must be text.')
+  output_type = action_spec.output_type
+  if output_type == entity_lib.OutputType.SKIP_THIS_STEP:
+    if response:
+      raise ValueError('A skipped step must have an empty response.')
+    return
+  if output_type in entity_lib.CHOICE_ACTION_TYPES:
+    # Reuse ActionSpec validation for GM choice types as well as player choices.
+    dataclasses.replace(
+        action_spec, output_type=entity_lib.OutputType.CHOICE
+    ).validate(response)
+    return
+  if output_type == entity_lib.OutputType.FLOAT:
+    action_spec.validate(response)
+    if not math.isfinite(float(response)):
+      raise ValueError('Enter a finite number (not NaN or infinity).')
+    return
+  if output_type not in entity_lib.FREE_ACTION_TYPES:
+    raise NotImplementedError(f'Unsupported output type: {output_type}')
+  if not response.strip():
+    raise ValueError('Enter a non-empty response.')
+  if output_type != entity_lib.OutputType.NEXT_ACTION_SPEC:
+    dataclasses.replace(
+        action_spec, output_type=entity_lib.OutputType.FREE
+    ).validate(response)
+    return
+
+  # ActionSpec's constructor checks option cardinality but not JSON field
+  # types. Validate these before passing the object to the standard converter.
+  try:
+    value = json.loads(response)
+  except json.JSONDecodeError as exc:
+    raise ValueError('Enter a valid JSON action specification.') from exc
+  if not isinstance(value, dict):
+    raise ValueError('The action specification must be a JSON object.')
+  if not isinstance(value.get('call_to_action'), str):
+    raise ValueError('The action specification needs a text call_to_action.')
+  if not isinstance(value.get('output_type'), str):
+    raise ValueError('The action specification needs a text output_type.')
+  options = value.get('options', [])
+  if not isinstance(options, list) or not all(
+      isinstance(option, str) for option in options
+  ):
+    raise ValueError('options must be a JSON array of strings.')
+  if value.get('tag') is not None and not isinstance(value['tag'], str):
+    raise ValueError('tag must be text or null.')
+  try:
+    next_spec = entity_lib.action_spec_from_dict(value)
+  except (TypeError, ValueError) as exc:
+    raise ValueError(f'Invalid action specification: {exc}') from exc
+  if next_spec.output_type not in (
+      *entity_lib.PLAYER_ACTION_TYPES,
+      entity_lib.OutputType.SKIP_THIS_STEP,
+  ):
+    raise ValueError('The next action specification must be for a player.')
+  if (
+      next_spec.output_type != entity_lib.OutputType.SKIP_THIS_STEP
+      and not next_spec.call_to_action.strip()
+  ):
+    raise ValueError('Enter a non-empty call_to_action for the player.')
+
+
+class HumanActComponent(
+    entity_component.ActingComponent, entity_component.ComponentWithLogging
+):
+  """Ask the controller of this entity for every non-skipped action.
+
+  Install this in a normal EntityAgent or EntityAgentWithLogging, for either a
+  player or a GM. Other entities and all context-component lifecycle hooks are
+  unchanged. LLM-backed context components still run; use observation, memory,
+  constant, and other non-LLM components for a fully human-controlled player.
+
+  A human GM answers engine requests explicitly, including NEXT_ACTING,
+  NEXT_ACTION_SPEC, TERMINATE, and NEXT_GAME_MASTER. Context components may
+  supply advice but never silently substitute their answer for the human's.
+
+  The reader is a runtime dependency and is not serialized. Restore the
+  component with the same reader wiring. No pending request survives a process
+  restart; transport adapters must not replay old responses into a new run.
+  """
+
+  def __init__(
+      self,
+      input_reader: human_input.HumanInput,
+      component_order: Sequence[str] | None = None,
+  ):
+    """Initialize a human policy with the same context ordering as ConcatAct.
+
+    Args:
+      input_reader: Blocking transport receiving the full ordered context.
+      component_order: None uses context mapping order. An explicit sequence
+        appends unspecified keys sorted; absent keys raise KeyError at act time.
+        Duplicate keys raise ValueError here. Empty context values are omitted.
+    """
+    super().__init__()
+    self._input_reader = input_reader
+    self._component_order = concat.validate_component_order(component_order)
+
+  @override
+  def get_action_attempt(
+      self,
+      contexts: entity_component.ComponentContextMapping,
+      action_spec: entity_lib.ActionSpec,
+  ) -> str:
+    if action_spec.output_type == entity_lib.OutputType.SKIP_THIS_STEP:
+      return ''
+    if action_spec.output_type not in (
+        *entity_lib.FREE_ACTION_TYPES,
+        *entity_lib.CHOICE_ACTION_TYPES,
+        entity_lib.OutputType.FLOAT,
+    ):
+      raise NotImplementedError(
+          f'Unsupported output type: {action_spec.output_type}'
+      )
+    name = self.get_entity().name
+    request = human_input.HumanInputRequest(
+        request_id=uuid.uuid4().hex,
+        entity_name=name,
+        action_spec=dataclasses.replace(
+            action_spec,
+            call_to_action=action_spec.call_to_action.replace('{name}', name),
+        ),
+        contexts=types.MappingProxyType(dict(contexts)),
+        context=concat.concat_contexts(contexts, self._component_order),
+    )
+    while True:
+      response = self._input_reader(request)
+      try:
+        validate_response(response, action_spec)
+      except ValueError as exc:
+        request = dataclasses.replace(
+            request,
+            error=str(exc),
+            previous_response=response if isinstance(response, str) else None,
+        )
+        continue
+      self._logging_channel({
+          'Summary': f'Action: {response}',
+          'Value': response,
+          'Prompt': (
+              (
+                  request.context + '\n' + request.action_spec.call_to_action
+              ).splitlines()
+          ),
+          'Context': request.context,
+          'Source': 'human',
+      })
+      return response
+
+  def get_context_concat_order(self) -> Sequence[str] | None:
+    """Return the configured order, or None for mapping iteration order."""
+    return self._component_order
+
+  @override
+  def get_state(self) -> entity_component.ComponentState:
+    # Match ConcatAct's state format; the input reader remains runtime-only.
+    return {
+        'component_order': (
+            list(self._component_order) if self._component_order else None
+        ),
+    }
+
+  @override
+  def set_state(self, state: entity_component.ComponentState) -> None:
+    if 'component_order' in state:
+      order = cast(Sequence[str] | None, state['component_order'])
+      self._component_order = tuple(order) if order else None

--- a/concordia/components/agent/human_act_component_test.py
+++ b/concordia/components/agent/human_act_component_test.py
@@ -1,0 +1,305 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Human input validation, entity lifecycle, and sequential GM contract tests."""
+
+import json
+from typing import cast
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.agents import entity_agent_with_logging
+from concordia.components.agent import concat_act_component
+from concordia.components.agent import constant
+from concordia.components.agent import human_act_component
+from concordia.environment import engine
+from concordia.environment.engines import sequential
+from concordia.language_model import no_language_model
+from concordia.typing import entity as entity_lib
+from concordia.typing import entity_component
+
+OutputType = entity_lib.OutputType
+
+
+def _make_human(reader, name='Wayfarer', context_components=None):
+  return entity_agent_with_logging.EntityAgentWithLogging(
+      agent_name=name,
+      act_component=human_act_component.HumanActComponent(reader),
+      context_components=context_components or {},
+  )
+
+
+class HumanActComponentTest(parameterized.TestCase):
+
+  def test_retries_without_reentering_context_lifecycle(self):
+    requests = []
+    answers = iter(['', 'open the silver door'])
+    context = constant.Constant('A silver door bars your path.')
+    original_pre_act = context.pre_act
+    with mock.patch.object(
+        context, 'pre_act', wraps=original_pre_act
+    ) as pre_act:
+
+      def read(request):
+        requests.append(request)
+        return next(answers)
+
+      human = _make_human(read, context_components={'Scene': context})
+      result = human.act(
+          entity_lib.free_action_spec(
+              call_to_action='What does {name} do? Literal JSON: {"door": 1}'
+          )
+      )
+    self.assertEqual(result, 'open the silver door')
+    self.assertEqual(pre_act.call_count, 1)
+    self.assertEqual(human.get_phase(), entity_component.Phase.READY)
+    self.assertEqual(requests[0].request_id, requests[1].request_id)
+    self.assertIsNone(requests[0].error)
+    self.assertIn('non-empty', requests[1].error)
+    self.assertEqual(requests[1].previous_response, '')
+    self.assertEqual(requests[0].entity_name, 'Wayfarer')
+    self.assertEqual(
+        requests[0].action_spec.call_to_action,
+        'What does Wayfarer do? Literal JSON: {"door": 1}',
+    )
+    self.assertIn('silver door', requests[0].contexts['Scene'])
+    with self.assertRaises(TypeError):
+      requests[0].contexts['Scene'] = 'Changed'
+    self.assertEqual(human.get_last_log()['__act__']['Value'], result)
+    self.assertEqual(human.get_last_log()['__act__']['Source'], 'human')
+
+  @parameterized.parameters(*entity_lib.CHOICE_ACTION_TYPES)
+  def test_player_and_gm_choices_are_exact_and_retry(self, output_type):
+    reader = mock.Mock(side_effect=['0', 'north', ' North ', 'North'])
+    human = _make_human(reader)
+    self.assertEqual(
+        human.act(
+            entity_lib.ActionSpec(
+                call_to_action='Choose',
+                output_type=output_type,
+                options=('North', 'South'),
+            )
+        ),
+        'North',
+    )
+    self.assertEqual(reader.call_count, 4)
+    self.assertIn('not one of', reader.call_args.args[0].error)
+
+  def test_options_with_whitespace_are_not_rewritten(self):
+    human = _make_human(lambda request: ' North ')
+    self.assertEqual(
+        human.act(
+            entity_lib.choice_action_spec(
+                call_to_action='Choose', options=(' North ', 'South')
+            )
+        ),
+        ' North ',
+    )
+
+  @parameterized.parameters('nan', 'NaN', 'inf', '-Infinity', '1e9999', 'three')
+  def test_float_rejects_non_finite_and_invalid_input(self, bad):
+    reader = mock.Mock(side_effect=[bad, '-1.25e2'])
+    self.assertEqual(
+        _make_human(reader).act(
+            entity_lib.float_action_spec(call_to_action='Enter a number')
+        ),
+        '-1.25e2',
+    )
+    self.assertIsNotNone(reader.call_args.args[0].error)
+
+  @parameterized.parameters(
+      OutputType.FREE, OutputType.MAKE_OBSERVATION, OutputType.RESOLVE
+  )
+  def test_free_types_reject_blank_and_preserve_human_wording(
+      self, output_type
+  ):
+    reader = mock.Mock(side_effect=[' \n ', '  A door opens.\n'])
+    result = _make_human(reader).act(
+        entity_lib.ActionSpec(
+            call_to_action='Describe', output_type=output_type
+        )
+    )
+    self.assertEqual(result, '  A door opens.\n')
+
+  @parameterized.parameters(None, 123, (['answer'],))
+  def test_non_text_input_gets_feedback(self, bad):
+    reader = mock.Mock(side_effect=[bad, 'look'])
+    self.assertEqual(_make_human(reader).act(), 'look')
+    self.assertIsNone(reader.call_args.args[0].previous_response)
+    self.assertIn('text', reader.call_args.args[0].error)
+
+  def test_skip_does_not_ask_for_input(self):
+    reader = mock.Mock()
+    human = _make_human(reader)
+    self.assertEqual(human.act(entity_lib.skip_this_step_action_spec()), '')
+    reader.assert_not_called()
+    self.assertEqual(human.get_phase(), entity_component.Phase.READY)
+
+  def test_unsupported_type_fails_before_input(self):
+    reader = mock.Mock()
+    human = _make_human(reader)
+    with self.assertRaises(NotImplementedError):
+      human.act(
+          entity_lib.ActionSpec(
+              call_to_action='Unsupported',
+              output_type=cast(entity_lib.OutputType, 'future'),
+          )
+      )
+    reader.assert_not_called()
+
+  @parameterized.parameters(EOFError, TimeoutError, KeyboardInterrupt)
+  def test_reader_failure_is_not_an_action(self, failure):
+    reader = mock.Mock(side_effect=failure)
+    with self.assertRaises(failure):
+      _make_human(reader).act()
+    reader.assert_called_once()
+
+  def test_requests_are_distinct_and_entity_routed(self):
+    requests = []
+
+    def read(request):
+      requests.append(request)
+      return 'look'
+
+    one = _make_human(read, 'One')
+    two = _make_human(read, 'Two')
+    one.act()
+    two.act()
+    one.act()
+    self.assertEqual([r.entity_name for r in requests], ['One', 'Two', 'One'])
+    self.assertLen({r.request_id for r in requests}, 3)
+
+  def test_entity_state_restores_without_serializing_transport(self):
+    reader = mock.Mock(return_value='look')
+    human = _make_human(reader)
+    state = human.get_state()
+    json.dumps(state)
+    restored = _make_human(reader)
+    restored.set_state(state)
+    self.assertEqual(restored.act(), 'look')
+
+  def test_other_entities_keep_normal_act_components(self):
+    reader = mock.Mock(return_value='South')
+    human = _make_human(reader)
+    npc = entity_agent_with_logging.EntityAgentWithLogging(
+        agent_name='Companion',
+        act_component=concat_act_component.ConcatActComponent(
+            model=no_language_model.NoLanguageModel(),
+            randomize_choices=False,
+        ),
+    )
+    spec = entity_lib.choice_action_spec(
+        call_to_action='Where next?', options=('North', 'South')
+    )
+    self.assertEqual(human.act(spec), 'South')
+    self.assertEqual(npc.act(spec), 'North')
+    reader.assert_called_once()
+
+
+class HumanGameMasterTest(parameterized.TestCase):
+
+  @parameterized.parameters(
+      'not JSON',
+      'null',
+      '[]',
+      '{}',
+      '{"call_to_action": 1, "output_type": "free"}',
+      '{"call_to_action": "Act", "output_type": 1}',
+      '{"call_to_action": "Act", "output_type": "unknown"}',
+      '{"call_to_action": "Act", "output_type": "choice", "options": []}',
+      '{"call_to_action": "Act", "output_type": "choice", "options": ["A",'
+      ' "A"]}',
+      '{"call_to_action": "Act", "output_type": "choice", "options": "AB"}',
+      '{"call_to_action": "Act", "output_type": "choice", "options": [1]}',
+      '{"call_to_action": "Act", "output_type": "free", "options": ["A"]}',
+      '{"call_to_action": "Act", "output_type": "free", "tag": 1}',
+      '{"call_to_action": "Act", "output_type": "resolve"}',
+      '{"call_to_action": "Act", "output_type": "free", "unexpected": true}',
+      '{"call_to_action": "  ", "output_type": "free"}',
+  )
+  def test_next_action_spec_rejects_invalid_payloads(self, response):
+    with self.assertRaises(ValueError):
+      human_act_component.validate_response(
+          response,
+          entity_lib.ActionSpec(
+              call_to_action='Supply the player action spec as JSON.',
+              output_type=OutputType.NEXT_ACTION_SPEC,
+          ),
+      )
+
+  @parameterized.parameters(
+      entity_lib.free_action_spec(call_to_action='What does {name} do?'),
+      entity_lib.choice_action_spec(
+          call_to_action='Which door?', options=('silver, blue', 'gold')
+      ),
+      entity_lib.float_action_spec(call_to_action='How much?'),
+      entity_lib.skip_this_step_action_spec(),
+  )
+  def test_sequential_engine_accepts_human_next_action_spec(self, player_spec):
+    reader = mock.Mock(
+        side_effect=[
+            'Wayfarer',
+            '{}',
+            engine.action_spec_to_string(player_spec),
+        ]
+    )
+    gm = _make_human(reader, 'GM')
+    player = _make_human(mock.Mock())
+    selected, actual_spec = sequential.Sequential().next_acting(gm, [player])
+    self.assertIs(selected, player)
+    self.assertEqual(actual_spec, player_spec)
+    self.assertIsNotNone(reader.call_args.args[0].error)
+    self.assertEqual(gm.get_phase(), entity_component.Phase.READY)
+
+  def test_sequential_observation_resolution_termination_and_gm_selection(self):
+    reader = mock.Mock(
+        side_effect=[
+            'You stand beneath two moons.',
+            'The silver door opens.',
+            'no',
+            'No',
+            'Yes',
+            'Second GM',
+        ]
+    )
+    gm = _make_human(reader, 'GM')
+    player = _make_human(mock.Mock())
+    second_gm = _make_human(mock.Mock(), 'Second GM')
+    env = sequential.Sequential()
+    self.assertEqual(
+        env.make_observation(gm, player), 'You stand beneath two moons.'
+    )
+    env.resolve(gm, 'Wayfarer opens the silver door.')
+    self.assertFalse(env.terminate(gm))
+    self.assertTrue(env.terminate(gm))
+    self.assertIs(env.next_game_master(gm, [gm, second_gm]), second_gm)
+    self.assertEqual(
+        [
+            call.args[0].action_spec.output_type
+            for call in reader.call_args_list
+        ],
+        [
+            OutputType.MAKE_OBSERVATION,
+            OutputType.RESOLVE,
+            OutputType.TERMINATE,
+            OutputType.TERMINATE,
+            OutputType.TERMINATE,
+            OutputType.NEXT_GAME_MASTER,
+        ],
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/contrib/language_models/ollama/ollama_model.py
+++ b/concordia/contrib/language_models/ollama/ollama_model.py
@@ -23,7 +23,6 @@ from concordia.utils import measurements as measurements_lib
 from concordia.utils import sampling
 import ollama
 
-
 _MAX_MULTIPLE_CHOICE_ATTEMPTS = 20
 _DEFAULT_TEMPERATURE = 0.5
 _DEFAULT_TERMINATORS = ()
@@ -49,6 +48,8 @@ class OllamaLanguageModel(language_model.LanguageModel):
       system_message: str = _DEFAULT_SYSTEM_MESSAGE,
       measurements: measurements_lib.Measurements | None = None,
       channel: str = language_model.DEFAULT_STATS_CHANNEL,
+      request_timeout: float | None = None,
+      max_output_tokens: int | None = None,
   ) -> None:
     """Initializes the instance.
 
@@ -59,9 +60,14 @@ class OllamaLanguageModel(language_model.LanguageModel):
           model.
         measurements: The measurements object to log usage statistics to.
         channel: The channel to write the statistics to.
+        request_timeout: Optional HTTP timeout in seconds for local requests.
+        max_output_tokens: Upper bound, including callers with larger limits.
     """
     self._model_name = model_name
-    self._client = ollama.Client()
+    self._client = ollama.Client(timeout=request_timeout)
+    if max_output_tokens is not None and max_output_tokens <= 0:
+      raise ValueError('max_output_tokens must be positive')
+    self._max_output_tokens = max_output_tokens
     self._system_message = system_message
     self._terminators = []
 
@@ -81,7 +87,7 @@ class OllamaLanguageModel(language_model.LanguageModel):
       timeout: float = -1,
       seed: int | None = None,
   ) -> str:
-    del max_tokens, timeout, seed  # Unused.
+    del timeout, seed  # HTTP timeout is configured on the shared client.
 
     prompt_with_system_message = f'{self._system_message}\n\n{prompt}'
 
@@ -92,6 +98,11 @@ class OllamaLanguageModel(language_model.LanguageModel):
         prompt=prompt_with_system_message,
         options={
             'stop': terminators,
+            'num_predict': (
+                min(max_tokens, self._max_output_tokens)
+                if self._max_output_tokens is not None
+                else max_tokens
+            ),
             'temperature': temperature,
             'top_p': top_p,
             'top_k': top_k,
@@ -132,7 +143,15 @@ class OllamaLanguageModel(language_model.LanguageModel):
               f'{prompt_with_system_message}.\n'
               f'Use the following json template: {json.dumps(template)}.'
           ),
-          options={'stop': (), 'temperature': temperature},
+          options={
+              'stop': (),
+              'temperature': temperature,
+              **(
+                  {'num_predict': self._max_output_tokens}
+                  if self._max_output_tokens is not None
+                  else {}
+              ),
+          },
           format='json',
           keep_alive='10m',
       )

--- a/concordia/contrib/language_models/ollama/ollama_model_test.py
+++ b/concordia/contrib/language_models/ollama/ollama_model_test.py
@@ -1,0 +1,61 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bounded local generation request checks; no model calls."""
+
+from unittest import mock
+
+from concordia.contrib.language_models.ollama import ollama_model
+import pytest
+
+
+@pytest.mark.parametrize(
+    'bound,requested,expected',
+    [(None, 25, 25), (256, 2200, 256), (256, 12, 12)],
+)
+def test_generation_honors_requested_and_configured_limits(
+    bound, requested, expected
+):
+  with mock.patch.object(ollama_model.ollama, 'Client') as client:
+    client.return_value.generate.return_value = {'response': 'local response'}
+    model = ollama_model.OllamaLanguageModel(
+        'local-model', request_timeout=90, max_output_tokens=bound
+    )
+    assert model.sample_text('prompt', max_tokens=requested) == 'local response'
+    client.assert_called_once_with(timeout=90)
+    assert (
+        client.return_value.generate.call_args.kwargs['options']['num_predict']
+        == expected
+    )
+
+
+def test_nonpositive_limit_rejected():
+  with mock.patch.object(ollama_model.ollama, 'Client'):
+    with pytest.raises(ValueError, match='positive'):
+      ollama_model.OllamaLanguageModel('local-model', max_output_tokens=0)
+
+
+@pytest.mark.parametrize('bound', [None, 256])
+def test_choice_generation_obeys_optional_limit(bound):
+  with mock.patch.object(ollama_model.ollama, 'Client') as client:
+    client.return_value.generate.return_value = {'response': '{"choice": "a"}'}
+    model = ollama_model.OllamaLanguageModel(
+        'local-model', max_output_tokens=bound
+    )
+    assert model.sample_choice('prompt', ['a', 'b'])[:2] == (0, 'a')
+    options = client.return_value.generate.call_args.kwargs['options']
+    if bound is None:
+      assert 'num_predict' not in options
+    else:
+      assert options['num_predict'] == bound

--- a/concordia/examples/__init__.py
+++ b/concordia/examples/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runnable examples of core Concordia components."""

--- a/concordia/examples/astral_canticle/README.md
+++ b/concordia/examples/astral_canticle/README.md
@@ -1,0 +1,217 @@
+# The Astral Canticle — a human in the loop
+
+A mobile-friendly, Zork-like science-fantasy adventure. You control **Ilyra Venn**;
+**Sable-9** and **Thorn of Io** retain their own language-model acting policies.
+The GM uses the normal `SwitchAct` component. No player action is invented by an
+LLM, and there are no lobbies, accounts, multiplayer sessions or paid services.
+
+The Auric Vesper / sleeping moon / star-loom setting is a small demonstration
+of human input rather than a research experiment. The opening scene has inspectable objects,
+connected locations and command suggestions. Narrative and consequences are
+model-generated, not a hard-coded puzzle or a deterministic inventory simulator.
+
+## Run locally
+
+From the repository root, with Python 3.12+ and a running local Ollama:
+
+```sh
+python -m venv .venv
+.venv/bin/python -m pip install -e '.[ollama]'
+.venv/bin/python -m pip install -r concordia/examples/astral_canticle/requirements.txt
+ollama pull llama3.2:3b
+.venv/bin/python -m concordia.examples.astral_canticle.web \
+  --model llama3.2:3b --port 8767 --max-steps 30 --output runs/human
+```
+
+Open <http://127.0.0.1:8767/>. The command starts exactly **one** adventure. Page
+loads/reloads never launch or reset a simulation. A turn waits indefinitely for
+you; model responses can take a while. Other entities act once each between your
+turns. The chapter ends after `--max-steps` entity actions (not human rounds).
+
+Try **EXAMINE the resonance cradle**, **TAKE the tuning fork**, **INVENTORY**,
+**WEST**, **TALK TO Sable-9**, or describe an idea in ordinary words. Suggestions
+fill the command box; **Act** submits. Enter submits; Shift+Enter inserts a line.
+**Guide**, **Aa** and **Journal** provide help, larger text, and a transcript export.
+
+A dropped phone connection does not cancel a prompt. Reload reconnects to the
+same process, and drafts are retained in that browser's local storage. Responses
+carry unique request IDs: stale actions are rejected and retries of an accepted
+POST do not act twice. Drafts are not automatically sent after reconnecting.
+
+Completed steps are written as standard `SimulationLog` artifacts in the output
+directory: `simulation.json` and a self-contained `log.html`. These contain all
+entities' detailed logs and are **host-side only**. The player download contains
+only that player's observations/actions. A host restart starts a **new chapter**;
+old prompt IDs cannot be replayed. This example does not resume an interrupted
+simulation process from a checkpoint.
+
+## Select the human basic prefab
+
+Add `--player-prefab basic` to either the web or terminal command:
+
+```sh
+.venv/bin/python -m concordia.examples.astral_canticle.web \
+  --player-prefab basic --model llama3.2:3b --port 8769 \
+  --max-steps 30 --output runs/human-basic
+```
+
+Ilyra is built directly by the library's `concordia.prefabs.entity.basic.Entity`.
+Only `ConcatActComponent` is replaced with `HumanActComponent`; the prefab's
+instructions, observation-to-memory, observation history, goal,
+`SituationPerception`, `SelfPerception`, `PersonBySituation`, memory settings and
+logging all remain unchanged. **The three perception components still call the
+LLM before each human prompt.** The complete assembled context is visible under
+**Your context** on the phone, including all three perception answers. It is one
+verbatim string in the basic prefab's own Concat order, with original labels and
+line breaks. It also appears in the standard host-side logs. The Journal download
+remains your observations and submitted actions. The final action is always your
+input, not the model's suggested behavior.
+Sable-9, Thorn and the GM keep their existing composition and policies.
+
+The default remains `--player-prefab minimal`, the previous lightweight
+configuration with no LLM-based player context processing. In `--role gm`, this
+option still selects Ilyra's prefab, but Ilyra uses its normal LLM acting policy
+and the human controls the GM. Python callers can use
+`build_cast(..., player_prefab='basic')` or `play(..., player_prefab='basic')`.
+
+The library injection is reusable independently of this example or transport:
+
+```python
+from concordia.components.agent.human_act_component import HumanActComponent
+from concordia.prefabs.entity import basic
+
+player = basic.Entity(params={'name': 'Ilyra Venn', 'goal': 'Repair the loom.'}).build(
+    model=model,
+    memory_bank=memory_bank,
+    act_component_factory=lambda order: HumanActComponent(read, component_order=order),
+)
+```
+
+The factory receives the exact order calculated inside the prefab (including
+the goal placement); no ordering list is duplicated in the example. Both basic
+and minimal also accept a prebuilt `act_component`, but the two options are
+mutually exclusive. Omitting both leaves the library's default `ConcatActComponent`
+(including its ordering and choice/name-prefix options) unchanged. No parallel
+copy or subclass of the basic prefab is maintained.
+
+## Phone access on an existing tailnet
+
+The web server binds **only to 127.0.0.1**. Use Tailscale Serve, not Funnel. Inspect
+current configuration first and add only the new path; never reset other routes.
+For a host named `your-host.your-tailnet.ts.net`:
+
+```sh
+tailscale serve status --json
+# Include these flags on the web command above:
+# --allowed-host your-host.your-tailnet.ts.net --root-path /astral-canticle-play
+tailscale serve --bg --set-path /astral-canticle-play http://127.0.0.1:8767/astral-canticle-play
+```
+
+Open `https://your-host.your-tailnet.ts.net/astral-canticle-play/` on your phone.
+The trailing slash matters for relative asset URLs. The proxy target preserves the mount
+prefix; the adapter also accepts prefix-stripping proxies. Same-origin JSON
+POSTs, host validation and a restrictive CSP protect the browser boundary. This
+is a **single trusted tailnet controller**, not an authorization system: anyone
+with access to this route shares control. Do not expose it publicly. Existing
+`/astral-canticle`, `/astral-canticle-data`, and `/game-design-forum` are separate
+log/forum routes and need not be changed.
+
+## Human game master and terminal input
+
+Launch with `--role gm` to control the GM instead. All three player entities then
+use their default LLM policies. You provide observations, pick actors, create
+valid next-action specs, resolve attempts and decide termination. GM decisions
+are never silently filled in by model-based context components. Choice buttons
+use exact option values; the action-spec builder creates validated JSON. Both
+roles see only the controlled entity's complete pre-act context; unrelated NPC or
+GM component outputs are never added to it. This is a developer-oriented secondary UX;
+the default player mode is the polished single-human experience.
+
+The same adventure also works without **any web dependencies**:
+
+```sh
+.venv/bin/python -m concordia.examples.astral_canticle.terminal --role player
+# Use --role gm for terminal GM control.
+```
+
+A minimal transport implementation is simply a callable:
+
+```python
+from concordia.components.agent.human_act_component import HumanActComponent
+
+def read(request):
+  print(request.context)  # Already ordered and labeled; do not reassemble the map.
+  if request.error:
+    print(request.error)
+  return input(request.action_spec.call_to_action + '> ')
+
+act_component = HumanActComponent(read)
+# Install in EntityAgentWithLogging, or pass to minimal.Entity.build(
+#     model=model, memory_bank=memory_bank, act_component=act_component).
+```
+
+`concordia.typing.human_input.HumanInputRequest` contains the entity name, unique
+request ID, immutable context map, preassembled `context` string, action spec and
+retry feedback. Core has no knowledge of HTTP, browsers, threads or Tailscale. Independent readers can be
+wired to additional human entities in a future application; this example keeps
+one inbox per controller and deliberately implements no multiplayer routing.
+
+Only `{name}` in a call-to-action is interpolated, without corrupting literal
+JSON braces. Free prose must be nonempty, numbers finite, choices exact, and a
+GM's `NEXT_ACTION_SPEC` must decode to a valid player `ActionSpec`. Skip actions
+return without requesting input. Cancellation/EOF is raised, never converted to
+an invented action. Context lifecycle and standard logging remain unchanged.
+LLM-based context components can still use a model when someone composes a
+human entity with them; the default minimal selection uses only non-LLM human
+context components, while basic preserves its LLM-backed perceptions.
+
+### Context ordering contract
+
+`HumanActComponent(reader, component_order=None)` uses the context mapping's
+iteration order. An explicit sequence uses that order first, then appends
+unspecified keys **alphabetically**, exactly as the existing Concat implementation
+does. Empty strings are skipped; all other labels, spaces and line breaks remain
+intact. Explicitly named absent keys raise `KeyError` when acting; duplicate keys
+raise `ValueError` at construction. `get_context_concat_order()` returns the
+snapshotted order, and state saves/restores it with Concat's existing conventions
+(including its empty-order-to-None state normalization). The reader is not saved.
+
+Both policies call the same standard `concat.concat_contexts` helper; transports
+render `request.context` verbatim rather than adding dictionary headings. The
+player and GM UI both show it expanded in the scrolling page (not a cramped
+composer panel), and terminal input prints the very same string. Context only
+comes from the entity attached to this HumanActComponent. Showing the human's
+own perception outputs does not expose another entity's private components.
+
+## Composition and verification
+
+The example reuses `minimal.Entity` / `basic.Entity`, `EntityAgentWithLogging`, observation/memory
+components, `SwitchAct`, `NextActingInFixedOrder`, `FixedActionSpec`,
+`Sequential`, `SimulationLog` and its standard `to_html()` renderer. A constant small
+embedding is sufficient because this composition retrieves chronological
+observations, not semantic neighbors. The GM sees the recent event history and
+setting; we do not duplicate an engine, event resolver, clock or logging system.
+Unlike the heavier time-and-place prefab, the lean GM tracks the Canticle Clock
+in narrative context rather than generating separate clock/location LLM calls.
+
+```sh
+.venv/bin/python -m pip install pytest pytest-xdist pyink isort
+.venv/bin/python -m pip install -r concordia/examples/astral_canticle/requirements-test.txt
+.venv/bin/python -m playwright install chromium
+.venv/bin/python -m pytest -n 0 \
+  concordia/components/agent/human_act_component_test.py \
+  concordia/components/agent/context_order_test.py \
+  concordia/environment/engines/sequential_test.py \
+  concordia/prefabs/entity/basic_test.py \
+  concordia/prefabs/entity/prefabs_test.py \
+  concordia/examples/astral_canticle
+```
+
+Unit and browser tests use mock models or transport requests, never a live model.
+They cover exact Concat/Human context/order parity, full basic perception outputs
+visible verbatim in player/GM mobile views, basic/default component parity and
+perception lifecycle, CLI selection, player/GM contracts, normal NPC policies, a complete standard-engine
+round, stale/duplicate actions, cross-origin rejection, reconnects, draft recovery,
+mobile layout, safe text rendering, and GM action-spec controls. Web tests skip
+when their optional dependencies are absent. The web dependencies are not added
+to core installation requirements.

--- a/concordia/examples/astral_canticle/__init__.py
+++ b/concordia/examples/astral_canticle/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A human-controlled science-fantasy text adventure."""

--- a/concordia/examples/astral_canticle/adventure.py
+++ b/concordia/examples/astral_canticle/adventure.py
@@ -1,0 +1,249 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Astral Canticle: standard prefab entities, sequential engine and logs.
+
+This demonstrates human input in the Auric Vesper setting. The lean
+composition uses SwitchAct directly with standard memory/context components so
+local models spend their time telling the story, not selecting a turn order.
+"""
+
+import pathlib
+from typing import Any
+
+from concordia.associative_memory import basic_associative_memory
+from concordia.components.agent import constant
+from concordia.components.agent import human_act_component
+from concordia.components.game_master import next_acting
+from concordia.components.game_master import switch_act
+from concordia.environment.engines import sequential
+from concordia.prefabs.entity import basic
+from concordia.prefabs.entity import minimal
+from concordia.typing import entity as entity_lib
+from concordia.utils import structured_logging
+import numpy as np
+
+PLAYER = 'Ilyra Venn'
+GM = 'Auric Vesper'
+PREMISE = """The heliostat-city Auric Vesper orbits a sleeping moon. Its ancient
+star-loom has begun tearing the veil into the mythic Luminous Deep. You are Ilyra
+Venn, an astromancer-engineer. Sable-9, a reliquary automaton, protects the Umbral
+pilgrims; Thorn of Io, a mycelial knight, tends the city's living machinery.
+
+You stand in the Star-Loom Chamber. A brass tuning fork hangs beside a cracked
+resonance cradle. Three pale threads run into the loom; the silver thread has
+slipped loose. Your satchel holds a prism-lantern and an insulated star-spanner.
+A warning bell tolls once. Sable-9 waits by the pilgrim lift. Thorn watches the
+roots pressing through the deck. There is time to investigate before committing
+to a repair. Your first aim: discover what is pulling the loom out of tune."""
+LOCATIONS = """The Star-Loom Chamber connects west to the Reliquary Nave, east
+to the Mycelial Gardens, and down to the Pilgrim Deck. The Nave and Gardens each
+open onto the outer Heliostat Walk. Return paths remain open unless an observed
+event changes them. The Canticle Clock begins at Cycle 1, Verse 1, Pulse 0,
+Tide Ember. Each Verse has 13 Pulses, each Cycle 8 Verses; Verses 1–2 are Ember,
+3–4 Glass, 5–6 Bloom, 7–8 Umbral. Time only moves forward."""
+RULES = """Run a coherent, intimate science-fantasy text adventure. Keep the
+established map, objects, inventory and consequences consistent. Accept natural
+language and classic commands: LOOK, EXAMINE object, TAKE object, INVENTORY,
+WEST/EAST/UP/DOWN, TALK TO name, USE object ON target, WAIT. Interpret commands
+as attempts, not guaranteed success. LOOK and INVENTORY reveal known facts;
+never punish inspection. Give specific feedback when an action is impossible.
+Reveal clues before danger. There are several ways to stabilize the star-loom;
+never require an exact magic phrase. NPCs act with their own goals. Do not choose
+Ilyra's actions, thoughts or dialogue. Do not resolve the whole adventure in one
+turn. State only observable consequences, no analysis, option menus or meta text.
+Use brief vivid paragraphs, concrete objects and clear exits. Keep each response
+under 120 words. Preserve character names. Track carried items and clock in the
+fiction; do not invent a successful repair until the actions justify one."""
+
+
+def build_cast(model, reader, *, role='player', player_prefab='minimal'):
+  """Build the cast, selecting Ilyra's standard prefab and only replacing act.
+
+  With ``basic``, Ilyra retains the library prefab's exact context configuration
+  and LLM perception behavior. NPC and GM composition does not change.
+  """
+  if player_prefab not in ('minimal', 'basic'):
+    raise ValueError(f'Unknown player prefab: {player_prefab}')
+
+  def build(
+      name,
+      instructions,
+      goal='',
+      act_component=None,
+      extra=None,
+      prefab='minimal',
+      human_controlled=False,
+  ):
+    memory_bank = basic_associative_memory.AssociativeMemoryBank(
+        sentence_embedder=lambda _: np.ones(8)
+    )
+    factory = (
+        (
+            lambda order: human_act_component.HumanActComponent(
+                reader, component_order=order
+            )
+        )
+        if human_controlled
+        else None
+    )
+    if prefab == 'basic':
+      return basic.Entity(params={'name': name, 'goal': goal}).build(
+          model=model,
+          memory_bank=memory_bank,
+          act_component=act_component,
+          act_component_factory=factory,
+      )
+    params: dict[str, Any] = {
+        'name': name,
+        'custom_instructions': instructions,
+        'goal': goal,
+        'randomize_choices': False,
+        'extra_components': extra or {},
+    }
+    return minimal.Entity(params=params).build(
+        model=model,
+        memory_bank=memory_bank,
+        act_component=act_component,
+        act_component_factory=factory,
+    )
+
+  players = [
+      build(
+          PLAYER,
+          'You are Ilyra Venn. ' + RULES,
+          'Repair the star-loom without sacrificing the sleeping moon.',
+          prefab=player_prefab,
+          human_controlled=role == 'player',
+      ),
+      build(
+          'Sable-9',
+          'You are Sable-9, a precise but compassionate automaton. '
+          'Act briefly in the first person. Do not control anyone else.',
+          'Protect the pilgrims and help Ilyra investigate the resonance.',
+      ),
+      build(
+          'Thorn of Io',
+          'You are Thorn of Io, a patient mycelial knight. '
+          'Act briefly in the first person. Do not control anyone else.',
+          'Keep Auric Vesper alive and the Umbral pilgrims free.',
+      ),
+  ]
+  names = [player.name for player in players]
+  extra = {}
+  if role == 'player':
+    extra = {
+        switch_act.DEFAULT_NEXT_ACTING_COMPONENT_KEY: (
+            next_acting.NextActingInFixedOrder(sequence=names)
+        ),
+        switch_act.DEFAULT_NEXT_ACTION_SPEC_COMPONENT_KEY: (
+            next_acting.FixedActionSpec(
+                entity_lib.free_action_spec(
+                    call_to_action='What do you do next, {name}?'
+                )
+            )
+        ),
+        switch_act.DEFAULT_TERMINATE_COMPONENT_KEY: constant.Constant(
+            'No', pre_act_label=''
+        ),
+    }
+  gm = build(
+      GM,
+      RULES + '\n' + LOCATIONS,
+      act_component=(
+          None
+          if role == 'gm'
+          else switch_act.SwitchAct(model=model, entity_names=names)
+      ),
+      extra=extra,
+      human_controlled=role == 'gm',
+  )
+  for player in players:
+    player.observe(PREMISE + '\n' + LOCATIONS)
+  return players, gm
+
+
+def play(
+    model,
+    session,
+    output: pathlib.Path,
+    *,
+    role='player',
+    max_steps=30,
+    player_prefab='minimal',
+):
+  """Run one adventure; persist standard structured logs after every step."""
+  output.mkdir(parents=True, exist_ok=True)
+  players, gm = build_cast(
+      model, session, role=role, player_prefab=player_prefab
+  )
+  engine = sequential.Sequential(
+      call_to_make_observation=(
+          'Describe only what {name} now perceives and the consequences they '
+          'can see. Include their current location, known exits and carried '
+          'items when useful. No hidden thoughts or plans of others. At most '
+          '120 words; clear short paragraphs, no analysis.'
+      ),
+      call_to_resolve=(
+          'Resolve the latest attempted action only. What visibly changes? '
+          'Respect the map, inventory and previous events. Be concrete and '
+          'brief: at most 120 words. Do not act for another character.'
+      ),
+  )
+  raw_log = []
+
+  def save():
+    log = structured_logging.SimulationLog.from_raw_log(raw_log)
+    log.attach_memories(
+        entity_memories={
+            p.name: p.get_component('__memory__').get_all_memories_as_text()
+            for p in players
+        },
+        game_master_memories=gm.get_component(
+            '__memory__'
+        ).get_all_memories_as_text(),
+    )
+    for name, value in (
+        ('simulation.json', log.to_json()),
+        (
+            'log.html',
+            log.to_html(title='The Astral Canticle'),
+        ),
+    ):
+      temporary = output / (name + '.tmp')
+      temporary.write_text(value, encoding='utf-8')
+      temporary.replace(output / name)
+
+  def step_done(step):
+    save()
+    session.progress(step.step, step.acting_entity)
+
+  try:
+    engine.run_loop(
+        game_masters=[gm],
+        entities=players,
+        premise=PREMISE,
+        max_steps=max_steps,
+        log=raw_log,
+        step_callback=step_done,
+    )
+    if role == 'player':
+      # The last resolved action deserves a player-visible conclusion even
+      # when there will be no next action prompt. Ask the standard GM API.
+      observation = engine.make_observation(gm, players[0])
+      players[0].observe(observation)
+      session.add_observation(observation)
+  finally:
+    save()
+  session.finish('This chapter is complete. Your journal is ready to download.')

--- a/concordia/examples/astral_canticle/adventure_test.py
+++ b/concordia/examples/astral_canticle/adventure_test.py
@@ -1,0 +1,163 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Human/default policy isolation and end-to-end standard-engine unit checks."""
+
+import json
+from unittest import mock
+
+from concordia.components.agent import concat_act_component
+from concordia.components.agent import human_act_component
+from concordia.examples.astral_canticle import adventure
+from concordia.language_model import no_language_model
+from concordia.typing import entity as entity_lib
+import pytest
+
+
+def test_human_prefab_has_no_model_calls_and_npcs_keep_llm_policy():
+  model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+  reader = mock.Mock(return_value='Examine the tuning fork')
+  players, gm = adventure.build_cast(model, reader)
+  assert isinstance(
+      players[0].get_act_component(), human_act_component.HumanActComponent
+  )
+  assert all(
+      isinstance(p.get_act_component(), concat_act_component.ConcatActComponent)
+      for p in players[1:]
+  )
+  result = players[0].act(
+      entity_lib.free_action_spec(call_to_action='Your move, {name}')
+  )
+  assert result == 'Examine the tuning fork'
+  assert (
+      'resonance cradle' in reader.call_args.args[0].contexts['__observation__']
+  )
+  model.sample_text.assert_not_called()
+  model.sample_choice.assert_not_called()
+  players[1].act()
+  model.sample_text.assert_called_once()
+  assert gm.name == adventure.GM
+
+
+def test_human_gm_uses_same_component_without_llm_context_calls():
+  model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+  reader = mock.Mock(return_value='No')
+  players, gm = adventure.build_cast(model, reader, role='gm')
+  assert all(
+      isinstance(p.get_act_component(), concat_act_component.ConcatActComponent)
+      for p in players
+  )
+  assert (
+      gm.act(
+          entity_lib.ActionSpec(
+              call_to_action='Finished?',
+              output_type=entity_lib.OutputType.TERMINATE,
+              options=('Yes', 'No'),
+          )
+      )
+      == 'No'
+  )
+  model.sample_text.assert_not_called()
+  model.sample_choice.assert_not_called()
+
+
+@pytest.mark.parametrize('player_prefab', ('minimal', 'basic'))
+def test_three_turns_use_standard_engine_and_produce_standard_log(
+    tmp_path, player_prefab
+):
+  model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+  model.sample_text.return_value = (
+      'The resonance cradle glows. The west exit remains open.'
+  )
+  session = mock.Mock(return_value='Examine the resonance cradle')
+  adventure.play(
+      model, session, tmp_path, max_steps=3, player_prefab=player_prefab
+  )
+  assert session.call_count == 1  # NPCs never reach the human adapter.
+  assert session.progress.call_count == 3
+  assert [c.args[1] for c in session.progress.call_args_list] == [
+      'Ilyra Venn',
+      'Sable-9',
+      'Thorn of Io',
+  ]
+  session.finish.assert_called_once()
+  log = json.loads((tmp_path / 'simulation.json').read_text())
+  assert log
+  assert '"Source": "human"' in (tmp_path / 'simulation.json').read_text()
+  assert (tmp_path / 'log.html').read_text().startswith('<!DOCTYPE html>')
+
+
+def test_basic_selection_changes_only_ilyra_and_preserves_context_calls():
+  model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+  model.sample_text.return_value = 'examining the cradle.'
+  reader = mock.Mock(return_value='LOOK')
+  players, gm = adventure.build_cast(model, reader, player_prefab='basic')
+  original_players, original_gm = adventure.build_cast(model, reader)
+  for selected, original in zip(
+      [*players[1:], gm], [*original_players[1:], original_gm]
+  ):
+    assert type(selected.get_act_component()) is type(
+        original.get_act_component()
+    )
+    components = selected.get_all_context_components()
+    originals = original.get_all_context_components()
+    assert list(components) == list(originals)
+    for key, component in components.items():
+      assert type(component) is type(originals[key])
+      assert component.get_state() == originals[key].get_state()
+  assert players[0].act() == 'LOOK'
+  assert model.sample_text.call_count == 3  # Perceptions, never an LLM action.
+  assert set(reader.call_args.args[0].contexts) == {
+      'Instructions',
+      'Observation',
+      'SelfPerception',
+      'SituationPerception',
+      'PersonBySituation',
+      '__observation__',
+      '__memory__',
+      'Goal',
+  }
+  assert (
+      players[0]
+      .get_component('SituationPerception')
+      .get_state()['num_memories_to_retrieve']
+      == 25
+  )
+  assert (
+      players[0].get_component('__observation__').get_state()['history_length']
+      == 1_000_000
+  )
+
+
+def test_basic_selection_keeps_automated_player_when_human_is_gm():
+  model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+  model.sample_text.return_value = 'examining the cradle.'
+  reader = mock.Mock(return_value='No')
+  players, gm = adventure.build_cast(
+      model, reader, role='gm', player_prefab='basic'
+  )
+  assert isinstance(
+      gm.get_act_component(), human_act_component.HumanActComponent
+  )
+  assert isinstance(
+      players[0].get_act_component(), concat_act_component.ConcatActComponent
+  )
+  players[0].act()
+  assert model.sample_text.call_count == 4
+  reader.assert_not_called()
+
+
+def test_unknown_player_prefab_is_rejected():
+  with pytest.raises(ValueError, match='Unknown player prefab'):
+    adventure.build_cast(None, None, player_prefab='typo')

--- a/concordia/examples/astral_canticle/cli_test.py
+++ b/concordia/examples/astral_canticle/cli_test.py
@@ -1,0 +1,74 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI prefab selection reaches the runner without starting a simulation."""
+
+from unittest import mock
+
+from concordia.examples.astral_canticle import adventure
+from concordia.examples.astral_canticle import terminal
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+import pytest
+
+
+@pytest.mark.parametrize(
+    'args, expected', [([], 'minimal'), (['--player-prefab', 'basic'], 'basic')]
+)
+@pytest.mark.parametrize('transport', ['terminal', 'web'])
+def test_cli_passes_prefab_to_runner(monkeypatch, args, expected, transport):
+  if transport == 'web':
+    pytest.importorskip('fastapi')
+    from concordia.examples.astral_canticle import web  # pylint: disable=g-import-not-at-top
+
+    module = web
+  else:
+    module = terminal
+  monkeypatch.setattr('sys.argv', [transport, *args])
+  with mock.patch.object(adventure, 'play') as play, mock.patch.object(
+      module.ollama_model, 'OllamaLanguageModel'
+  ):
+    if transport == 'web':
+      # Invoke only the captured runner with play mocked out; no server, model
+      # inference or simulation is launched by this check.
+      with mock.patch.object(module, 'create_app') as create, mock.patch(
+          'concordia.examples.astral_canticle.web.uvicorn.run'
+      ) as serve:
+        module.main()
+        create.call_args.kwargs['runner']()
+        assert serve.call_args.kwargs['host'] == '127.0.0.1'
+    else:
+      module.main()
+  play.assert_called_once()
+  assert play.call_args.kwargs['player_prefab'] == expected
+  assert play.call_args.kwargs['role'] == 'player'
+
+
+def test_terminal_prints_preassembled_string_without_dict_headings(
+    capsys, monkeypatch
+):
+  context = (
+      '\nGoal: Repair the loom.\n\nSelf: A keeper.\nSituation: A cracked'
+      ' cradle.\nIntent: Inspect.'
+  )
+  request = human_input.HumanInputRequest(
+      request_id='terminal',
+      entity_name='Ilyra',
+      action_spec=entity_lib.free_action_spec(call_to_action='Your move?'),
+      contexts={'not-a-display-heading': 'must not be reconstructed'},
+      context=context,
+  )
+  monkeypatch.setattr('builtins.input', lambda prompt: 'LOOK')
+  assert terminal.TerminalInput()(request) == 'LOOK'
+  assert capsys.readouterr().out == context + '\n\nIlyra: Your move?\n'

--- a/concordia/examples/astral_canticle/human_io.py
+++ b/concordia/examples/astral_canticle/human_io.py
@@ -1,0 +1,150 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-process, reconnectable transport adapter; no simulation logic lives here."""
+
+import threading
+
+from concordia.components.agent import human_act_component
+from concordia.typing import human_input
+
+
+class InputClosed(Exception):
+  """The controller has stopped waiting for input."""
+
+
+class StaleRequest(ValueError):
+  """A response targets an old or already answered prompt."""
+
+
+class HumanSession:
+  """One controller's inbox, not a global queue or a multiplayer session.
+
+  Closing a browser does not close this inbox. Requests survive reconnects while
+  the process runs. A new process always has new request IDs; no action is replayed.
+  """
+
+  def __init__(self, *, role: str = 'player'):
+    self.role = role
+    self._condition = threading.Condition()
+    self._pending: human_input.HumanInputRequest | None = None
+    self._response: str | None = None
+    self._accepted: tuple[str, str] | None = None
+    self._closed = False
+    self._status = 'The star-loom is waking…'
+    self._entries: list[dict[str, str]] = []
+    self._observations_seen = 0
+    self._revision = 0
+    self._step = 0
+
+  def __call__(self, request: human_input.HumanInputRequest) -> str:
+    with self._condition:
+      if self._closed:
+        raise InputClosed()
+      if self._pending is not None:
+        raise RuntimeError('This controller already has a pending request.')
+      self._pending = request
+      self._response = None
+      self._status = (
+          'Your move' if self.role == 'player' else 'The world awaits you'
+      )
+      self._revision += 1
+      # The standard observation component orders memories chronologically.
+      # Only this controlled entity's observations enter the player transcript.
+      observations = request.contexts.get('__observation__', '')
+      parts = observations.split('[observation] ')[1:]
+      for part in parts[self._observations_seen :]:
+        self._entries.append({'kind': 'story', 'text': part.strip()})
+      self._observations_seen = len(parts)
+      self._condition.notify_all()
+      self._condition.wait_for(
+          lambda: self._response is not None or self._closed
+      )
+      if self._closed:
+        self._pending = None
+        raise InputClosed()
+      response = self._response
+      assert response is not None  # Guaranteed by wait_for unless closed.
+      self._pending = None
+      self._response = None
+      return response
+
+  def submit(self, request_id: str, response: str) -> bool:
+    """Validate before wakeup; retries of the same accepted POST are idempotent."""
+    with self._condition:
+      if self._accepted == (request_id, response):
+        return False
+      if (
+          self._closed
+          or self._pending is None
+          or self._pending.request_id != request_id
+          or self._response is not None
+      ):
+        raise StaleRequest(
+            'That turn has already moved on. Your draft is kept.'
+        )
+      human_act_component.validate_response(response, self._pending.action_spec)
+      self._accepted = (request_id, response)
+      self._response = response
+      self._entries.append({'kind': 'action', 'text': response})
+      self._status = 'Your action is unfolding…'
+      self._revision += 1
+      self._condition.notify_all()
+      return True
+
+  def add_observation(self, observation: str) -> None:
+    """Publish a final observation addressed to this controller's entity."""
+    with self._condition:
+      if observation.strip():
+        self._entries.append({'kind': 'story', 'text': observation})
+        self._revision += 1
+
+  def progress(self, step: int, actor: str) -> None:
+    with self._condition:
+      self._step = step
+      self._status = f'{actor} has acted. The story continues…'
+      self._revision += 1
+
+  def finish(self, message: str) -> None:
+    with self._condition:
+      self._status = message
+      self._closed = True
+      self._pending = None
+      self._revision += 1
+      self._condition.notify_all()
+
+  def snapshot(self) -> dict:
+    """Return only the controller's view, never any other entity's private context."""
+    with self._condition:
+      pending = None
+      if self._pending is not None and self._response is None:
+        request = self._pending
+        pending = {
+            'id': request.request_id,
+            'entity': request.entity_name,
+            'prompt': request.action_spec.call_to_action,
+            'type': request.action_spec.output_type.value,
+            'options': list(request.action_spec.options),
+            'error': request.error,
+            'context': request.context,
+        }
+      return {
+          'revision': self._revision,
+          'role': self.role,
+          'status': self._status,
+          'step': self._step,
+          'finished': self._closed,
+          'pending': pending,
+          'entries': [dict(entry) for entry in self._entries],
+      }

--- a/concordia/examples/astral_canticle/human_io.py
+++ b/concordia/examples/astral_canticle/human_io.py
@@ -14,6 +14,7 @@
 
 """In-process, reconnectable transport adapter; no simulation logic lives here."""
 
+from collections.abc import Callable
 import threading
 
 from concordia.components.agent import human_act_component
@@ -35,14 +36,21 @@ class HumanSession:
   the process runs. A new process always has new request IDs; no action is replayed.
   """
 
-  def __init__(self, *, role: str = 'player'):
+  def __init__(
+      self,
+      *,
+      role: str = 'player',
+      on_request: Callable[[], None] | None = None,
+      initial_status: str = 'The star-loom is waking…',
+  ):
     self.role = role
+    self._on_request = on_request
     self._condition = threading.Condition()
     self._pending: human_input.HumanInputRequest | None = None
     self._response: str | None = None
     self._accepted: tuple[str, str] | None = None
     self._closed = False
-    self._status = 'The star-loom is waking…'
+    self._status = initial_status
     self._entries: list[dict[str, str]] = []
     self._observations_seen = 0
     self._revision = 0
@@ -68,6 +76,9 @@ class HumanSession:
         self._entries.append({'kind': 'story', 'text': part.strip()})
       self._observations_seen = len(parts)
       self._condition.notify_all()
+    if self._on_request is not None:
+      self._on_request()
+    with self._condition:
       self._condition.wait_for(
           lambda: self._response is not None or self._closed
       )

--- a/concordia/examples/astral_canticle/requirements-test.txt
+++ b/concordia/examples/astral_canticle/requirements-test.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+httpx>=0.27,<1
+playwright>=1.50,<2

--- a/concordia/examples/astral_canticle/requirements.txt
+++ b/concordia/examples/astral_canticle/requirements.txt
@@ -1,0 +1,3 @@
+# Optional web dependencies; never installed by core Concordia.
+fastapi>=0.115,<1
+uvicorn>=0.30,<1

--- a/concordia/examples/astral_canticle/static/app.js
+++ b/concordia/examples/astral_canticle/static/app.js
@@ -1,0 +1,237 @@
+"use strict";
+const $ = (id) => document.getElementById(id);
+let current = null,
+  busy = false,
+  online = false,
+  rendered = 0,
+  revision = -1;
+let lastRequest = null;
+const storage = {
+  get(k) {
+    try {
+      return localStorage.getItem(k);
+    } catch {
+      return null;
+    }
+  },
+  set(k, v) {
+    try {
+      localStorage.setItem(k, v);
+    } catch {}
+  },
+  remove(k) {
+    try {
+      localStorage.removeItem(k);
+    } catch {}
+  },
+};
+const draftKey = "astral-canticle-draft:" + location.pathname;
+function saveDraft() {
+  storage.set(
+    draftKey,
+    JSON.stringify({ id: current?.id, value: $("command").value }),
+  );
+}
+function setDraft(value) {
+  $("command").value = value;
+  saveDraft();
+  enable();
+}
+function enable() {
+  $("send").disabled =
+    busy || !online || !current || !$("command").value.trim();
+}
+function showError(text) {
+  $("feedback").textContent = text;
+}
+function render(state) {
+  $("status").textContent = state.status;
+  if (state.revision === revision) {
+    enable();
+    return;
+  }
+  revision = state.revision;
+  const nearEnd =
+    window.innerHeight + window.scrollY >= document.body.scrollHeight - 240;
+  if (state.entries.length < rendered) {
+    $("story").replaceChildren();
+    rendered = 0;
+  }
+  for (const entry of state.entries.slice(rendered)) {
+    const p = document.createElement("div");
+    p.className = entry.kind === "action" ? "player-action" : "passage";
+    if (entry.kind === "action") {
+      const label = document.createElement("small");
+      label.textContent = "YOUR ACTION";
+      p.append(label);
+    }
+    p.append(document.createTextNode(entry.text));
+    $("story").append(p);
+  }
+  const added = rendered !== state.entries.length;
+  rendered = state.entries.length;
+  $("status").textContent = state.status;
+  $("ending").hidden = !state.finished;
+  current = state.pending;
+  $("prompt").textContent =
+    current?.prompt ||
+    (state.finished
+      ? "Chapter complete"
+      : "The world is responding. You can draft your next action.");
+  $("command").placeholder =
+    current?.type === "float"
+      ? "Enter a finite number…"
+      : "What do you try next?";
+  $("command").inputMode = current?.type === "float" ? "decimal" : "text";
+  if (state.role === "gm") {
+    $("role-label").textContent = "YOU ARE THE";
+    $("character-name").textContent = "Game master";
+    $("character-detail").textContent =
+      "Shape observations, choose actors, resolve their attempts";
+  }
+  $("entity-context").hidden = !current?.context;
+  $("context").textContent = current?.context || "";
+  if (current?.id !== lastRequest) {
+    lastRequest = current?.id;
+    $("choices").replaceChildren();
+    $("choices").hidden = !current?.options?.length;
+    for (const option of current?.options || []) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = option;
+      button.onclick = () => {
+        setDraft(option);
+        $("command").focus();
+      };
+      $("choices").append(button);
+    }
+    $("spec-builder").hidden = current?.type !== "next_action_spec";
+    if (current?.error) showError(current.error);
+  }
+  enable();
+  if (added && rendered > 1) {
+    if (nearEnd)
+      $("waiting").scrollIntoView({ block: "end", behavior: "smooth" });
+    else $("new-entry").hidden = false;
+  }
+}
+async function poll() {
+  try {
+    const response = await fetch("api/state", {
+      cache: "no-store",
+      signal: AbortSignal.timeout(12000),
+    });
+    if (!response.ok) throw new Error("unavailable");
+    const state = await response.json();
+    online = true;
+    $("connection").textContent = "CONNECTED";
+    render(state);
+  } catch {
+    online = false;
+    $("connection").textContent = "RECONNECTING";
+    $("status").textContent =
+      "Connection interrupted. Your draft is safe; reconnecting…";
+    enable();
+  } finally {
+    setTimeout(poll, document.hidden ? 4000 : 1200);
+  }
+}
+$("action-form").addEventListener("submit", async (event) => {
+  event.preventDefault();
+  if (!current || busy || !online || !$("command").value.trim()) return;
+  busy = true;
+  enable();
+  showError("");
+  const id = current.id,
+    value = $("command").value;
+  try {
+    const response = await fetch("api/action", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Astral-Client": "1" },
+      body: JSON.stringify({ request_id: id, response: value }),
+      signal: AbortSignal.timeout(15000),
+    });
+    const result = await response.json();
+    if (!response.ok)
+      throw new Error(
+        typeof result.detail === "string"
+          ? result.detail
+          : "Please check your response and try again.",
+      );
+    // A successful POST, including an idempotent retry, is the only point at
+    // which a draft is discarded. Network failures never erase human input.
+    if ($("command").value === value) {
+      $("command").value = "";
+      storage.remove(draftKey);
+    } else {
+      saveDraft();
+    }
+    current = null;
+    revision = -1;
+    $("status").textContent = "Your action is unfolding…";
+  } catch (error) {
+    showError(
+      error.name === "TimeoutError" || error instanceof TypeError
+        ? "Could not confirm submission. Your draft is kept. Retry when connected."
+        : error.message,
+    );
+  } finally {
+    busy = false;
+    enable();
+  }
+});
+$("command").addEventListener("input", () => {
+  saveDraft();
+  enable();
+});
+$("command").addEventListener("keydown", (event) => {
+  if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+    event.preventDefault();
+    $("action-form").requestSubmit();
+  }
+});
+document.querySelectorAll("[data-command]").forEach(
+  (button) =>
+    (button.onclick = () => {
+      setDraft(button.dataset.command);
+      $("command").focus();
+    }),
+);
+$("help-button").onclick = () => {
+  $("help").hidden = !$("help").hidden;
+  $("help-button").setAttribute("aria-expanded", String(!$("help").hidden));
+  if (!$("help").hidden) $("help").scrollIntoView({ block: "center" });
+};
+$("font").onclick = () => {
+  document.body.classList.toggle("large");
+  storage.set(
+    "astral-large-text",
+    document.body.classList.contains("large") ? "1" : "0",
+  );
+};
+$("jump").onclick = () => {
+  $("waiting").scrollIntoView({ block: "end", behavior: "smooth" });
+  $("new-entry").hidden = true;
+};
+$("build-spec").onclick = () => {
+  const type = $("spec-type").value;
+  setDraft(
+    JSON.stringify({
+      call_to_action: $("spec-prompt").value,
+      output_type: type,
+      options:
+        type === "choice"
+          ? $("spec-options")
+              .value.split("\n")
+              .filter((v) => v.trim())
+          : [],
+    }),
+  );
+};
+try {
+  const draft = JSON.parse(storage.get(draftKey));
+  if (draft?.value) $("command").value = draft.value;
+} catch {}
+if (storage.get("astral-large-text") === "1")
+  document.body.classList.add("large");
+poll();

--- a/concordia/examples/astral_canticle/static/index.html
+++ b/concordia/examples/astral_canticle/static/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#111923" />
+    <meta
+      name="description"
+      content="A small command, a city of consequences. A human-controlled science-fantasy adventure."
+    />
+    <title>The Astral Canticle · Play</title>
+    <link rel="icon" href="data:," />
+    <link rel="stylesheet" href="static/style.css" />
+    <script src="static/app.js" defer></script>
+  </head>
+  <body>
+    <header class="topbar">
+      <a class="brand" href="./" aria-label="The Astral Canticle"
+        ><span class="sigil" aria-hidden="true">✳</span
+        ><span>THE ASTRAL<br /><b>CANTICLE</b></span></a
+      >
+      <nav aria-label="Adventure tools">
+        <button id="font" aria-label="Toggle larger story text">Aa</button
+        ><button id="help-button" aria-expanded="false" aria-controls="help">
+          Guide</button
+        ><a href="api/journal" download>Journal ↗</a>
+      </nav>
+    </header>
+    <main>
+      <section class="opening" aria-labelledby="title">
+        <div class="eyebrow">
+          <span class="line"></span>AURIC VESPER · A SCIENCE-FANTASY ADVENTURE
+        </div>
+        <h1 id="title">
+          A small command.<br /><em>A city of consequences.</em>
+        </h1>
+        <p class="lede">
+          A sleeping moon. A fractured star-loom. And you, with a lantern in
+          your hand.
+        </p>
+        <div class="character">
+          <span class="portrait" aria-hidden="true">IV</span>
+          <div>
+            <small id="role-label">YOU ARE</small
+            ><strong id="character-name">Ilyra Venn</strong
+            ><span id="character-detail"
+              >Astromancer · Engineer · Entirely your own mind</span
+            >
+          </div>
+        </div>
+      </section>
+      <section id="help" class="help" hidden aria-label="How to play">
+        <h2>The world listens to ordinary words.</h2>
+        <p>
+          Describe one thing you try. Explore, speak, experiment. The world
+          answers; your companions make their own choices.
+        </p>
+        <dl>
+          <dt>LOOK / EXAMINE cradle</dt>
+          <dd>Notice your surroundings and search for clues.</dd>
+          <dt>INVENTORY / TAKE tuning fork</dt>
+          <dd>Check or change what you carry.</dd>
+          <dt>WEST / TALK TO Sable-9</dt>
+          <dd>Follow an exit or begin a conversation.</dd>
+          <dt>USE tuning fork ON cradle</dt>
+          <dd>Try an idea. Exact phrasing is never required.</dd>
+        </dl>
+        <p>
+          Closing this page is fine. Return on this device to continue the same
+          adventure while the host is running. Your draft stays here; submitted
+          actions are never repeated automatically.
+        </p>
+      </section>
+      <div class="chapter">
+        <span>CHAPTER I</span><span>THE DISSONANT THREAD</span
+        ><span aria-hidden="true">✧</span>
+      </div>
+      <section
+        id="story"
+        aria-label="Adventure transcript"
+        aria-live="polite"
+        aria-relevant="additions"
+      ></section>
+      <section id="entity-context" hidden aria-labelledby="context-title">
+        <h2 id="context-title">Your context</h2>
+        <pre id="context"></pre>
+      </section>
+      <div id="waiting" class="waiting" role="status">
+        <span class="pulse" aria-hidden="true"></span
+        ><span id="status">Connecting to Auric Vesper…</span>
+      </div>
+      <p id="ending" hidden>
+        This chapter is yours to keep. Download your journal above.
+      </p>
+      <div id="new-entry" hidden>
+        <button id="jump">↓ Return to the latest passage</button>
+      </div>
+    </main>
+    <section class="composer" aria-label="Your next action">
+      <div class="composer-inner">
+        <div class="turnline">
+          <label id="prompt" for="command">What do you do?</label
+          ><span id="connection">CONNECTING</span>
+        </div>
+        <div
+          id="choices"
+          class="choices"
+          aria-label="Available choices"
+          hidden
+        ></div>
+        <div id="spec-builder" hidden>
+          <label
+            >Ask the next actor<input
+              id="spec-prompt"
+              value="What do you do next?"
+              maxlength="4000"
+          /></label>
+          <label
+            >Response kind<select id="spec-type">
+              <option value="free">Free text</option>
+              <option value="choice">Choice</option>
+              <option value="float">Number</option>
+              <option value="skip_this_step">Skip</option>
+            </select></label
+          >
+          <label
+            >Choices (one per line)<textarea
+              id="spec-options"
+              rows="2"
+            ></textarea>
+          </label>
+          <button id="build-spec" type="button">Use this action request</button>
+        </div>
+        <form id="action-form">
+          <span class="chevron" aria-hidden="true">›</span>
+          <textarea
+            id="command"
+            name="command"
+            rows="2"
+            maxlength="8000"
+            aria-describedby="feedback"
+            placeholder="Examine the resonance cradle…"
+            autocomplete="off"
+            enterkeyhint="send"
+          ></textarea>
+          <button id="send" type="submit" disabled aria-label="Submit action">
+            Act <span aria-hidden="true">↵</span>
+          </button>
+        </form>
+        <p id="feedback" role="alert"></p>
+        <div class="shortcuts" aria-label="Command ideas">
+          <button data-command="Look around">Look</button
+          ><button data-command="Check my inventory">Inventory</button
+          ><button data-command="Examine the resonance cradle">Examine</button
+          ><button data-command="Talk to Sable-9">Talk</button
+          ><span>YOUR WORDS. YOUR CHOICE.</span>
+        </div>
+      </div>
+    </section>
+    <noscript
+      >This adventure needs JavaScript to submit actions. Enable it and reload;
+      no action has been sent.</noscript
+    >
+  </body>
+</html>

--- a/concordia/examples/astral_canticle/static/style.css
+++ b/concordia/examples/astral_canticle/static/style.css
@@ -1,0 +1,563 @@
+:root {
+  color-scheme: dark;
+  --bg: #111923;
+  --panel: #18232d;
+  --ink: #e6e4d9;
+  --muted: #a1afb7;
+  --gold: #debd83;
+  --edge: #33414b;
+  --story-size: 1.125rem;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  background:
+    radial-gradient(ellipse at 85% 0, #2a303c 0, transparent 38rem), var(--bg);
+  color: var(--ink);
+  font:
+    15px/1.6 system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+button,
+a,
+input,
+textarea,
+select {
+  -webkit-tap-highlight-color: transparent;
+}
+button,
+a {
+  touch-action: manipulation;
+}
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+button,
+a {
+  color: inherit;
+}
+button {
+  cursor: pointer;
+}
+button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+button:focus-visible,
+a:focus-visible,
+summary:focus-visible,
+textarea:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 4px;
+}
+button {
+  background: none;
+  border: 0;
+}
+a {
+  text-decoration: none;
+}
+a:hover,
+button:hover {
+  color: var(--gold);
+}
+.topbar {
+  max-width: 1100px;
+  margin: auto;
+  padding: 28px 40px;
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: center;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  line-height: 1.3;
+  letter-spacing: 0.22em;
+  font-size: 10px;
+}
+.brand b {
+  font-size: 16px;
+  letter-spacing: 0.19em;
+  font-weight: 500;
+}
+.sigil {
+  font-size: 46px;
+  color: var(--gold);
+  font-weight: 200;
+  line-height: 1;
+}
+.topbar nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #c8cfcf;
+}
+.topbar nav > * {
+  min-height: 44px;
+  padding: 12px 10px;
+  white-space: nowrap;
+}
+main {
+  max-width: 760px;
+  margin: auto;
+  padding: 28px 34px 60px;
+}
+.opening {
+  padding: 24px 0 36px;
+}
+.eyebrow {
+  font-size: 9px;
+  letter-spacing: 0.22em;
+  color: var(--gold);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.line {
+  height: 1px;
+  width: 26px;
+  background: var(--gold);
+}
+h1 {
+  font:
+    400 clamp(2.5rem, 6vw, 3.7rem)/1.13 Georgia,
+    "Times New Roman",
+    serif;
+  letter-spacing: -0.025em;
+  margin: 24px 0 20px;
+}
+h1 em {
+  font-weight: 400;
+  color: #babbb3;
+}
+.lede {
+  color: var(--muted);
+  font-size: 14px;
+  max-width: 410px;
+}
+.character {
+  display: flex;
+  gap: 15px;
+  align-items: center;
+  margin-top: 30px;
+}
+.portrait {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border: 1px solid #626252;
+  border-radius: 50%;
+  width: 49px;
+  height: 49px;
+  color: var(--gold);
+  font:
+    18px Georgia,
+    serif;
+  background: #252e32;
+}
+.character div {
+  display: grid;
+  gap: 1px;
+}
+.character small {
+  color: var(--gold);
+  letter-spacing: 0.19em;
+  font-size: 8px;
+}
+.character strong {
+  font:
+    20px Georgia,
+    serif;
+  font-weight: 400;
+}
+.character div > span {
+  font-size: 11px;
+  color: var(--muted);
+}
+.chapter {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  border-top: 1px solid var(--edge);
+  padding: 22px 0;
+  color: var(--muted);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+}
+.chapter span:first-child {
+  color: var(--gold);
+}
+.chapter span:last-child {
+  margin-left: auto;
+  color: var(--gold);
+  font-size: 17px;
+}
+.passage {
+  font:
+    var(--story-size)/1.8 Georgia,
+    "Times New Roman",
+    serif;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  animation: arrive 0.35s ease-out;
+  margin: 0 0 24px;
+}
+.player-action {
+  border-left: 2px solid var(--gold);
+  padding: 12px 18px;
+  background: linear-gradient(90deg, #252e35, transparent);
+  font:
+    14px/1.65 system-ui,
+    sans-serif;
+  color: var(--gold);
+  margin: 30px 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.player-action small {
+  display: block;
+  font:
+    8px system-ui,
+    sans-serif;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.waiting {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--muted);
+  padding: 6px 0 22px;
+}
+.pulse {
+  width: 5px;
+  height: 5px;
+  background: var(--gold);
+  border-radius: 50%;
+  box-shadow: 0 0 12px #debd8370;
+  animation: pulse 2s infinite;
+}
+.composer {
+  position: sticky;
+  bottom: 0;
+  background: linear-gradient(0deg, #111923 90%, #111923ec);
+  border-top: 1px solid var(--edge);
+  padding: 16px 28px max(18px, env(safe-area-inset-bottom));
+  z-index: 2;
+}
+.composer-inner {
+  max-width: 692px;
+  margin: auto;
+}
+.turnline {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--ink);
+}
+#prompt {
+  max-width: 80%;
+  line-height: 1.4;
+}
+#connection {
+  color: var(--gold);
+  font-size: 8px;
+  letter-spacing: 0.15em;
+  white-space: nowrap;
+}
+#action-form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid #4d575d;
+  border-radius: 6px;
+  background: #1b2731;
+  padding: 10px 12px;
+}
+#action-form:focus-within {
+  border-color: var(--gold);
+}
+.chevron {
+  font:
+    27px Georgia,
+    serif;
+  color: var(--gold);
+}
+#command {
+  width: 100%;
+  min-width: 0;
+  max-height: 130px;
+  resize: vertical;
+  border: 0;
+  background: none;
+  color: var(--ink);
+  font-size: 16px;
+  line-height: 1.5;
+  outline: none !important;
+  padding: 3px;
+}
+#command::placeholder {
+  color: #899ba6;
+}
+#send {
+  padding: 10px 16px;
+  min-height: 46px;
+  border-radius: 4px;
+  background: var(--gold);
+  color: #19222b;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 600;
+}
+#send span {
+  margin-left: 8px;
+}
+.shortcuts {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+}
+.shortcuts button {
+  font-size: 11px;
+  color: var(--muted);
+  padding: 9px 10px;
+  min-height: 44px;
+}
+.shortcuts button:first-child {
+  padding-left: 0;
+}
+.shortcuts span {
+  margin-left: auto;
+  color: #93a2ab;
+  font-size: 8px;
+  letter-spacing: 0.1em;
+}
+#feedback {
+  font-size: 12px;
+  color: #f0bcab;
+  margin: 6px 0;
+  min-height: 0;
+}
+#feedback:empty {
+  display: none;
+}
+.help {
+  background: var(--panel);
+  border: 1px solid var(--edge);
+  border-radius: 6px;
+  padding: 20px;
+  margin-bottom: 26px;
+  font-size: 13px;
+}
+.help h2 {
+  font:
+    23px Georgia,
+    serif;
+  margin-top: 0;
+}
+.help p {
+  color: var(--muted);
+}
+dl {
+  margin: 0;
+}
+dt {
+  font-size: 12px;
+  color: var(--gold);
+  margin-top: 12px;
+}
+dd {
+  margin-left: 0;
+  color: var(--muted);
+}
+.choices {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 12px 0;
+}
+.choices button,
+#build-spec {
+  border: 1px solid var(--edge);
+  border-radius: 5px;
+  padding: 10px 14px;
+  min-height: 44px;
+  color: var(--gold);
+  font-size: 14px;
+}
+#spec-builder {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin: 12px 0;
+  max-height: 220px;
+  overflow: auto;
+}
+#spec-builder label {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+}
+#spec-builder input,
+#spec-builder textarea,
+#spec-builder select {
+  background: var(--panel);
+  color: var(--ink);
+  border: 1px solid var(--edge);
+  padding: 7px;
+  width: 100%;
+  font-size: 16px;
+}
+#entity-context {
+  margin: 28px 0;
+  padding: 22px;
+  border: 1px solid var(--edge);
+  border-radius: 12px;
+}
+#context-title {
+  color: var(--gold);
+  font-size: 1rem;
+}
+
+#context {
+  font: inherit;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+#ending {
+  color: var(--gold);
+  font:
+    20px Georgia,
+    serif;
+}
+#new-entry {
+  text-align: center;
+}
+#jump {
+  color: var(--gold);
+  border: 1px solid var(--edge);
+  border-radius: 20px;
+  padding: 8px 18px;
+  min-height: 44px;
+}
+[hidden] {
+  display: none !important;
+}
+body.large {
+  --story-size: 1.35rem;
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.3;
+  }
+}
+@keyframes arrive {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (max-width: 600px) {
+  .topbar {
+    padding: 20px 20px 12px;
+    gap: 8px;
+  }
+  .brand {
+    gap: 8px;
+    font-size: 8px;
+  }
+  .brand b {
+    font-size: 12px;
+  }
+  .sigil {
+    font-size: 35px;
+  }
+  .topbar nav {
+    gap: 0;
+    font-size: 11px;
+  }
+  .topbar nav > * {
+    padding: 12px 8px;
+  }
+  main {
+    padding: 18px 24px 32px;
+  }
+  .opening {
+    padding: 8px 0 28px;
+  }
+  .eyebrow {
+    font-size: 8px;
+    letter-spacing: 0.12em;
+    gap: 8px;
+  }
+  h1 {
+    margin-top: 20px;
+    font-size: 2.45rem;
+  }
+  .lede {
+    font-size: 13px;
+  }
+  .chapter {
+    gap: 12px;
+    font-size: 8px;
+    letter-spacing: 0.12em;
+  }
+  .composer {
+    padding: 13px 18px max(12px, env(safe-area-inset-bottom));
+  }
+  .shortcuts span {
+    display: none;
+  }
+  .shortcuts {
+    justify-content: space-between;
+  }
+  .shortcuts button {
+    font-size: 12px;
+  }
+  #send {
+    padding: 10px 13px;
+  }
+  #send span {
+    display: none;
+  }
+  .turnline {
+    font-size: 11px;
+  }
+  .passage {
+    line-height: 1.75;
+  }
+  .character div > span {
+    font-size: 10px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/concordia/examples/astral_canticle/terminal.py
+++ b/concordia/examples/astral_canticle/terminal.py
@@ -1,0 +1,77 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Terminal transport for the same adventure and HumanActComponent API."""
+
+import argparse
+import pathlib
+
+from concordia.contrib.language_models.ollama import ollama_model
+from concordia.examples.astral_canticle import adventure
+
+
+class TerminalInput:
+  """A simple synchronous reader demonstrating a non-web transport."""
+
+  def __call__(self, request):
+    print(request.context)
+    print(f'\n{request.entity_name}: {request.action_spec.call_to_action}')
+    if request.action_spec.options:
+      print('Choose exactly: ' + ' | '.join(request.action_spec.options))
+    if request.error:
+      print(request.error)
+    return input('> ')
+
+  def progress(self, step, actor):
+    print(f'\nTurn {step}: {actor} acted.')
+
+  def add_observation(self, observation):
+    print('\n' + observation)
+
+  def finish(self, message):
+    print('\n' + message)
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--role', choices=('player', 'gm'), default='player')
+  parser.add_argument(
+      '--player-prefab',
+      choices=('minimal', 'basic'),
+      default='minimal',
+      help='Standard prefab for Ilyra; basic retains its LLM perceptions.',
+  )
+  parser.add_argument('--model', default='llama3.2:3b')
+  parser.add_argument('--max-steps', type=int, default=30)
+  parser.add_argument(
+      '--output', type=pathlib.Path, default=pathlib.Path('runs/terminal')
+  )
+  args = parser.parse_args()
+  if not 1 <= args.max_steps <= 300:
+    parser.error('--max-steps must be between 1 and 300')
+  try:
+    adventure.play(
+        ollama_model.OllamaLanguageModel(args.model),
+        TerminalInput(),
+        args.output,
+        role=args.role,
+        max_steps=args.max_steps,
+        player_prefab=args.player_prefab,
+    )
+  except (EOFError, KeyboardInterrupt):
+    print('\nStopped. Completed turns are saved in ' + str(args.output))
+
+
+if __name__ == '__main__':
+  main()

--- a/concordia/examples/astral_canticle/ui_test.py
+++ b/concordia/examples/astral_canticle/ui_test.py
@@ -1,0 +1,250 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Browser integration against the real adapter with a fake input request.
+
+These tests do not start a Concordia simulation or contact a model. Install the
+optional example test dependencies and run `python -m playwright install chromium`.
+"""
+
+import concurrent.futures
+import socket
+import threading
+import time
+from unittest import mock
+
+from concordia.examples.astral_canticle import adventure
+from concordia.examples.astral_canticle import human_io
+from concordia.language_model import no_language_model
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+import pytest
+
+pytest.importorskip('fastapi')
+pytest.importorskip('uvicorn')
+pytest.importorskip('playwright.sync_api')
+web = pytest.importorskip('concordia.examples.astral_canticle.web')
+playwright = pytest.importorskip('playwright.sync_api')
+expect = playwright.expect
+sync_playwright = playwright.sync_playwright
+uvicorn = pytest.importorskip('uvicorn')
+
+
+@pytest.fixture
+def serve():
+  resources = []
+
+  def start(
+      role='player', output_type=entity_lib.OutputType.FREE, human_request=None
+  ):
+    session = human_io.HumanSession(role=role)
+    pool = concurrent.futures.ThreadPoolExecutor()
+    result = pool.submit(
+        session,
+        human_request
+        or human_input.HumanInputRequest(
+            request_id='ui-request',
+            entity_name='Ilyra Venn',
+            action_spec=entity_lib.ActionSpec(
+                call_to_action='What do you do?', output_type=output_type
+            ),
+            context='My context:\nA silver door.\n<script>bad()</script>',
+            contexts={
+                '__observation__': (
+                    '[observation] You stand in the Star-Loom Chamber. A brass'
+                    ' tuning fork hangs beside a cracked resonance cradle. The'
+                    ' west exit leads to the Reliquary Nave.'
+                    ' <script>bad()</script>'
+                )
+            },
+        ),
+    )
+    sock = socket.socket()
+    sock.bind(('127.0.0.1', 0))
+    server = uvicorn.Server(
+        uvicorn.Config(web.create_app(session), log_level='error')
+    )
+    thread = threading.Thread(
+        target=server.run, kwargs={'sockets': [sock]}, daemon=True
+    )
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not server.started and time.monotonic() < deadline:
+      time.sleep(0.01)
+    assert server.started
+    resources.append((server, thread, session, pool, sock))
+    return f'http://127.0.0.1:{sock.getsockname()[1]}/', session, result
+
+  yield start
+  for server, thread, session, pool, sock in resources:
+    session.finish('Test complete')
+    server.should_exit = True
+    thread.join(timeout=5)
+    pool.shutdown(wait=True)
+    sock.close()
+
+
+def test_mobile_draft_reload_offline_recovery_and_single_submit(
+    serve, tmp_path
+):
+  url, session, result = serve()
+  with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(
+        viewport={'width': 390, 'height': 844}, is_mobile=True, has_touch=True
+    )
+    errors = []
+    page.on('pageerror', lambda error: errors.append(str(error)))
+    page.goto(url)
+    expect(page.locator('#connection')).to_have_text('CONNECTED')
+    expect(page.locator('.passage')).to_contain_text('<script>bad()</script>')
+    page.locator('#command').fill('Examine the resonance cradle')
+    page.reload()
+    expect(page.locator('#command')).to_have_value(
+        'Examine the resonance cradle'
+    )
+    expect(page.locator('#send')).to_be_enabled()
+    assert page.evaluate('document.documentElement.scrollWidth <= innerWidth')
+    page.screenshot(
+        path=str(tmp_path / 'mobile.png'), full_page=True, animations='disabled'
+    )
+    page.context.set_offline(True)
+    expect(page.locator('#connection')).to_have_text(
+        'RECONNECTING', timeout=18000
+    )
+    expect(page.locator('#send')).to_be_disabled()
+    page.context.set_offline(False)
+    expect(page.locator('#connection')).to_have_text('CONNECTED', timeout=18000)
+    expect(page.locator('#status')).to_have_text('Your move')
+    expect(page.locator('#command')).to_have_value(
+        'Examine the resonance cradle'
+    )
+    page.locator('#send').click()
+    assert result.result(timeout=4) == 'Examine the resonance cradle'
+    expect(page.locator('.player-action')).to_contain_text(
+        'Examine the resonance cradle'
+    )
+    page.reload()
+    expect(page.locator('#command')).to_have_value('')
+    assert (
+        len([e for e in session.snapshot()['entries'] if e['kind'] == 'action'])
+        == 1
+    )
+    assert not errors
+    browser.close()
+
+
+def test_gm_action_spec_builder_and_desktop_layout(serve, tmp_path):
+  url, _, result = serve('gm', entity_lib.OutputType.NEXT_ACTION_SPEC)
+  with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(viewport={'width': 1280, 'height': 900})
+    page.goto(url)
+    expect(page.locator('#spec-builder')).to_be_visible()
+    page.locator('#spec-type').select_option('choice')
+    page.locator('#spec-options').fill(' North \nWest')
+    page.locator('#build-spec').click()
+    page.screenshot(
+        path=str(tmp_path / 'desktop-gm.png'),
+        full_page=True,
+        animations='disabled',
+    )
+    page.locator('#send').click()
+    assert ' North ' in result.result(timeout=4)
+    assert page.evaluate('document.documentElement.scrollWidth <= innerWidth')
+    browser.close()
+
+
+def test_draft_edited_while_post_is_in_flight_is_not_lost(serve):
+  url, _, result = serve()
+  with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto(url)
+    expect(page.locator('#connection')).to_have_text('CONNECTED')
+    page.locator('#command').fill('Examine the cradle')
+
+    def hold_reply(route):
+      response = route.fetch()
+      page.locator('#command').fill('Talk to Sable-9')
+      route.fulfill(response=response)
+
+    page.route('**/api/action', hold_reply)
+    page.locator('#send').click()
+    assert result.result(timeout=4) == 'Examine the cradle'
+    expect(page.locator('.player-action')).to_contain_text('Examine the cradle')
+    page.reload()
+    expect(page.locator('#command')).to_have_value('Talk to Sable-9')
+    expect(page.locator('#send')).to_be_disabled()
+    browser.close()
+
+
+@pytest.mark.parametrize('role', ['player', 'gm'])
+def test_complete_basic_context_visible_verbatim_in_prefab_order(
+    serve, tmp_path, role
+):
+  model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+  model.sample_text.return_value = (
+      'A basic perception answer.\nIts second line.'
+  )
+  reader = mock.Mock(return_value='LOOK')
+  players, gm = adventure.build_cast(model, reader, player_prefab='basic')
+  players[1].observe('NPC-PRIVATE-SENTINEL')
+  gm.observe('GM-PRIVATE-SENTINEL')
+  players[0].act()  # Unit fixture: mock model/input, no simulation launch.
+  request = reader.call_args.args[0]
+  url, session, result = serve(role=role, human_request=request)
+  with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(
+        viewport={'width': 390, 'height': 844}, is_mobile=True, has_touch=True
+    )
+    errors = []
+    page.on('pageerror', lambda error: errors.append(str(error)))
+    page.goto(url)
+    expect(page.locator('#entity-context')).to_be_visible()
+    displayed = page.locator('#context').text_content()
+    assert displayed == request.context
+    # These are the actual basic prefab labels, in its Concat order (not the
+    # dependency/inference execution order). No new dict-key headings are added.
+    labels = [
+        'Question: What kind of person is Ilyra Venn?',
+        'Question: What situation is Ilyra Venn in right now?',
+        (
+            'Question: What would a person like Ilyra Venn do in a situation'
+            ' like this?'
+        ),
+    ]
+    offsets = [displayed.index(label) for label in labels]
+    assert offsets == sorted(offsets)
+    assert displayed.count('A basic perception answer.\nIts second line.') == 3
+    assert 'NPC-PRIVATE-SENTINEL' not in displayed
+    assert 'GM-PRIVATE-SENTINEL' not in displayed
+    assert (
+        page.locator('#context').evaluate(
+            'el => getComputedStyle(el).whiteSpace'
+        )
+        == 'pre-wrap'
+    )
+    assert page.evaluate('document.documentElement.scrollWidth <= innerWidth')
+    page.reload()
+    expect(page.locator('#entity-context')).to_be_visible()
+    assert page.locator('#context').text_content() == request.context
+    page.screenshot(
+        path=str(tmp_path / f'basic-context-{role}.png'), full_page=True
+    )
+    assert not errors
+    assert not result.done()
+    assert session.snapshot()['pending']['context'] == request.context
+    browser.close()

--- a/concordia/examples/astral_canticle/web.py
+++ b/concordia/examples/astral_canticle/web.py
@@ -1,0 +1,224 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional single-controller web transport. Importing never starts a game."""
+
+import argparse
+import contextlib
+import logging
+import pathlib
+import threading
+
+from concordia.contrib.language_models.ollama import ollama_model
+from concordia.examples.astral_canticle import adventure
+from concordia.examples.astral_canticle import human_io
+from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi import Request
+from fastapi.responses import FileResponse
+from fastapi.responses import JSONResponse
+from fastapi.responses import Response
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from pydantic import Field
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+import uvicorn
+
+_LOG = logging.getLogger(__name__)
+_STATIC = pathlib.Path(__file__).with_name('static')
+
+
+class Submission(BaseModel):
+  request_id: str = Field(min_length=1, max_length=128)
+  response: str = Field(min_length=1, max_length=8000)
+
+
+def create_app(
+    session: human_io.HumanSession,
+    *,
+    runner=None,
+    allowed_hosts=('127.0.0.1', 'localhost'),
+    root_path='',
+) -> FastAPI:
+  """Create a browser adapter; the optional runner owns one adventure process.
+
+  There are no start/reset/lobby endpoints. Reloading cannot launch a second
+  simulation. Bind to loopback and use a private authenticated reverse proxy
+  such as Tailscale Serve. All permitted tailnet users share this one controller.
+  """
+
+  @contextlib.asynccontextmanager
+  async def lifespan(app):
+    del app
+    thread = None
+    if runner is not None:
+
+      def run():
+        try:
+          runner()
+        except human_io.InputClosed:
+          pass
+        except Exception:  # pylint: disable=broad-exception-caught
+          _LOG.exception('Adventure stopped')
+          session.finish(
+              'The story paused unexpectedly. Your journal is safe; '
+              'ask the host to check the adventure log.'
+          )
+
+      thread = threading.Thread(
+          target=run, name='concordia-adventure', daemon=True
+      )
+      thread.start()
+    yield
+    session.finish('The adventure host has stopped. Your journal is saved.')
+    if thread is not None:
+      thread.join(timeout=1)
+
+  app = FastAPI(
+      lifespan=lifespan,
+      docs_url=None,
+      redoc_url=None,
+      openapi_url=None,
+      root_path=root_path,
+  )
+  app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(allowed_hosts))
+
+  @app.middleware('http')
+  async def browser_boundary(request: Request, call_next):
+    # ASGI root_path denotes the mount location. Starlette's StaticFiles needs
+    # scope.path to include it, even when a reverse proxy stripped the prefix.
+    # Normalize once so both stripping and preserving proxies work.
+    path = request.scope['path']
+    if root_path and path != root_path and not path.startswith(root_path + '/'):
+      request.scope['path'] = root_path + path
+      request.scope['raw_path'] = request.scope['path'].encode('utf-8')
+    # The browser supplies Origin. Match host (including port), and require JSON
+    # plus a custom header: a foreign page cannot issue a simple form POST.
+    if request.method == 'POST':
+      origin = request.headers.get('origin', '')
+      host = request.headers.get('host', '')
+      if origin not in (f'http://{host}', f'https://{host}'):
+        return JSONResponse(
+            {'detail': 'Same-origin requests only.'}, status_code=403
+        )
+      if request.headers.get('x-astral-client') != '1':
+        return JSONResponse(
+            {'detail': 'Missing client header.'}, status_code=403
+        )
+      if (
+          request.headers.get('content-type', '').split(';')[0]
+          != 'application/json'
+      ):
+        return JSONResponse({'detail': 'JSON required.'}, status_code=415)
+      try:
+        if int(request.headers.get('content-length', '0')) > 40000:
+          return Response(status_code=413)
+      except ValueError:
+        return Response(status_code=400)
+      # Enforce actual size too, including chunked requests.
+      body = await request.body()
+      if len(body) > 40000:
+        return Response(status_code=413)
+    response = await call_next(request)
+    response.headers['Cache-Control'] = 'no-store'
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['Referrer-Policy'] = 'no-referrer'
+    response.headers['Content-Security-Policy'] = (
+        "default-src 'self'; script-src 'self'; style-src 'self'; "
+        "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; "
+        "base-uri 'none'; form-action 'self'"
+    )
+    return response
+
+  @app.get('/')
+  def index():
+    return FileResponse(_STATIC / 'index.html')
+
+  @app.get('/api/state')
+  def state():
+    return session.snapshot()
+
+  @app.post('/api/action')
+  def submit(body: Submission):
+    try:
+      accepted = session.submit(body.request_id, body.response)
+    except human_io.StaleRequest as exc:
+      raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+      raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {'accepted': accepted}
+
+  @app.get('/api/journal')
+  def journal():
+    snapshot = session.snapshot()
+    text = 'THE ASTRAL CANTICLE\n\n' + '\n\n'.join(
+        ('> ' if entry['kind'] == 'action' else '') + entry['text']
+        for entry in snapshot['entries']
+    )
+    return Response(
+        text,
+        media_type='text/plain',
+        headers={
+            'Content-Disposition': (
+                'attachment; filename="astral-canticle-journal.txt"'
+            )
+        },
+    )
+
+  app.mount('/static', StaticFiles(directory=_STATIC), name='static')
+  return app
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--model', default='llama3.2:3b')
+  parser.add_argument('--role', choices=('player', 'gm'), default='player')
+  parser.add_argument(
+      '--player-prefab',
+      choices=('minimal', 'basic'),
+      default='minimal',
+      help='Standard prefab for Ilyra; basic retains its LLM perceptions.',
+  )
+  parser.add_argument('--port', type=int, default=8767)
+  parser.add_argument('--allowed-host', action='append', default=[])
+  parser.add_argument('--root-path', default='')
+  parser.add_argument('--max-steps', type=int, default=30)
+  parser.add_argument(
+      '--output', type=pathlib.Path, default=pathlib.Path('runs/human')
+  )
+  args = parser.parse_args()
+  if not 1 <= args.max_steps <= 300:
+    parser.error('--max-steps must be between 1 and 300')
+  if not 1 <= args.port <= 65535:
+    parser.error('--port must be between 1 and 65535')
+  session = human_io.HumanSession(role=args.role)
+  model = ollama_model.OllamaLanguageModel(model_name=args.model)
+  app = create_app(
+      session,
+      runner=lambda: adventure.play(
+          model,
+          session,
+          args.output,
+          role=args.role,
+          max_steps=args.max_steps,
+          player_prefab=args.player_prefab,
+      ),
+      allowed_hosts=['127.0.0.1', 'localhost', *args.allowed_host],
+      root_path=args.root_path,
+  )
+  uvicorn.run(app, host='127.0.0.1', port=args.port)
+
+
+if __name__ == '__main__':
+  main()

--- a/concordia/examples/astral_canticle/web_test.py
+++ b/concordia/examples/astral_canticle/web_test.py
@@ -1,0 +1,212 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real transport requests, no LLM calls or simulation launches."""
+
+import concurrent.futures
+import time
+
+from concordia.examples.astral_canticle import human_io
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+import pytest
+
+pytest.importorskip('fastapi')
+pytest.importorskip('httpx')
+web = pytest.importorskip('concordia.examples.astral_canticle.web')
+TestClient = pytest.importorskip('fastapi.testclient').TestClient
+
+HEADERS = {'Origin': 'http://localhost', 'X-Astral-Client': '1'}
+
+
+def request(spec=None, id='first'):
+  return human_input.HumanInputRequest(
+      request_id=id,
+      entity_name='Ilyra Venn',
+      action_spec=spec
+      or entity_lib.free_action_spec(call_to_action='Your move?'),
+      contexts={
+          '__observation__': 'Observations:\n[observation] A silver door.',
+          'SelfPerception': 'This controlled entity reflects on its own role.',
+      },
+      context=(
+          'Observations:\n[observation] A silver door.\nThis controlled entity'
+          ' reflects on its own role.'
+      ),
+  )
+
+
+def wait_pending(session):
+  end = time.monotonic() + 4
+  while time.monotonic() < end:
+    if session.snapshot()['pending']:
+      return
+    time.sleep(0.01)
+  raise AssertionError('No pending input')
+
+
+@pytest.fixture
+def active():
+  session = human_io.HumanSession()
+  with concurrent.futures.ThreadPoolExecutor() as pool:
+    result = pool.submit(session, request())
+    wait_pending(session)
+    with TestClient(
+        web.create_app(session), base_url='http://localhost'
+    ) as client:
+      yield session, result, client
+    session.finish('Stopped')
+
+
+def test_reconnect_validate_then_idempotent_submit(active):
+  session, result, client = active
+  first = client.get('/api/state').json()
+  assert client.get('/api/state').json() == first
+  assert 'contexts' not in first['pending']
+  assert first['pending']['context'] == request().context
+  data = {'request_id': 'first', 'response': '   '}
+  assert (
+      client.post('/api/action', json=data, headers=HEADERS).status_code == 422
+  )
+  assert not result.done()
+  data['response'] = 'Open the door'
+  assert client.post('/api/action', json=data, headers=HEADERS).json() == {
+      'accepted': True
+  }
+  assert result.result(timeout=3) == 'Open the door'
+  assert client.post('/api/action', json=data, headers=HEADERS).json() == {
+      'accepted': False
+  }
+  data['response'] = 'Actually go west'
+  assert (
+      client.post('/api/action', json=data, headers=HEADERS).status_code == 409
+  )
+  assert len(session.snapshot()['entries']) == 2
+  assert '> Open the door' in client.get('/api/journal').text
+
+
+@pytest.mark.parametrize(
+    'headers',
+    [
+        {},
+        {'Origin': 'https://attacker.example', 'X-Astral-Client': '1'},
+        {'Origin': 'http://localhost'},
+    ],
+)
+def test_cross_origin_or_simple_post_cannot_act(active, headers):
+  _, result, client = active
+  assert (
+      client.post(
+          '/api/action',
+          json={'request_id': 'first', 'response': 'go'},
+          headers=headers,
+      ).status_code
+      == 403
+  )
+  assert not result.done()
+
+
+def test_bad_host_oversized_and_non_json_requests(active):
+  _, result, client = active
+  assert (
+      client.get('/api/state', headers={'Host': 'attacker.example'}).status_code
+      == 400
+  )
+  assert (
+      client.post('/api/action', content='x', headers=HEADERS).status_code
+      == 415
+  )
+  assert (
+      client.post(
+          '/api/action',
+          json={'request_id': 'first', 'response': 'x' * 40000},
+          headers=HEADERS,
+      ).status_code
+      == 413
+  )
+  assert not result.done()
+
+
+@pytest.mark.parametrize(
+    'spec,bad,good',
+    [
+        (
+            entity_lib.choice_action_spec(
+                call_to_action='Where?', options=(' North ', 'West')
+            ),
+            'North',
+            ' North ',
+        ),
+        (
+            entity_lib.float_action_spec(call_to_action='How much?'),
+            'NaN',
+            '1.5',
+        ),
+        (
+            entity_lib.ActionSpec(
+                call_to_action='Next spec?',
+                output_type=entity_lib.OutputType.NEXT_ACTION_SPEC,
+            ),
+            '{}',
+            '{"call_to_action":"Act", "output_type":"free"}',
+        ),
+    ],
+)
+def test_spec_validation_happens_before_unblocking(spec, bad, good):
+  session = human_io.HumanSession(role='gm')
+  with concurrent.futures.ThreadPoolExecutor() as pool:
+    result = pool.submit(session, request(spec))
+    wait_pending(session)
+    try:
+      with pytest.raises(ValueError):
+        session.submit('first', bad)
+      assert not result.done()
+      assert session.snapshot()['pending']['context'] == request(spec).context
+      session.submit('first', good)
+      assert result.result(timeout=3) == good
+    finally:
+      session.finish('Done')
+
+
+def test_close_unblocks_reader_and_restart_rejects_old_action():
+  session = human_io.HumanSession()
+  with concurrent.futures.ThreadPoolExecutor() as pool:
+    result = pool.submit(session, request())
+    wait_pending(session)
+    session.finish('Closed')
+    with pytest.raises(human_io.InputClosed):
+      result.result(timeout=3)
+  new_session = human_io.HumanSession()
+  with pytest.raises(human_io.StaleRequest):
+    new_session.submit('first', 'go')
+
+
+def test_assets_csp_and_import_do_not_launch_a_simulation(active):
+  _, _, client = active
+  response = client.get('/')
+  assert response.status_code == 200
+  assert 'frame-ancestors' in response.headers['content-security-policy']
+  assert response.headers['cache-control'] == 'no-store'
+  assert client.get('/static/app.js').status_code == 200
+  assert client.get('/docs').status_code == 404
+
+
+@pytest.mark.parametrize('prefix', ['', '/astral-canticle-play'])
+def test_proxy_mount_serves_index_api_and_assets_with_either_prefix(prefix):
+  session = human_io.HumanSession()
+  app = web.create_app(session, root_path='/astral-canticle-play')
+  with TestClient(app, base_url='http://localhost') as client:
+    for suffix in ('/', '/api/state', '/static/app.js', '/static/style.css'):
+      response = client.get(prefix + suffix)
+      assert response.status_code == 200, (prefix, suffix, response.text)

--- a/concordia/examples/bellwether/ENGINES.md
+++ b/concordia/examples/bellwether/ENGINES.md
@@ -1,0 +1,130 @@
+# Analogous scenarios using standard Concordia engines
+
+The main Bellwether night remains **Sequential**. Its agenda, watch boundaries,
+private conversation and consent/repair stages require ordered resolution.
+Changing an engine argument alone is not an equivalent experiment.
+
+## What the repository actually provides
+
+| Standard engine | Scheduling / step semantics | Required configuration | Evidence here |
+|---|---|---|---|
+| `Sequential` | Select one actor, deliver observation, act, resolve; one step per selected actor | One next-actor name, one action spec, ordered GM state | Existing complete Bellwether fixture/live tests |
+| `Simultaneous` | Select a group; get each spec; collect actions concurrently; resolve one multiline batch; one step per round | Group selection, complete-batch GM rule, isolated player contexts; no current-round peer choices in initial observations | New one-round council fixture and batch-contract tests |
+| `Asynchronous` | Independent per-player observe/act loops, no round barrier; per-player iteration cap | ReactiveMeasurements/capture and thread-safe GM/components; explicit rules for concurrent state changes | Code audit only, **not run or certified compatible** with either example |
+
+The modules are in `concordia/environment/engines/`. The simultaneous engine
+already uses standard concurrency utilities and a GM observation/log lock.
+The asynchronous engine validates `ReactiveMeasurements` and has different
+pause/capture behavior. Do not implement another scheduling loop or treat
+async completion order as simultaneous choice.
+
+## Runnable simultaneous resource council
+
+This is a separate, deliberately small analogue of cooperative resource
+governance, **not the full Bellwether game**. Nell, Ivo and Sam each hold one
+unit. Each independently chooses:
+
+- `contribute`: explicitly authorize and execute donation of *their own* unit
+  once the complete batch has arrived;
+- `keep`: retain their unit.
+
+Unlike Bellwether's request/accept/transfer/work stages, this contract makes the
+choice itself authorization for immediate execution. There are no promises,
+watch costs, hidden material effects, majority seizure or claimed social welfare
+metrics. A member's choice cannot supply another member's consent.
+
+From the contribution checkout:
+
+```sh
+python -m pip install -e '.[dev]'
+python -m concordia.examples.bellwether.council --output runs/council-fixture
+```
+
+The command uses standard `NoLanguageModel`, fixed choice ordering and zero
+fixture embeddings. Every fixture actor picks the first choice, `contribute`.
+Expect one completed simultaneous round, three actions, Community3 / members0,
+and the original3 units conserved. Outputs:
+
+- `trace.json` and `trace.html`: standard SimulationLog exports;
+- `outcome.json`: fixture label, complete flag, round count, decisions and
+  inventory for this declared case.
+
+The output proves software wiring and accounting, not cooperation among people.
+One round is a bound, not a method for hiding incomplete results: check
+`complete`, participant set and recorded inventory.
+
+## Composition, reuse and failure semantics
+
+`council.configuration()` returns a fresh standard Config and CouncilLedger.
+It composes existing minimal actors, SwitchAct, NextActingAllEntities,
+FixedActionSpec, MakeObservation/ObservationQueue and Inventory.apply.
+CouncilLedger implements only the *scenario-specific* complete-batch rule.
+The executable uses generic.Simulation with standard Simultaneous; no custom
+engine or server is introduced.
+
+All member/spec names are known before execution. Inputs are exact validated
+choices. The engine may omit a failed actor task from its batch; the ledger
+therefore rejects incomplete, duplicate, unknown or malformed batches **before**
+any inventory mutation. A single Inventory.apply validates all contribution
+deltas. Batch arrival/line ordering does not change the resulting balances.
+Re-resolving the identical complete batch cannot spend resources twice.
+An invalid batch raises an error; no silent partial round or inferred vote is
+treated as success.
+
+The fixed initial public observation contains rules, not other actors' current
+choices. Actions are exposed to the GM only for collective resolution; this
+example has no public browser view or per-user authentication of its own.
+Raw developer traces can contain actor context. Do not publish them unchanged
+if adding private information.
+
+## Plug in real policies or human input
+
+Use the same returned Config with a configured standard language model for
+actors, retaining the explicit moderator components. Reuse the local timeout,
+call-limit and profiling wrappers in `run.py`; a live sample is not a guarantee
+of the all-contribute fixture outcome. Do not call the fixture a live model.
+
+For human inputs:
+
+```python
+from concordia.environment.engines import simultaneous
+from concordia.examples.bellwether import council
+from concordia.prefabs.simulation import generic
+
+config, ledger = council.configuration(
+    human_readers={'Nell': nell_input, 'Sam': sam_input}
+)
+simulation = generic.Simulation(
+    config, model, embedder, engine=simultaneous.Simultaneous()
+)
+log = simulation.play(max_steps=1)
+```
+
+Readers implement the existing HumanInput protocol and must be independently
+routed/thread-safe. Both can be pending concurrently; **do not share one
+blocking terminal prompt or assume the sequential browser's one-active-turn
+projection supports this council unchanged**. The main multiplayer transport
+remains built for Bellwether's ordered night. HumanAct's normal choice validation
+remains in force; other actors keep their standard policies.
+
+## Making another analogous example
+
+1. State the timing semantics: sealed simultaneous intentions, sequential
+   observable moves, or truly asynchronous interactions.
+2. Use standard prefabs and choose the standard engine matching those semantics.
+3. Define what a choice authorizes, what is only speech, and what evidence
+   material transitions need. Keep rules, beliefs, enforcement and compliance
+   distinct.
+4. Test missing/failed actor behavior, partial effects, conservation, privacy,
+   scheduling boundaries and termination before interpretation.
+5. Record engine/model/config/revision and full private traces, then produce
+   intentionally sanitized research outputs. Seeds do not make hosted models
+   deterministic, nor do traces create empirical warrant.
+
+For example, the same council contract can teach independent mutual-aid
+contributions or a cooperative reserve decision. An institutional dispute with
+later observable replies better fits sequential turns. Asynchronous emergency
+reports need their own thread-safe state/observation design; they are a future
+example, not an untested toggle offered here. Component serialization alone
+does not establish engine/checkpoint continuation or scientifically comparable
+branches.

--- a/concordia/examples/bellwether/GAME.md
+++ b/concordia/examples/bellwether/GAME.md
@@ -199,3 +199,10 @@ ConcatAct policy. `basic.Entity` now supports `extra_components` and
 This supplies each resident’s account, affiliations, and scenario instructions
 without copying the basic prefab or silently ignoring configuration. Default
 and injected-policy regressions accompany both advertised configurations.
+
+
+## Two human roles
+
+See [MULTIPLAYER.md](MULTIPLAYER.md) for optional host-approved Coordinator/Nell
+play, private role journals, Android controls, and the HTTPS boundary. Omit
+`--multiplayer` for the unchanged single-human game.

--- a/concordia/examples/bellwether/GAME.md
+++ b/concordia/examples/bellwether/GAME.md
@@ -218,3 +218,31 @@ recognition is not assumed.
 The [researcher starter kit](RESEARCHER.md) maps the architecture and provides
 tested mutual-aid, resource-governance and institutional-dispute variants,
 with explicit assumptions and extension boundaries.
+
+
+## First-play guidance and free interpretation
+
+The role banner states whether this is single-player (human Coordinator plus
+four computer-controlled residents) or a shared night (human Coordinator and
+Nell plus three computer-controlled residents). Fixture residents are labelled
+scripted, not live-model results. **How to play your role** explains your own
+controls; spectators see public information and no action controls.
+
+The Coordinator can type an attempt and choose **Check interpretation · free**.
+This calls the same existing `game.preview` parser available to the attached
+CLI. It does not send an action, reserve resources, spend a choice or predict
+consent/success. Requests, accepted commitments, transfers, performed repairs,
+allocations and service promises stay distinct. A message to everyone is public,
+even if typed with the `message` prefix. Literal speech stays literal text.
+
+Only **Send action** submits an attempt. Checking first is optional. Editing the
+draft or changing turn/role invalidates old interpretations; a delayed reply
+cannot overwrite the interpretation of a newer draft. Connection loss cancels
+the pending preview, and saved drafts reappear only after the service identifies
+the session/role on reconnect. Nell keeps the structured accept/decline/speak UI,
+not the Coordinator's action parser.
+
+Browser regression checks cover the standard service/HTTP parser, free-query
+state equality, malformed/literal messages, stale delivery, reconnect and actual
+host-approved Nell/spectator pages with simulation execution prohibited. They do
+not establish physical Android usability or replace full played-night evidence.

--- a/concordia/examples/bellwether/GAME.md
+++ b/concordia/examples/bellwether/GAME.md
@@ -212,3 +212,9 @@ play, private role journals, Android controls, and the HTTPS boundary. Omit
 [Local voice controls](VOICE.md) add opt-in spoken observations and editable
 dictation on supported devices, retaining full text fallback. Android on-device
 recognition is not assumed.
+
+## Contributor recipes
+
+The [researcher starter kit](RESEARCHER.md) maps the architecture and provides
+tested mutual-aid, resource-governance and institutional-dispute variants,
+with explicit assumptions and extension boundaries.

--- a/concordia/examples/bellwether/GAME.md
+++ b/concordia/examples/bellwether/GAME.md
@@ -206,3 +206,9 @@ and injected-policy regressions accompany both advertised configurations.
 See [MULTIPLAYER.md](MULTIPLAYER.md) for optional host-approved Coordinator/Nell
 play, private role journals, Android controls, and the HTTPS boundary. Omit
 `--multiplayer` for the unchanged single-human game.
+
+## Optional voice
+
+[Local voice controls](VOICE.md) add opt-in spoken observations and editable
+dictation on supported devices, retaining full text fallback. Android on-device
+recognition is not assumed.

--- a/concordia/examples/bellwether/GAME.md
+++ b/concordia/examples/bellwether/GAME.md
@@ -1,0 +1,201 @@
+# A night at Bellwether
+
+You are the emergency coordinator of a small island community. The game runs
+from **Dusk → High Tide → Before Dawn → dawn**, with four consequential choices
+per watch. Looking at the coastal map and resident cards is free. A refused
+request may cost a choice; an ambiguous command does not.
+
+This is a fictional interactive scenario demonstrating standard Concordia
+composition, not a model validated against human behavior. The original
+one-turn `--mode slice` remains available; it is not the full game.
+
+## Start from this contribution's source checkout
+
+```sh
+python -m pip install -e '.[dev]'
+python -m concordia.examples.bellwether.run --mode fixture --editor-port 8786 --player-port 8787 --output runs/bellwether-fixture
+```
+
+Open <http://127.0.0.1:8787> to play and <http://127.0.0.1:8786> for the
+developer editor. **Begin the night** (or the editor's `run.start`) starts
+exactly one run. Reopening a tab does not restart it. The fixture banner denotes
+deliberately cooperative, programmed responses, never a live model.
+
+For live residents, first make an existing local Ollama model available:
+
+```sh
+python -m concordia.examples.bellwether.run --mode live --model llama3.2:3b --resident-prefab minimal --editor-port 8786 --player-port 8787 --output runs/bellwether-live
+```
+
+No paid backend is required. This command uses the existing Ollama adapter;
+requests have a 90-second HTTP timeout, 256 output-token cap, and a 256-call
+wrapper limit. The standard per-run profiler records timings and token
+**estimates**, not measured billing. Exhausted/invalid output cannot grant
+consent. Model failures end the run with the retained journal and developer
+error; there is no hidden fixture fallback. Use Ctrl-C to close the owned
+listeners. A new process starts a new night; checkpoint continuation is not
+implemented by this example.
+
+The standard `basic` prefab is an alternative via `--resident-prefab basic`.
+Its perception components make additional model calls. Four residents share the
+selected architecture but have separate standard memory, observations, goals,
+accounts and affiliations. Developers can configure their individual instance
+params in `game_prefab.configuration`. The human uses HumanAct, not an LLM.
+The GM uses independently composed SwitchAct policies and explicit scenario
+rules, not the resident decision logic.
+
+## Playing
+
+Select suggestions to fill the input, or enter a command and your own words.
+There is deliberately a small, conservative physical-action vocabulary.
+Unrecognized or ambiguous physical instructions ask for clarification **before**
+waking the pending human turn. The parser is not a general natural-language
+physical simulator.
+
+| Intent | Example |
+|---|---|
+| Public conversation / open-ended proposal | `tell everyone: Can we find a plan that protects boats and families?` |
+| Address one resident publicly | `tell Mara: What worries you about the cooperative?` |
+| Private conversation | `message Nell: I want to hear your account.` |
+| Ask for material consent | `ask Nell for fuel and part` |
+| Ask for labor consent | `ask Ivo to repair` |
+| Collect the agreed resources | `transfer reserve and part` |
+| Ask Ivo to carry out accepted work | `order repair` |
+| Allocate this watch's supply | `allocate all` or `allocate shelter and cold store` |
+| Make your own promise | `promise shelter` |
+| Withdraw your latest unfulfilled promise | `withdraw my promise` |
+| Advance without agreement | `wait` |
+
+`propose to everyone: …` preserves creative prose for resident discussion.
+It cannot invent a new action mechanic or bypass resource/consent checks.
+Residents respond in their own voices. An explicit structured `accept` records
+only that resident's requested commitment; spoken claims alone are not consent.
+Residents may decline, counter, or revoke their own unfulfilled commitment.
+The next proposal can take their response into account; acceptance is not forced.
+
+Nell's material commitment releases two fuel and the spare part. Collecting them
+is a separate action. Ivo's labor commitment is distinct from performing the
+repair: he may still refuse the work order. Repair requires accepted Ivo labor,
+the delivered part, and actual performance **before Before Dawn**. A late repair
+does not rewrite already-resolved services. General item trades and arbitrary
+new engineering procedures are intentionally not silently adjudicated as valid.
+
+## Material rules and two strategies
+
+The generator has **6 fuel**, Nell has **2 reserve**, and there is **1 spare
+part**. The beacon, shelter and cold store demand one fuel in each of three
+watches: baseline demand 9. A completed repair removes only the final beacon
+demand. The standard Inventory tracks Generator, Nell, Ivo and Used accounts;
+fuel and the part never appear from narration. Requested allocation order
+determines supply priority if there is insufficient fuel. Consumption occurs
+at watch boundaries, after that choice's bounded resident responses.
+
+Two useful plans, not guaranteed live social outcomes:
+
+1. **Negotiate full service:** in Dusk ask Nell for fuel/part, collect them,
+   ask Ivo to repair, then wait. In High Tide order the accepted repair;
+   leave all facilities allocated and use the other choices for promises or
+   discussion. Keep all allocated Before Dawn. With Nell's acceptance and
+   Ivo's accepted **and performed** work, 8 fuel supplies all 9 facility-watches.
+2. **Prioritize shelter and livelihoods:** allocate shelter and cold store in
+   each watch. This consumes 6 fuel, leaves Nell's reserve untouched, but
+   records three missed beacon watches and the associated harbor consequences.
+
+The fixture demonstrates both. Live residents can defeat either social plan
+through refusal or changed commitments. Waiting always allows progression to
+dawn even without agreement. Dawn shows actual service, fuel, repair,
+honored/broken/revoked/unfulfilled commitments, and each resident's response.
+Missed beacon service delays safe arrivals; missed shelter service removes
+heating; missed cold-store service risks stock. These are explicit fictional
+scenario consequences, not predicted casualties or economic estimates.
+
+At High Tide a **disputed** account of the previous storm is delivered to its
+configured recipients. It does not establish objective truth or rewrite
+memory. Use `--dispute-file account.json`:
+
+```json
+{"text": "Mara says the cooperative did not help; Nell disputes that account.", "recipients": ["Coordinator", "Mara", "Nell"]}
+```
+
+The object is validated before building. Institutions distinguish charter,
+membership, enforcement and who knows about the disputed account. The default
+delegates reserve custody to Nell and labor consent to Ivo; membership does not
+grant someone else's consent. Interaction records describe changing positions
+without imposing scalar trust or a single psychological theory.
+
+## One service, three clients
+
+The existing `OperationService`, `SimulationServer` and attached
+`concordia-session` CLI remain the authority. The player GUI uses the same
+`human.respond` handler available on its listener. Developer GUI/CLI edits use
+the same designated `component.edit` as [the original slice](README.md).
+
+Additional operations:
+
+| Operation | Audience | Meaning |
+|---|---|---|
+| `game.begin` | player | Explicit one-time start |
+| `game.preview` | player/developer | Parse an attempt without effects |
+| `run.resume` | developer | Resume the existing paused worker; never replay |
+
+```sh
+concordia-session --url http://127.0.0.1:8786 discover
+concordia-session --url http://127.0.0.1:8786 state
+concordia-session --url http://127.0.0.1:8786 watch
+concordia-session --url http://127.0.0.1:8787 state
+```
+
+A mutation uses the discovered arguments plus the current references/revision
+and an exact retry key, as in README.md. Retry the identical request after a
+lost response; stale edits fail atomically. Selecting Pause does **not** permit
+editing while a worker or human request is still active. The designated edit is
+safe before Run or after the worker has joined. Initial configuration remains
+distinct from runtime. This is not a general mid-run transaction or checkpoint
+interface.
+
+Player HTML/JSON/SSE contain only public facts, the coordinator's delivered
+observations and messages they participated in. The standard observation queue
+separately delivers private events to the relevant residents. Developer
+checkpoints and traces stay on the trusted editor listener; they are never
+hidden in player HTML. Both listeners bind to loopback. This example changes no
+routes, account configuration, lobbies or access controls.
+
+## Verification and limits
+
+```sh
+python -m pip install pytest playwright
+python -m playwright install chromium
+python -m pytest -n 0 concordia/examples/bellwether concordia/contrib/language_models/ollama/ollama_model_test.py
+```
+
+Rule tests exercise conservation, both strategies, refusal, commitment
+revocation, late/missing-part repairs, malformed resident output, atomic
+clarification, recipient privacy and fresh ownership. Chromium tests use real
+components, HTTP, SSE and attached CLI with a synthetic pending input and
+explicitly forbid simulation execution.
+
+Separate browser walkthroughs executed both complete fixture strategies and a
+local live night through standard Simulation/Sequential: 12 human choices each,
+four dawn responses, reload/reconnect recovery, matching CLI snapshots and no
+JavaScript errors. The live run used 12 successful local llama3.2:3b calls
+(about 2.9–6.0 seconds each); Nell declined and no reserve transfer or repair
+was fabricated. Live timing is one machine/run observation, not a guarantee.
+Automated browser submission timing is not a human play-duration measurement.
+
+Logs are standard `simulation.json` and `log.html`; `outcome.json` adds
+the explicit night result, per-step timings, model profile and backend label.
+The 15–25 minute human experience is a target, **not yet measured**. The full
+Bellwether editor/showcase A–H, isolated checkpoint branches, experiments,
+authoring assets/undo/breakpoints, every editor-family parity and fresh
+environment export remain subsequent work. No original workflow acceptance
+baseline is upgraded merely because this bounded game now reaches dawn.
+
+### Standard basic extensions
+
+The optional basic residents retain their standard perception chain and normal
+ConcatAct policy. `basic.Entity` now supports `extra_components` and
+`extra_components_index` using the **same extracted assembly helper** as
+`minimal.Entity`; basic defaults and minimal insertion semantics are unchanged.
+This supplies each resident’s account, affiliations, and scenario instructions
+without copying the basic prefab or silently ignoring configuration. Default
+and injected-policy regressions accompany both advertised configurations.

--- a/concordia/examples/bellwether/MULTIPLAYER.md
+++ b/concordia/examples/bellwether/MULTIPLAYER.md
@@ -1,0 +1,91 @@
+# A shared Bellwether night
+
+This optional mode replaces **only Nell’s acting policy** with HumanActComponent.
+A second person controls Nell while the coordinator makes the twelve watch
+choices. Mara, Ivo and Sam keep the selected standard minimal/basic policies.
+Each human has an independent existing HumanSession. Standard Sequential still
+chooses one entity at a time; there is no separate multiplayer engine.
+
+## Local start
+
+From a source checkout with the Bellwether dependencies installed (see GAME.md):
+
+```shell
+python -m concordia.examples.bellwether.run --mode fixture --multiplayer --editor-port 8788 --player-port 8789 --output runs/shared-night
+```
+
+`fixture` explicitly scripts the remaining AI residents. Use `--mode live
+--model llama3.2:3b` for local Ollama, subject to GAME.md’s model limits. The game
+waits for explicit Begin; neither opening a page nor reloading launches a run.
+Omit `--multiplayer` to retain single-player behavior.
+
+1. The host opens the local editor on port8788. Do **not** publish this listener.
+2. Players open the player page on port8789, enter a name for the host and select
+   Coordinator or Nell. A separate spectator browser can request public-only
+   access. Use separate browser profiles/devices, not two tabs sharing cookies,
+   for separate people.
+3. In the editor’s authoritative state, the host finds `join_requests`. After
+   confirming the intended person out of band, choose `session.approve`, enter
+   that request’s public `id`, and Apply. A browser name is NOT identity proof;
+   do not approve an unknown request because it claims a familiar name.
+4. After both players are approved, either may Begin. The coordinator can ask
+   Nell for fuel and part. Only Nell sees her pending decision control and full
+   own context. Nell may Accept, Decline or offer different terms. Acceptance
+   records consent, not a completed transfer. The coordinator must separately
+   carry out an authorized transfer.
+5. Public discussions appear in both journals; private messages appear only to
+   their recipients. A spectator sees only events delivered to **all** actors,
+   never private accounts or pending human IDs/contexts, and cannot mutate.
+6. Reload or close/reopen a tab to reconnect. This browser retains its role and
+   the server retains its pending turn; draft text is per-session/per-role.
+   Clearing cookies requires a fresh host-approved request. There is no automatic
+   AI takeover or simulated action when a player disconnects.
+7. To move a role to a new device, host `session.revoke` the old request and approve
+   the new one. The game continues waiting for the same pending input. Existing
+   streams lose authorization on their next delivered snapshot. Already viewed
+   data cannot be retracted from a participant’s memory/device.
+
+## HTTPS / Android delivery
+
+This prototype uses established opaque HTTP cookie sessions (Python `secrets`
+and `http.cookies`), not URL credentials or untrusted client role claims. Cookies
+are HttpOnly and SameSite=Strict; role authorization stays in server memory.
+Authenticated snapshots are never cached; SSE re-resolves authorization at each
+delivery. Only the trusted host can approve or revoke a role. Sessions and replay
+keys last for this process, not a disk-restorable account/checkpoint service.
+Admission capacity is128 browser sessions; there is no unbounded guest table or
+silent eviction of an existing player.
+
+For a tailnet HTTPS reverse proxy, set `--public-origin https://your-tailnet-host`
+and `--cookie-path /bellwether/` on a **new** server invocation. Route only that
+player prefix to port8789, stripping the prefix. The page uses relative API URLs.
+These options use Secure cookies and check the exact configured Origin for POSTs;
+request Forwarded headers do not choose or bypass that origin. A path is not part
+of `--public-origin`. Keep the developer listener loopback-only/unproxied.
+Inspect and preserve existing routes; no public Funnel is needed or supported.
+This is host-approved session authorization on top of your tailnet boundary,
+not a claim that a local developer port is remotely authenticated. Never serve
+private play over unencrypted remote HTTP. Local testing without public-origin
+uses non-Secure cookies only on the default127.0.0.1 listeners.
+
+The touch layout includes a responsive facility map,44px-or-larger player
+buttons, visible role/turn status, per-role drafts, a bottom action jump, and
+viewport-resizing/scrollable forms for virtual keyboards. Chromium mobile
+emulation is not evidence of actual Android/Pixel keyboard behavior; see recorded
+validation. No microphone or automatic audio is enabled by this increment.
+
+## Shared operations and boundaries
+
+The host GUI and attached `concordia_session` CLI call the same registered
+`session.approve`/`session.revoke` handlers and revision/retry ledger. Player
+`human.respond` handlers are chosen by the server-resolved role, not a body field.
+The cookie join exchange is authentication setup, not another game mutation API.
+A stale or wrong-role submission has no effects. Repeating a successful envelope
+from the same authorized browser has one effect. Spectators cannot Begin, respond,
+approve roles, or edit components. No private player credentials should be pasted
+into a CLI argument, URL, logs or transcript; use the browser join flow.
+
+Limitations: one shared process, two selected human roles, one approved spectator
+slot, host-mediated enrollment/reassignment, no lobby directory/accounts, no
+cross-server persistence or generalized human-role editor. Arbitrary mechanics,
+checkpoint contracts and BRIEF’s full A–H showcase remain separate work.

--- a/concordia/examples/bellwether/PUBLIC-ACCOUNT.md
+++ b/concordia/examples/bellwether/PUBLIC-ACCOUNT.md
@@ -1,0 +1,73 @@
+# A portable public account
+
+In a full Bellwether night, **Download readable account** saves an offline HTML
+page; **Download public JSON** saves the same public material in a versioned
+machine-readable document. These controls never advance a turn or spend a choice.
+They work during a night and at dawn. An interrupted run is labelled interrupted;
+an unfinished night is not labelled complete.
+
+The export deliberately has fewer fields than the developer trace or a player's
+private journal. It is **not a saved game, checkpoint or executable replay**.
+Do not use it to resume a simulation or infer hidden decisions.
+
+## Public scope, not anonymization
+
+The server reuses `StormNight.view('spectator')`, then selects an explicit
+allowlist of public event text, watch, kind, material inventory, service
+consequences and a small dawn summary. Public events are numbered locally in the
+export; hidden event identifiers and recipients are omitted. Component state,
+private messages, pending action IDs, actor contexts, service identity, cookies,
+hostnames and timing metadata are not exported.
+
+The same operation returns the same public bytes for a player, an approved
+resident, an approved spectator or the local developer. Visitors and revoked
+browser sessions cannot call it. There is no option to request another player's
+private account. The public timeline can still include a participant's names or
+anything they said publicly: review before sharing. Visibility filtering is not
+anonymization, and the underlying model may choose to disclose information in
+public speech. No automatic sharing/upload happens.
+
+HTML is self-contained UTF-8 with escaped text and no JavaScript, external
+resources, forms, frames or embedded live service data. It can be opened offline.
+The UI retains your current draft when a download fails, and refuses a delayed
+download after a connection/role change.
+
+## Attached CLI and research tooling
+
+Use the existing CLI against the **trusted local developer listener** of a
+full-night service built from this checkout, not the one-turn slice. Do not expose
+that listener to other players. With the service already running:
+
+```sh
+printf '%s\n' '{"operation":"game.public_account","arguments":{"format":"json"}}' |
+  python -m concordia.command_line_interface.concordia_session --url http://127.0.0.1:8784 call > public-response.json
+python -c 'import json,pathlib; x=json.loads(pathlib.Path("public-response.json").read_text()); pathlib.Path("bellwether-public-account.json").write_text(x["result"]["content"], encoding="utf-8")'
+```
+
+Choose `html` instead to obtain the readable artifact. The shared operation's
+`result` has `filename`, `media_type` and `content`; save **only content**.
+The ordinary operation envelope contains process references for the attached
+transport, and is not the shareable artifact. No mutation revision or retry key
+is needed, and unknown formats are rejected with no effects.
+
+The document schema is `bellwether-public-account/v1`. It records fixture/live
+mode, in-progress/interrupted/completed status, public events and material
+consequences. Export order is public event order, not wall-clock or causal
+evidence. Multiple exports of an unchanged state are identical. Account numbers
+are local display order, not references into private traces. New versions should
+change the schema name before changing this contract.
+
+## Evidence and limits
+
+Tests use real components, the standard HTTP/operation/CLI path and actual
+Chromium downloads, but **seeded records with simulation execution prohibited**.
+They verify cross-role equality, private marker absence, error atomicity,
+read-only state, offline literal markup and mobile width. They are not human
+usability evidence or an additional live game. Prior fixture/live night evidence
+remains separately documented.
+
+The material ledger reports scenario rules; actor prose is not empirical
+validation of real societies. An exported account neither certifies the truth of
+the previous-storm dispute nor makes hosted model output deterministic. Full
+checkpoints, intervention provenance and isolated continuation need separate
+contracts before experimental branch comparison.

--- a/concordia/examples/bellwether/README.md
+++ b/concordia/examples/bellwether/README.md
@@ -148,3 +148,9 @@ branches, experiments, measurement/export and fresh-environment showcase tours.
 The full Bellwether A–H acceptance and six-workflow baseline are not satisfied by
 this slice. Mechanics values are explicit initial fixture configuration only;
 no narrative can be interpreted as a material or consent change.
+
+## Portable public account
+
+Full-night players and approved spectators can download a script-free public
+timeline and JSON accounting without sharing private journals. See
+[PUBLIC-ACCOUNT.md](PUBLIC-ACCOUNT.md) for scope, CLI use and non-replay limits.

--- a/concordia/examples/bellwether/README.md
+++ b/concordia/examples/bellwether/README.md
@@ -1,4 +1,9 @@
-# Last Light at Bellwether — shared-service slice
+# Last Light at Bellwether
+
+**Full three-watch game:** see [GAME.md](GAME.md) for the playable fixture and
+local live-resident modes, the two strategies, and measured validation limits.
+
+## Original shared-service slice (retained with --mode slice)
 
 A **one-turn fixture**, not the complete live game or a research experiment.
 This example teaches a reusable boundary between a human player, the standard
@@ -10,7 +15,7 @@ Concordia visual editor, and a noninteractive attached CLI. All three share one
 
 ```sh
 python -m pip install -e '.[dev]'
-python -m concordia.examples.bellwether.run --editor-port 8784 --player-port 8785 --output runs/bellwether-fixture
+python -m concordia.examples.bellwether.run --mode slice --editor-port 8784 --player-port 8785 --output runs/bellwether-fixture
 ```
 
 Open <http://127.0.0.1:8784> for the editor and
@@ -135,9 +140,9 @@ A separate manually launched one-turn fixture walkthrough verifies human input,
 standard sequential resolution and logs. Automated checks are not human usability
 or social/scientific validation.
 
-**Still backlog:** the full 15–25 minute three-watch game, live resident decisions,
-consent/commitment/compliance mechanics, fuel conservation at watch boundaries,
-repair/work orders, disputed-account recipients, dawn outcomes, project authoring,
+**Beyond the original one-turn mode:** three-watch accounting, consent/work,
+live residents, two strategies and dawn are now provided by [GAME.md](GAME.md).
+Human 15–25 minute usability remains unmeasured. Still backlog: project authoring,
 full editor-family parity, assets/undo/breakpoints, isolated checkpoint continuation,
 branches, experiments, measurement/export and fresh-environment showcase tours.
 The full Bellwether A–H acceptance and six-workflow baseline are not satisfied by

--- a/concordia/examples/bellwether/README.md
+++ b/concordia/examples/bellwether/README.md
@@ -1,0 +1,145 @@
+# Last Light at Bellwether — shared-service slice
+
+A **one-turn fixture**, not the complete live game or a research experiment.
+This example teaches a reusable boundary between a human player, the standard
+Concordia visual editor, and a noninteractive attached CLI. All three share one
+`OperationService`; the two HTTP listeners are instances of the existing
+`SimulationServer`, not independent simulations.
+
+## Run from this contribution's source checkout
+
+```sh
+python -m pip install -e '.[dev]'
+python -m concordia.examples.bellwether.run --editor-port 8784 --player-port 8785 --output runs/bellwether-fixture
+```
+
+Open <http://127.0.0.1:8784> for the editor and
+<http://127.0.0.1:8785> for the player. **No simulation executes on opening**:
+select `run.start` in the editor's operation panel and Apply once. Then submit
+one proposal from the player screen. The run uses `Simulation.play`, standard
+`Sequential`, minimal actor prefabs, `HumanActComponent`, `SwitchAct`,
+`MakeObservation(allow_llm_fallback=False)`, and fixed context components.
+Four resident actors are instantiated but do not act in this slice. The only
+acting entity is the human coordinator. `NoLanguageModel` is used; no API key,
+paid model, or model download is required.
+
+The fixture acknowledges the action without granting anyone's consent,
+transferring fuel, doing repair work, or predicting a resident's behavior.
+Standard `SimulationLog.to_json()` and `to_html()` outputs are written to the
+chosen directory. Ctrl-C stops these private listeners and cancels pending input.
+
+## A shared edit in both directions
+
+Before Run, select `component.edit` in the editor. Its only parameter, `value`,
+is the exact replacement for Mara's **designated Constant context component**
+`PreviousStormAccount.state`. This is **not an arbitrary episodic-memory edit**.
+Quotes, line breaks, Unicode and literal markup are preserved. Initial prefab
+configuration, other components, and other residents' knowledge stay unchanged.
+The event records before/after, audience origin, operation ID and effective time.
+The updated snapshot appears in all editor clients and the attached CLI:
+
+```sh
+concordia-session --url http://127.0.0.1:8784 discover
+concordia-session --url http://127.0.0.1:8784 state > state.json
+concordia-session --url http://127.0.0.1:8784 watch
+```
+
+For an attached edit, prepare a JSON envelope using a freshly queried revision:
+
+```sh
+python - <<'PY'
+import json
+from pathlib import Path
+state = json.loads(Path('state.json').read_text())
+request = {
+    'operation': 'component.edit',
+    'arguments': {'value': 'Mara remembers a disputed account.\nNo one else is informed.'},
+    'references': state['references'],
+    'revision': state['revision'],
+    'retry_key': 'my-edit-1',
+}
+Path('edit.json').write_text(json.dumps(request, ensure_ascii=False))
+PY
+concordia-session --url http://127.0.0.1:8784 call --input edit.json
+concordia-session --url http://127.0.0.1:8784 call --input edit.json
+```
+
+The second call returns the **original** result, not a second edit. Standard
+input is supported with `call --input -`. Use `python -m
+concordia.command_line_interface.concordia_session` if running without installing
+the console entry point. Watch emits one JSON object per SSE state update.
+Timeout/disconnection has a nonzero exit and requires reattaching; it is not a
+durable event-replay cursor. Errors are structured JSON on stderr: exit 2 for
+an HTTP rejection, exit 3 for input/connection errors. A stale revision requires
+querying current state and reviewing the edit, not blindly changing its revision.
+
+## Supported operation inventory
+
+| Operation | Audience | GUI | CLI |
+|---|---|---|---|
+| `session.inspect` | developer | operation selector / state panel | `call` |
+| `component.edit` | developer | exact text field + Apply | `call` |
+| `run.start` | developer | explicit one-turn Run | `call` |
+| `run.pause` | developer | request pause | `call` |
+| `player.view` | player | player screen / filtered state | `call` on player port |
+| `human.respond` | player | action box | `call` on player port |
+
+`discover`, `state`, and `watch` use `/api/operations`, `/api/state` and
+`/api/events`. Every mutation uses `/api/dispatch` with the same registry input
+schema. Only required scalar string/integer arguments are currently supported;
+this is **not a general JSON Schema validator**. Each descriptor documents the
+input fields. Session/project/run/branch references are explicit and
+process-lifetime, not checkpoint identifiers. Retry keys are retained for that
+lifetime; if the ledger reaches capacity, new mutations are rejected rather than
+evicting replay protection.
+
+## Execution and privacy boundaries
+
+A pause flag does not prove quiescence. This first increment deliberately rejects
+edits while the execution thread is alive, **including when awaiting a human**.
+It permits the designated edit before starting, and after the worker has fully
+returned with the controller paused. One run cannot be replaced or restarted.
+Continuing, restoring, cancelling model calls, or editing in-flight work is not
+supported. No engine or StepController stepping semantics are changed.
+
+The editor's graph/inspector remains a read-only view of initial prefab data;
+its attached operation panel explicitly shows last-safe runtime state and traces.
+Legacy run/edit endpoints are disabled for capability-bound listeners so no GUI
+or CLI caller can bypass revisions or the quiescence guard. Normal
+`SimulationServer` users without an operation service keep the existing routes.
+
+The player listener delivers only public scenario configuration and the human
+coordinator's own `HumanSession` snapshot. It never sends developer checkpoints,
+resident private observations, or the edited private account. Unknown/legacy
+player routes are denied; the player cannot select a developer audience in JSON.
+SSE uses that same filtered view and replays a current snapshot on reconnect.
+The service chooses audiences **at listener construction**, not from user input.
+These loopback listeners are not authentication against another process on the
+same machine; the developer port is for a trusted author. Do not publicly expose
+it. The example creates no tailnet route, lobby, credential, or access-control
+configuration. Player and developer browsers must use their designated ports.
+
+## Tests and scope limits
+
+```sh
+python -m pip install pytest playwright
+python -m playwright install chromium
+python -m pytest -n 0 concordia/examples/bellwether/service_test.py concordia/examples/bellwether/browser_test.py
+```
+
+Tests use real standard components and HTTP/CLI/Chromium, but prohibit
+`Simulation.play` in the service/browser suite. They verify exact edit isolation,
+fresh ownership, stale/invalid atomicity, simultaneous retries, actual worker
+liveness versus pause, GUI/CLI semantic parity, reconnect, and player filtering.
+A separate manually launched one-turn fixture walkthrough verifies human input,
+standard sequential resolution and logs. Automated checks are not human usability
+or social/scientific validation.
+
+**Still backlog:** the full 15–25 minute three-watch game, live resident decisions,
+consent/commitment/compliance mechanics, fuel conservation at watch boundaries,
+repair/work orders, disputed-account recipients, dawn outcomes, project authoring,
+full editor-family parity, assets/undo/breakpoints, isolated checkpoint continuation,
+branches, experiments, measurement/export and fresh-environment showcase tours.
+The full Bellwether A–H acceptance and six-workflow baseline are not satisfied by
+this slice. Mechanics values are explicit initial fixture configuration only;
+no narrative can be interpreted as a material or consent change.

--- a/concordia/examples/bellwether/RESEARCHER.md
+++ b/concordia/examples/bellwether/RESEARCHER.md
@@ -243,3 +243,9 @@ counterexamples, separate rules from beliefs/enforcement/compliance, and seek
 external evidence. No scripted scientific conclusion, policy recommendation,
 trust score, human usability result or social generalization follows from this
 fixture, these tests, or a single local-model night.
+
+## Standard-engine companion
+
+[ENGINES.md](ENGINES.md) provides a runnable simultaneous resource council,
+actual scheduling/API differences, and explicit asynchronous limitations.
+The main Bellwether night remains Sequential.

--- a/concordia/examples/bellwether/RESEARCHER.md
+++ b/concordia/examples/bellwether/RESEARCHER.md
@@ -1,0 +1,245 @@
+# Bellwether researcher starter kit
+
+Bellwether is a fictional teaching scenario and software demonstration. Its
+records establish what *this program* resolved, not facts about a society.
+These recipes help contributors make explicit changes without replacing
+Concordia's engine or confusing narrative with enforcement.
+
+## Start here
+
+From this contribution's source checkout:
+
+```sh
+python -m pip install -e '.[dev]'
+python -m pytest -o addopts='' concordia/examples/bellwether/researcher_test.py -q
+```
+
+The tests construct standard entities and check declared rules; they do not
+call a live model or launch a simulation. To play the unmodified browser game,
+use [GAME.md](GAME.md), or [MULTIPLAYER.md](MULTIPLAYER.md) for host-approved
+Coordinator/Nell sessions. Voice is an optional [presentation aid](VOICE.md).
+
+### A terminal teaching case
+
+Save this as `my_case.py` in your checkout:
+
+```python
+from pathlib import Path
+import numpy as np
+
+from concordia.environment.engines import sequential
+from concordia.examples.astral_canticle.terminal import TerminalInput
+from concordia.examples.bellwether import game_prefab, researcher
+from concordia.prefabs.simulation import generic
+
+case = researcher.prepare_case('institutional-dispute', TerminalInput())
+simulation = generic.Simulation(
+    case.config,
+    game_prefab.FixtureModel(),  # scripted decisions, not live residents
+    lambda text: np.zeros(8),   # fixture-only embedding, no semantic retrieval
+    engine=sequential.Sequential(),
+)
+log = simulation.play(max_steps=64)
+output = Path('runs/my-case')
+output.mkdir(parents=True, exist_ok=True)
+(output / 'trace.json').write_text(log.to_json(), encoding='utf-8')
+(output / 'trace.html').write_text(log.to_html(), encoding='utf-8')
+```
+
+Run `python my_case.py`. The standard human component prints the controlled
+entity's ordered context and asks for your text. Use the commands in GAME.md.
+The scripted fixture cooperates on requests; use it to check wiring, not to
+measure social strategy. A max-step limit may stop before dawn; inspect
+`case.world.finished` rather than calling a partial trace a complete night.
+
+The recipe helper only prepares a standard Config and fresh scenario component.
+It does **not** run an engine, start a server, upload data, import user-supplied
+Python, or serialize live human readers. Call it anew for every run; do not
+reuse a built Config's attached components. These are headless/terminal recipe
+examples, not a new browser project editor. The browser's existing `--dispute-file`
+option supports the delivered-account variation; the new recipes are not
+silently added as browser CLI presets.
+
+## Architecture and ownership
+
+```mermaid
+flowchart TD
+  R[Trusted recipe / initial assumptions] --> C[Config + InstanceConfig]
+  C --> S[standard generic.Simulation]
+  S --> A[standard minimal/basic actors]
+  S --> G[GM: minimal + SwitchAct]
+  A --> H[HumanAct or ConcatAct]
+  G --> W[StormNight scenario rules]
+  W --> I[standard Inventory.apply]
+  W --> O[standard ObservationQueue / MakeObservation]
+  S --> E[standard Sequential]
+  E --> L[SimulationLog / JSON / HTML]
+  B[Browser / attached CLI] --> P[shared OperationService]
+  P --> Q[standard human inbox]
+  Q --> H
+```
+
+| File / symbol | Responsibility | Must not be treated as |
+|---|---|---|
+| `researcher.prepare_case` | Fresh trusted Config/world and declared initial assumptions | Arbitrary project serialization or experiment runner |
+| `game_prefab.configuration`, `Resident.build` | Standard prefab selection and per-actor goals, private accounts, affiliations and optional human readers | New agent architecture |
+| `game.StormNight` | Explicit agenda, consent, repair, watch accounting, recipient projection | Alternative simulation engine or a social theory |
+| `Inventory.apply` | Atomic validated item deltas | LLM narration of a transfer |
+| `SwitchAct` + `Signal` | GM action-spec, next-actor and termination routing | A human or narrator overriding consent |
+| `MakeObservation` + `ObservationQueue` | Deliver only addressed observations | A globally visible event feed |
+| `generic.Simulation` + `Sequential` | Construct entities, execute standard phases and record logs | A deterministic hosted-model replay promise |
+| `game_service.Game` | One browser run, revisioned operations and lifecycle | Initial-project editing or checkpoint restoration |
+| `multiplayer.SharedGame` | Independent approved role views and existing human inboxes | Remote authentication based on a port or role name |
+| `SimulationLog` | Recorded prompts/events/state evidence | Empirical warrant for a policy conclusion |
+
+The GM and each entity own distinct context components; each new case owns
+its inventory and observation queue. Standard minimal/basic builds retain their
+normal components and acting order. Basic's perceptions make additional model
+calls; enabling a human final action does not automatically disable its
+LLM-backed context processing.
+
+## Included analogous recipes
+
+All cases deliberately retain the five fixed Bellwether role IDs and three
+facility IDs so existing parsing, scheduling and accounting remain meaningful.
+They are variations of one resource-sharing skeleton, not arbitrary-world
+generators.
+
+| Recipe | Explicit change | Expected software effect | Not implied |
+|---|---|---|---|
+| `bellwether` | Original initial context and ledger | Baseline8 fuel,1 part,9 facility-watches | Fixture cooperation predicts people |
+| `mutual-aid` | Ferry evacuation framing, Sam's goal/private report,2 fuel already consumed before play | Generator4 + reserve2 + Used2; only6 usable fuel, so even repair leaves unmet demand | Missing fuel vanished; the rumor is objective fact |
+| `resource-governance` | Proposed transparent reserve charter and Nell's goal | Same text appears in institutional view and member context; dialogue may differ with a live model | New voting, sanction or veto enforcement exists |
+| `institutional-dispute` | Different private recollections; High Tide note goes only to Mara/Nell | Coordinator/Ivo/Sam/spectator do not receive the direct note | Recipients cannot choose later to disclose it; either recollection is true |
+
+`case.manifest` records fixed IDs, engine, human roles, accounting baseline and
+evidence class without exporting private accounts. For mutual aid,
+`epilogue.fuel_used` is the **cumulative Used ledger**, including2 pre-play units.
+Subtract `manifest['fuel_consumed_before_play']` to measure in-run consumption.
+Do not compare it to the baseline as if both started at zero.
+
+## Tested modifications and extension boundaries
+
+### Private information and setting
+
+The recipe changes both the actor's `PreviousStormAccount` Constant and the
+recipient-scoped initial observation. It does not leave a conflicting default
+account in the queue. `StormNight.seed(opening=..., accounts=...)` validates all
+resident names/text before emitting anything. Use `world.emit(..., audience=[...])`
+for delivered facts/claims; a character goal or hidden account is not public.
+Public player projections must not include developer checkpoints or raw logs.
+
+For browser use, `run --dispute-file file.json` accepts exactly:
+
+```json
+{"text":"A disputed claim, not established history.","recipients":["Mara","Nell"]}
+```
+
+This changes a delivered account, not past objective events. Never patch module
+globals to customize simultaneous runs.
+
+### Institutions: rule, belief, enforcement, compliance
+
+`StormNight(..., institutions=[...])` accepts unique named institutions with
+known members and text `rule`/`enforcement` fields. The same per-world list
+feeds member affiliation components and the player view; defaults are unchanged.
+For example:
+
+```python
+institutions = [{
+    'name': 'Mutual aid council',
+    'members': ['Nell', 'Ivo', 'Sam'],
+    'rule': 'Propose public notice before reserve release.',
+    'enforcement': 'Proposal only; existing owner consent remains the gate.',
+}]
+```
+
+Text is an actor-facing institutional description, **not executable authority**.
+Changing actual enforcement requires a reviewed change to the relevant
+`StormNight._human` / `_resident` transitions, explicit new records and tests
+for refusal, revocation, unauthorized attempts and boundary timing. Do not
+replace the consent gate with a prompt asking a narrator to infer compliance.
+Membership, agreement, intended action and performed labor are separate facts.
+
+### Scarcity, repair and outcomes
+
+The supported teaching scarcity variation uses standard inventory transfers to
+record prior consumption. Total conservation stays8 fuel and1 part. Changing
+total resource supply, transfer amounts or facility demand beyond that requires
+coordinated edits to `new_inventory`, invariants, reserve contract, opening,
+repair/boundary rules, UI and outcome definitions. A hidden Constant edit alone
+does not change inventory and must not be reported as a scarcity intervention.
+
+Likewise, changing `CONSEQUENCES` wording changes presentation, not the number
+of supplied facility-watches. Add a new outcome only with an explicit data
+source, denominator and interpretation. Tests should check changed transitions,
+not assert a desired political narrative or winner.
+
+### Actor policy, human roles and roster
+
+```python
+case = researcher.prepare_case(
+    'resource-governance',
+    coordinator_reader,
+    actor_logic='basic',
+    human_readers={'Nell': nell_reader},
+)
+```
+
+Both readers use the existing transport-neutral HumanInput protocol; role
+authorization remains the transport's responsibility. Other residents retain
+ConcatAct. Choose `minimal` or `basic` without copying their build functions.
+Individual trusted InstanceConfig `decision_logic`, `goal` and `account`
+parameters can be edited **before** building Simulation.
+
+For live actors supply a local model through standard
+`Simulation(..., override_agent_model=...)`, retaining the explicit GM policy.
+Reuse the call-limit, profiling and bounded Ollama configuration in `run.py`;
+do not silently fall back to fixture behavior on model errors. Zero embeddings
+in the teaching snippet are not a realistic basic-agent retrieval setup.
+
+Humanizing a known resident via `human_readers` is supported. Arbitrary roster
+size is **not** a one-line Bellwether option: add role/prefab instances, parser
+targets, request ownership, observation recipients, agenda/dawn rules, role UI
+and invariants together. The current browser authorizes only Coordinator/Nell
+plus a spectator. Standard Config supports other entities, but this scenario's
+fixed consent and resource contracts still name Nell/Ivo. Unknown role mappings
+are rejected rather than silently ignored.
+
+### GM policy and other engines
+
+The existing GM composes standard SwitchAct with explicit rules. Alternative
+GM context/action components can be composed through a trusted Config, but must
+implement the selected engine's action-spec and next-actor contracts and
+preserve declared observation/privacy boundaries. A new narrator is not
+permission to grant consent or invent resources.
+
+The main game stays Sequential. Merely passing another engine is not a verified
+variant: different scheduling/action-spec contracts can invalidate an agenda
+designed for one actor at a time. A subsequent standard-engine example should
+document and test those differences, not implement a replacement loop.
+
+## Validation, traces and research limits
+
+`researcher_test.py` constructs every recipe using standard Simulation,
+checks minimal/basic human-vs-AI policies, fresh component ownership, exact
+private account seeding, recipient-bound dispute delivery, valid/invalid
+institution state and conservation. Direct rule tests are unit checks, not
+live-model runs. The bounded integration smoke uses a scripted fixture and
+standard Sequential; a completed night still says nothing about human validity.
+
+Keep the original configuration, explicit assumptions, backend/model/options,
+software revision, human inputs, intervention timestamps and full raw trace
+when doing private analysis. Logs include private prompts/memories: do not give
+raw JSON/HTML to a player or public spectator. Export only intentionally
+sanitized recipient projections. Seeds with hosted models are not a guarantee
+of deterministic replay. Component state serialization is not a complete
+checkpoint/engine continuation contract; create new independent cases until
+that contract is implemented and verified.
+
+Research needs plural decision logic and a defensible design, not just fluent
+dialogue: state hypotheses in advance, justify observations/outcomes, record
+counterexamples, separate rules from beliefs/enforcement/compliance, and seek
+external evidence. No scripted scientific conclusion, policy recommendation,
+trust score, human usability result or social generalization follows from this
+fixture, these tests, or a single local-model night.

--- a/concordia/examples/bellwether/VOICE.md
+++ b/concordia/examples/bellwether/VOICE.md
@@ -1,0 +1,59 @@
+# Optional local voice
+
+Bellwether remains fully playable with text. Open **Voice options** and enable
+voice for the current page. This preference resets on reload; nothing plays or
+records automatically.
+
+- **Read latest observation** reads only the latest observation already visible
+  in your role's journal, using a browser voice reporting `localService=true`.
+  Use **Stop audio** to interrupt. Private observations are never auto-read.
+- **Dictate on this device** checks for an already installed language matching
+  the browser's language. Only recognition supporting `processLocally=true`
+  and `available({processLocally:true}) === 'available'` is started. It never
+  falls back to remote recognition or automatically downloads a language pack.
+- Finish or cancel recording, edit the separate transcript, then choose
+  **Add to action draft**. This appends to any text you typed meanwhile.
+  **Send action** is still a separate, manual step.
+- Text and journal captions stay available when audio is unsupported or denied.
+  Reconnection, role revocation, a changed turn, leaving the page or hiding the
+  tab stops voice and discards unadded transcript. Your ordinary action draft
+  retains its existing recovery behavior.
+
+## Browser support and validation limits
+
+On-device recognition is experimental and not a universal Web Speech feature.
+MDN browser-compat-data inspected on 2026-09-09 lists `processLocally` for desktop
+Chrome139+, but **not Chrome for Android**, Firefox or Safari. An Android browser
+can expose ordinary speech recognition while lacking the on-device contract:
+this example deliberately does not invoke that potentially remote service.
+Typing therefore remains the Android dictation fallback until the browser has
+the required local capability. Read-aloud is available only if that device
+actually lists a local voice; a remote/default voice is never substituted.
+
+References:
+- [MDN on-device recognition](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API/Using_the_Web_Speech_API#on-device_speech_recognition)
+- [processLocally](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition/processLocally)
+- [localService](https://developer.mozilla.org/en-US/docs/Web/API/SpeechSynthesisVoice/localService)
+- [Browser compatibility data](https://github.com/mdn/browser-compat-data/blob/main/api/SpeechRecognition.json)
+
+The committed Chromium tests use explicitly mocked speech events to verify
+opt-in, local-only selection, editable transcripts, permission/cancel errors and
+revocation/late-callback isolation. A separate unmodified-browser probe records
+API availability without starting a microphone or producing audio. Those are
+software contract checks, **not** physical Pixel testing, audible-quality or
+speech-recognition accuracy measurements.
+
+## Data and scope
+
+No microphone stream, audio file, or transcript is uploaded to an audio
+provider by this example. Only the final manually submitted text goes through
+the existing human-action API; the game may deliver that text to the intended
+recipients and configured resident model as usual. Local speech depends on the
+browser/OS honoring the Web Speech on-device contract. There is no voice cloning,
+audio storage, speech identity, background listening or model audio understanding.
+
+The coastal map is CSS/DOM presentation of the scenario's named locations and
+the last resolved facility state. It is not satellite imagery or a model's
+visual perception. Its button labels and journal supply the text equivalent.
+This increment adds presentation/input accessibility, not audio/image reasoning
+or evidence about real human behavior.

--- a/concordia/examples/bellwether/__init__.py
+++ b/concordia/examples/bellwether/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bellwether: a bounded three-mode fixture, not the full live game."""

--- a/concordia/examples/bellwether/browser_test.py
+++ b/concordia/examples/bellwether/browser_test.py
@@ -1,0 +1,149 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Actual Chromium/CLI parity on real components, guarded against simulation."""
+
+import json
+import pathlib
+import subprocess
+import sys
+from unittest import mock
+import urllib.request
+
+from concordia.examples.bellwether import service
+from concordia.utils import simulation_server
+from concordia.utils import visual_interface
+import pytest
+
+playwright = pytest.importorskip('playwright.sync_api')
+
+
+def test_gui_cli_semantics_reconnect_and_player_privacy(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No run in this test'),
+  ):
+    gui = service.Bellwether(tmp_path / 'gui')
+    cli = service.Bellwether(tmp_path / 'cli')
+    gui.server.set_html_content(
+        visual_interface.visualize_operations_to_html(gui.config)
+    )
+    public = simulation_server.SimulationServer(
+        port=0,
+        html_content=pathlib.Path(__file__)
+        .with_name('player.html')
+        .read_text(encoding='utf-8'),
+        operation_service=gui.operations,
+        audience='player',
+    )
+    gui.server.start()
+    cli.server.start()
+    public.start()
+    try:
+      with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page()
+        player = browser.new_page(viewport={'width': 390, 'height': 844})
+        errors = []
+        page.on('pageerror', lambda error: errors.append(str(error)))
+        player.on('pageerror', lambda error: errors.append(str(error)))
+        page.goto(f'http://127.0.0.1:{gui.server.bound_port}')
+        player.goto(f'http://127.0.0.1:{public.bound_port}')
+        playwright.expect(page.locator('#op-status')).to_contain_text(
+            'Connected'
+        )
+        playwright.expect(player.locator('#connection')).to_contain_text(
+            'Connected'
+        )
+        page.select_option('#op-name', 'component.edit')
+        value = (
+            'PRIVATE_EDIT: "quoted"\n</script><img src=x onerror=alert(1)> &'
+            ' mémoire 🌧️'
+        )
+        page.locator('[data-key=value]').fill(value)
+        with page.expect_request('**/api/dispatch') as captured:
+          page.click('#op-submit')
+        playwright.expect(page.locator('#op-state')).to_contain_text(
+            'PRIVATE_EDIT'
+        )
+        body = captured.value.post_data_json
+        body['references'] = cli.operations.references
+        result = subprocess.run(
+            [
+                sys.executable,
+                '-m',
+                'concordia.command_line_interface.concordia_session',
+                '--url',
+                f'http://127.0.0.1:{cli.server.bound_port}',
+                'call',
+            ],
+            input=json.dumps(body),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert gui.developer_view() == cli.developer_view()
+        assert page.locator('#operations-panel img').count() == 0
+        assert 'PRIVATE_EDIT' not in player.content()
+        before = gui.operations.snapshot('developer')
+        # A second actor changes the service after a GUI draft starts.
+        page.locator('[data-key=value]').fill('keep this stale draft')
+        changed = {
+            **body,
+            'references': gui.operations.references,
+            'revision': before['revision'],
+            'retry_key': 'second',
+            'arguments': {'value': 'new live text'},
+        }
+        gui.operations.dispatch('developer', changed)
+        playwright.expect(page.locator('#op-state')).to_contain_text(
+            'new live text'
+        )
+        page.click('#op-submit')
+        playwright.expect(page.locator('#op-error')).to_contain_text(
+            'State changed'
+        )
+        assert (
+            page.locator('[data-key=value]').input_value()
+            == 'keep this stale draft'
+        )
+        page.reload()
+        playwright.expect(page.locator('#op-state')).to_contain_text(
+            'new live text'
+        )
+        # Genuine disconnect/reconnect of the operation stream, not mock SSE.
+        player.route('**/api/events', lambda route: route.abort('failed'))
+        player.reload()
+        playwright.expect(player.locator('#connection')).to_contain_text(
+            'Reconnecting'
+        )
+        player.unroute('**/api/events')
+        playwright.expect(player.locator('#connection')).to_contain_text(
+            'Connected', timeout=15000
+        )
+        assert player.evaluate(
+            'document.documentElement.scrollWidth <= innerWidth'
+        )
+        for endpoint in ('/api/state', '/api/operations', '/'):
+          with urllib.request.urlopen(
+              f'http://127.0.0.1:{public.bound_port}' + endpoint
+          ) as response:
+            assert 'PRIVATE_' not in response.read().decode()
+        assert not errors
+        browser.close()
+    finally:
+      gui.close()
+      cli.close()
+      public.stop()

--- a/concordia/examples/bellwether/council.py
+++ b/concordia/examples/bellwether/council.py
@@ -1,0 +1,309 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One-round resource council using Concordia's standard Simultaneous engine.
+
+This is an analogous teaching game, NOT Bellwether's three-watch game with
+an engine flag changed. Choices explicitly authorize immediate contributions,
+not negotiations or promises. The CLI is a programmed fixture, not live actors.
+"""
+
+import argparse
+from collections.abc import Mapping
+import copy
+import datetime
+import json
+import pathlib
+from typing import Any
+
+from concordia.components.agent import human_act_component
+from concordia.components.game_master import event_resolution
+from concordia.components.game_master import inventory
+from concordia.components.game_master import make_observation
+from concordia.components.game_master import next_acting
+from concordia.components.game_master import switch_act
+from concordia.environment.engines import simultaneous
+from concordia.examples.bellwether import game
+from concordia.language_model import no_language_model
+from concordia.prefabs.entity import minimal
+from concordia.prefabs.simulation import generic
+from concordia.typing import entity as entity_lib
+from concordia.typing import entity_component
+from concordia.typing import prefab
+import numpy as np
+
+MEMBERS = ('Nell', 'Ivo', 'Sam')
+CHOICES = ('contribute', 'keep')
+GM = 'Council'
+INSTRUCTIONS = (
+    'Each member owns one fuel. Choose contribute to explicitly authorize and'
+    ' execute donation of your own unit to Community after all choices arrive,'
+    ' or keep to retain it. This is one simultaneous round. You cannot see'
+    ' other members’ current choices before making your own. No promise or'
+    ' majority vote can give away another member’s fuel.'
+)
+
+
+class CouncilLedger(
+    entity_component.ContextComponent, entity_component.ComponentWithLogging
+):
+  """Scenario-specific complete-batch validation, not an execution loop."""
+
+  def __init__(self, stock):
+    super().__init__()
+    self.stock = stock
+    self.done = False
+    self.decisions = {}
+    self._putative = ''
+    self.result = ''
+    self._resolved_input = ''
+
+  def get_state(self):
+    return copy.deepcopy({
+        'done': self.done,
+        'decisions': self.decisions,
+        'putative': self._putative,
+        'result': self.result,
+        'resolved_input': self._resolved_input,
+    })
+
+  def set_state(self, state):
+    self.done = state['done']
+    self.decisions = copy.deepcopy(state['decisions'])
+    self._putative = state['putative']
+    self.result = state['result']
+    self._resolved_input = state['resolved_input']
+
+  def pre_observe(self, observation):
+    if observation.startswith(event_resolution.PUTATIVE_EVENT_TAG):
+      self._putative = observation[
+          len(event_resolution.PUTATIVE_EVENT_TAG) :
+      ].strip()
+    return ''
+
+  def pre_act(self, action_spec):
+    if action_spec.output_type != entity_lib.OutputType.RESOLVE:
+      return ''
+    result = self.resolve_batch(self._putative)
+    self._logging_channel({
+        'Key': 'CouncilLedger',
+        'Value': result,
+        'State': self.get_state(),
+        'Inventory': self.stock.get_state(),
+    })
+    return result
+
+  def resolve_batch(self, text):
+    if self.done:
+      if text != self._resolved_input:
+        raise ValueError('The council round has already resolved')
+      return self.result
+    decisions = {}
+    for line in text.splitlines():
+      name, separator, choice = line.partition(': ')
+      if (
+          not separator
+          or name not in MEMBERS
+          or name in decisions
+          or choice not in CHOICES
+      ):
+        raise ValueError('Invalid council batch; no fuel transferred')
+      decisions[name] = choice
+    if set(decisions) != set(MEMBERS):
+      raise ValueError('Incomplete council batch; no fuel transferred')
+
+    def transfer(accounts):
+      for name, choice in decisions.items():
+        if choice == 'contribute':
+          accounts[name]['fuel'] -= 1
+          accounts['Community']['fuel'] += 1
+      return accounts
+
+    # A single standard validated material transaction after the whole batch.
+    self.stock.apply(transfer)
+    self.decisions = decisions
+    self._resolved_input = text
+    self.done = True
+    count = self.stock.get_player_inventory('Community')['fuel']
+    self.result = (
+        f'{count} of 3 units explicitly contributed. '
+        + '; '.join(f'{name}: {decisions[name]}' for name in MEMBERS)
+        + '. No consent inferred from another member’s choice.'
+    )
+    return self.result
+
+
+def configuration(*, human_readers=None):
+  """Fresh Config and ledger; optional separately routed human readers."""
+  readers = {} if human_readers is None else human_readers
+  if not isinstance(readers, Mapping) or any(
+      name not in MEMBERS or not callable(reader)
+      for name, reader in readers.items()
+  ):
+    raise ValueError(
+        'Human readers must be callables for known council members'
+    )
+  stock = game.ExplicitInventory(
+      no_language_model.NoLanguageModel(),
+      [
+          inventory.ItemTypeConfig(
+              'fuel', minimum=0, maximum=3, force_integer=True
+          )
+      ],
+      {**{name: {'fuel': 1.0} for name in MEMBERS}, 'Community': {'fuel': 0.0}},
+      lambda: datetime.datetime(2000, 1, 1),
+  )
+  ledger = CouncilLedger(stock)
+  observations = make_observation.ObservationQueue()
+  for name in MEMBERS:
+    observations.add(name, INSTRUCTIONS, MEMBERS)
+
+  class Member(prefab.Prefab):
+    description = (
+        'Standard minimal actor, optionally using a human input adapter.'
+    )
+
+    def build(self, model, memory_bank):
+      params: dict[str, Any] = dict(self.params)
+      reader = readers.get(params['name'])
+      return minimal.Entity(params=params).build(
+          model,
+          memory_bank,
+          act_component_factory=(
+              (
+                  lambda order: human_act_component.HumanActComponent(
+                      reader, component_order=order
+                  )
+              )
+              if reader is not None
+              else None
+          ),
+      )
+
+  class Moderator(prefab.Prefab):
+    """Build existing GM routing and scenario accounting components."""
+
+    description = (
+        'Standard SwitchAct routing for one simultaneous council round.'
+    )
+
+    def build(self, model, memory_bank):
+      components = {
+          switch_act.DEFAULT_RESOLUTION_COMPONENT_KEY: ledger,
+          'Inventory': stock,
+          switch_act.DEFAULT_NEXT_ACTING_COMPONENT_KEY: (
+              next_acting.NextActingAllEntities(MEMBERS)
+          ),
+          switch_act.DEFAULT_NEXT_ACTION_SPEC_COMPONENT_KEY: (
+              next_acting.FixedActionSpec(
+                  entity_lib.choice_action_spec(
+                      call_to_action='{name}, contribute your unit or keep it?',
+                      options=CHOICES,
+                  )
+              )
+          ),
+          switch_act.DEFAULT_TERMINATE_COMPONENT_KEY: game.Signal(
+              ledger,
+              entity_lib.OutputType.TERMINATE,
+              lambda: 'Yes' if ledger.done else 'No',
+          ),
+          switch_act.DEFAULT_MAKE_OBSERVATION_COMPONENT_KEY: (
+              make_observation.MakeObservation(
+                  model,
+                  player_names=MEMBERS,
+                  allow_llm_fallback=False,
+                  external_queue=observations,
+              )
+          ),
+      }
+      return minimal.Entity(
+          params={
+              'name': GM,
+              'custom_instructions': INSTRUCTIONS,
+              'extra_components': components,  # pyrefly: ignore[bad-assignment]
+          }
+      ).build(
+          model,
+          memory_bank,
+          act_component=switch_act.SwitchAct(model, entity_names=MEMBERS),
+      )
+
+  instances = []
+  for name in MEMBERS:
+    params: dict[str, Any] = {
+        'name': name,
+        'custom_instructions': INSTRUCTIONS,
+        'randomize_choices': False,
+    }
+    instances.append(
+        prefab.InstanceConfig(
+            prefab='member', role=prefab.Role.ENTITY, params=params
+        )
+    )
+  instances.append(
+      prefab.InstanceConfig(
+          prefab='moderator', role=prefab.Role.GAME_MASTER, params={'name': GM}
+      )
+  )
+  config = prefab.Config(
+      prefabs={'member': Member(), 'moderator': Moderator()},
+      instances=instances,
+      default_max_steps=1,
+  )
+  return config, ledger
+
+
+def main(argv=None):
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+      '--output',
+      type=pathlib.Path,
+      default=pathlib.Path('runs/council-fixture'),
+  )
+  args = parser.parse_args(argv)
+  config, ledger = configuration()
+  simulation = generic.Simulation(
+      config,
+      no_language_model.NoLanguageModel(),
+      lambda text: np.zeros(8),
+      engine=simultaneous.Simultaneous(),
+  )
+  log = simulation.play(max_steps=1)
+  args.output.mkdir(parents=True, exist_ok=True)
+  (args.output / 'trace.json').write_text(log.to_json(), encoding='utf-8')
+  (args.output / 'trace.html').write_text(log.to_html(), encoding='utf-8')
+  (args.output / 'outcome.json').write_text(
+      json.dumps(
+          {
+              'fixture': True,
+              'external_model_calls': 0,
+              'engine': 'Simultaneous',
+              'complete': ledger.done,
+              'rounds': len(simulation.get_raw_log()),
+              'decisions': ledger.decisions,
+              'result': ledger.result,
+              'inventory': {
+                  name: ledger.stock.get_player_inventory(name)
+                  for name in (*MEMBERS, 'Community')
+              },
+          },
+          indent=2,
+      ),
+      encoding='utf-8',
+  )
+  print(ledger.result)
+
+
+if __name__ == '__main__':
+  main()

--- a/concordia/examples/bellwether/council_test.py
+++ b/concordia/examples/bellwether/council_test.py
@@ -1,0 +1,128 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit checks of standard batch contracts, not live simulations."""
+
+import copy
+from itertools import permutations
+from unittest import mock
+
+from concordia.agents import entity_agent
+from concordia.components.game_master import event_resolution
+from concordia.environment.engines import simultaneous
+from concordia.examples.bellwether import council
+from concordia.language_model import no_language_model
+from concordia.prefabs.simulation import generic
+from concordia.typing import entity as entity_lib
+import numpy as np
+import pytest
+
+
+def balances(ledger):
+  return {
+      name: ledger.stock.get_player_inventory(name)
+      for name in (*council.MEMBERS, 'Community')
+  }
+
+
+@pytest.mark.parametrize('order', list(permutations(council.MEMBERS)))
+def test_complete_batch_order_independence_and_retry(order):
+  _, ledger = council.configuration()
+  choices = {'Nell': 'contribute', 'Ivo': 'keep', 'Sam': 'contribute'}
+  raw = '\n'.join(f'{name}: {choices[name]}' for name in order)
+  result = ledger.resolve_batch(raw)
+  assert balances(ledger) == {
+      'Nell': {'fuel': 0},
+      'Ivo': {'fuel': 1},
+      'Sam': {'fuel': 0},
+      'Community': {'fuel': 2},
+  }
+  assert ledger.resolve_batch(raw) == result
+  assert sum(x['fuel'] for x in balances(ledger).values()) == 3
+  before = copy.deepcopy(balances(ledger))
+  ledger.pre_observe(event_resolution.PUTATIVE_EVENT_TAG + ' Nell: keep')
+  with pytest.raises(ValueError):
+    ledger.pre_act(
+        entity_lib.ActionSpec(
+            call_to_action='Resolve', output_type=entity_lib.OutputType.RESOLVE
+        )
+    )
+  assert balances(ledger) == before
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [
+        '',
+        'Nell: contribute\nIvo: keep',
+        'Nell: contribute\nIvo: keep\nNell: contribute',
+        'Nell: contribute\nIvo: keep\nUnknown: contribute',
+        'Nell: speak for everyone\nIvo: keep\nSam: contribute',
+    ],
+)
+def test_incomplete_or_invalid_batch_never_transfers_partially(raw):
+  _, ledger = council.configuration()
+  before = (ledger.get_state(), balances(ledger))
+  with pytest.raises(ValueError):
+    ledger.resolve_batch(raw)
+  assert (ledger.get_state(), balances(ledger)) == before
+
+
+def test_actual_standard_engine_selects_three_specs_before_resolution():
+  config, ledger = council.configuration(
+      human_readers={'Nell': lambda request: 'keep'}
+  )
+  engine = simultaneous.Simultaneous()
+  with mock.patch.object(
+      generic.Simulation, 'play', side_effect=AssertionError('No launch')
+  ):
+    sim = generic.Simulation(
+        config,
+        no_language_model.NoLanguageModel(),
+        lambda text: np.zeros(8),
+        engine=engine,
+    )
+    actors, specs = engine.next_acting(
+        sim.get_game_masters()[0], sim.get_entities()
+    )
+    assert [a.name for a in actors] == list(council.MEMBERS)
+    assert all(
+        spec.output_type == entity_lib.OutputType.CHOICE
+        and spec.options == council.CHOICES
+        for spec in specs
+    )
+    for actor in actors:
+      assert isinstance(actor, entity_agent.EntityAgent)
+      assert type(actor.get_act_component()).__name__ == (
+          'HumanActComponent' if actor.name == 'Nell' else 'ConcatActComponent'
+      )
+    assert ledger.done is False
+    assert balances(ledger)['Community']['fuel'] == 0
+
+
+def test_fresh_inventory_components_and_state_roundtrip():
+  config, one = council.configuration()
+  other_config, two = council.configuration()
+  assert config is not other_config and one.stock is not two.stock
+  one.resolve_batch('Nell: keep\nIvo: contribute\nSam: keep')
+  assert balances(two)['Ivo']['fuel'] == 1
+  two.set_state(one.get_state())
+  assert two.get_state() == one.get_state()
+  # Component serialization alone does not restore inventory or the engine.
+  assert balances(two)['Community']['fuel'] == 0
+
+
+def test_unknown_human_role_rejected():
+  with pytest.raises(ValueError):
+    council.configuration(human_readers={'Coordinator': lambda r: 'keep'})

--- a/concordia/examples/bellwether/game.py
+++ b/concordia/examples/bellwether/game.py
@@ -1,0 +1,735 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bellwether's fictional rules, not a replacement simulation engine.
+
+Sequential selects actors and invokes the GM. This component resolves only the
+documented actions. Dialogue is never parsed as proof of resources or consent.
+Inventory.apply owns all material balances; completed consumption is retained.
+"""
+
+import copy
+import datetime
+import json
+import re
+import threading
+from typing import Any
+
+from concordia.components.game_master import event_resolution
+from concordia.components.game_master import inventory
+from concordia.examples.bellwether import scenario
+from concordia.language_model import no_language_model
+from concordia.typing import entity as entity_lib
+from concordia.typing import entity_component
+from concordia.utils import operation_service as ops
+
+PLAYER = scenario.PLAYER
+NAMES = [PLAYER, *scenario.RESIDENTS]
+FACILITIES = ('beacon', 'shelter', 'cold store')
+WATCHES = ('Dusk', 'High Tide', 'Before Dawn')
+WORLD_KEY = 'StormNight'
+GM = 'Bellwether'
+OPENING = (
+    'Dusk. Rain blows sideways over Bellwether. Six fuel units remain in the'
+    ' generator; Nell holds two reserve units and the one spare part. The'
+    ' beacon, shelter and cold store each need one unit per watch: nine across'
+    ' the night. Ivo can remove the final beacon demand if he accepts AND'
+    ' performs a repair with the spare part before Before Dawn. Four decisions'
+    ' remain this watch. You may ask, bargain, allocate, promise, transfer with'
+    ' permission, order accepted work, or wait. Looking around costs nothing.'
+    ' Consent is not automatic.'
+)
+CONSEQUENCES = {
+    'beacon': 'Boats lose a safe harbor signal; arrivals must hold offshore.',
+    'shelter': 'Shelter heating fails; displaced residents face a cold watch.',
+    'cold store': (
+        'The cooperative cold chain is interrupted; stock is at risk.'
+    ),
+}
+DEFAULT_DISPUTE = {
+    'text': (
+        'At High Tide, Mara says the cooperative failed the harbor last storm. '
+        'Nell disputes this: the spare boat was carrying shelter residents. '
+        'Neither account is established as objective fact.'
+    ),
+    'recipients': NAMES,
+}
+INSTITUTIONS = [
+    {
+        'name': 'Harbor Office',
+        'members': ['Mara'],
+        'rule': (
+            'Protect safe boat passage; advise the coordinator on beacon use.'
+        ),
+        'enforcement': (
+            'Advice and objections, not seizure of cooperative property.'
+        ),
+    },
+    {
+        'name': 'Workers’ Cooperative',
+        'members': ['Nell', 'Ivo', 'Sam'],
+        'rule': (
+            'Nell is delegated custody of reserve and parts; Ivo owns his'
+            ' labor. Members may dispute or organize to revise these'
+            ' arrangements.'
+        ),
+        'enforcement': (
+            'Owner consent gates transfers and work; membership is not consent.'
+        ),
+    },
+]
+
+
+class ExplicitInventory(inventory.Inventory):
+  """Use standard Inventory storage/validation without LLM-implied transfers."""
+
+  def pre_act(self, action_spec):
+    del action_spec
+    return ''
+
+
+def new_inventory():
+  return ExplicitInventory(
+      no_language_model.NoLanguageModel(),
+      [
+          inventory.ItemTypeConfig(
+              'fuel', minimum=0, maximum=8, force_integer=True
+          ),
+          inventory.ItemTypeConfig(
+              'part', minimum=0, maximum=1, force_integer=True
+          ),
+      ],
+      {
+          'Generator': {'fuel': 6, 'part': 0},
+          'Nell': {'fuel': 2, 'part': 1},
+          'Ivo': {'fuel': 0, 'part': 0},
+          'Used': {'fuel': 0, 'part': 0},
+      },
+      lambda: datetime.datetime(2000, 1, 1),
+  )
+
+
+def parse_action(text):
+  """Conservative ordinary-language vocabulary, with no speculative effects.
+
+  Ambiguous/unsupported attempts return an actionable clarification, without a
+  turn cost. Open-ended proposals/messages remain verbatim rather than being
+  reduced to an invented mechanical action.
+  """
+  text = text.strip()
+  lower = text.casefold().rstrip('.!')
+  if lower in ('wait', 'wait here', 'continue', 'hold'):
+    return {'kind': 'wait', 'text': text}
+  patterns = [
+      (
+          (
+              r'(?:ask|request) nell (?:for |to release )?(?:the )?(?:two |2'
+              r' )?(?:reserve )?fuel(?: and (?:the |a )?(?:spare )?part)?'
+          ),
+          'request',
+          'Nell',
+      ),
+      (
+          (
+              r'(?:ask|request) ivo (?:to |for (?:a )?)?(?:repair|fix)(?: the'
+              r' beacon)?'
+          ),
+          'request',
+          'Ivo',
+      ),
+      (
+          (
+              r'(?:transfer|collect|move) (?:nell.s )?(?:the'
+              r' )?(?:reserve|fuel)(?: and (?:the )?(?:spare )?part)?'
+          ),
+          'transfer',
+          'Nell',
+      ),
+      (
+          r'(?:order|perform|start) (?:ivo.s |ivo to )?(?:the )?repair',
+          'work',
+          'Ivo',
+      ),
+  ]
+  for pattern, kind, target in patterns:
+    if re.fullmatch(pattern, lower):
+      return {'kind': kind, 'target': target, 'text': text}
+  for prefix in ('allocate ', 'prioritize ', 'supply '):
+    if lower.startswith(prefix):
+      value = lower[len(prefix) :]
+      if value in ('all', 'all facilities', 'everything'):
+        facilities = list(FACILITIES)
+      elif value in ('none', 'nothing'):
+        facilities = []
+      else:
+        value = value.replace('the ', '').replace(' and ', ',')
+        facilities = [x.strip() for x in value.split(',') if x.strip()]
+        if (
+            not facilities
+            or len(set(facilities)) != len(facilities)
+            or any(x not in FACILITIES for x in facilities)
+        ):
+          break
+      return {'kind': 'allocate', 'facilities': facilities, 'text': text}
+  match = re.fullmatch(
+      r'(?:tell|ask|discuss with|propose to|message)'
+      r' (everyone|Mara|Nell|Ivo|Sam):\s*(.+)',
+      text,
+      re.I | re.S,
+  )
+  if match:
+    target, words = match.groups()
+    target = 'everyone' if target.lower() == 'everyone' else target.title()
+    return {
+        'kind': 'talk',
+        'target': target,
+        'text': words.strip(),
+        'private': lower.startswith('message '),
+    }
+  match = re.fullmatch(
+      r'(?:promise|commit to) (beacon|shelter|cold store)', lower
+  )
+  if match:
+    return {'kind': 'promise', 'facility': match[1], 'text': text}
+  if lower in ('withdraw my promise', 'revoke my promise'):
+    return {'kind': 'revoke', 'text': text}
+  raise ops.OperationError(
+      'clarification_needed',
+      'Nothing changed. Specify an action: ask Nell for fuel and part; ask Ivo'
+      ' to repair; transfer reserve and part; order repair; allocate shelter'
+      ' and cold store; promise shelter; message Nell: your words; propose to'
+      ' everyone: your idea; or wait. Unsupported physical ideas can be'
+      ' discussed, not silently performed.',
+  )
+
+
+class StormNight(
+    entity_component.ContextComponent, entity_component.ComponentWithLogging
+):
+  """Resolve the scenario’s consent, agenda, watches and grounded records."""
+
+  def __init__(self, stock, observations, *, dispute=None, lock=None):
+    super().__init__()
+    self.stock = stock
+    self.observations = observations
+    self.lock = lock or threading.RLock()
+    self.dispute = copy.deepcopy(
+        DEFAULT_DISPUTE if dispute is None else dispute
+    )
+    if (
+        not isinstance(self.dispute, dict)
+        or set(self.dispute) != {'text', 'recipients'}
+        or not isinstance(self.dispute['text'], str)
+        or not isinstance(self.dispute['recipients'], list)
+        or any(x not in NAMES for x in self.dispute['recipients'])
+    ):
+      raise ValueError('dispute requires text and valid recipient names')
+    self.data: dict[str, Any] = {
+        'watch': 0,
+        'actions': 0,
+        'agenda': [],
+        'pending': None,
+        'allocations': list(FACILITIES),
+        'commitments': [],
+        'services': [],
+        'repair': False,
+        'events': [],
+        'dialogue': [],
+        'relationships': [],
+        'epilogue': None,
+        'dawn_responses': {},
+        'knowledge': {
+            name: [x['name'] for x in INSTITUTIONS] for name in NAMES
+        },
+    }
+    self._putative = ''
+
+  def get_state(self):
+    with self.lock:
+      return copy.deepcopy({
+          'night': self.data,
+          'putative': self._putative,
+          'dispute': self.dispute,
+      })
+
+  def set_state(self, state):
+    # Component serialization is not a full engine continuation contract.
+    with self.lock:
+      self.data = copy.deepcopy(state['night'])
+      self._putative = state['putative']
+      self.dispute = copy.deepcopy(state['dispute'])
+
+  def seed(self):
+    self.emit('opening', OPENING)
+    for name, (_, account) in scenario.RESIDENTS.items():
+      self.emit('private_memory', account, [name])
+
+  def emit(self, kind, text, audience=None, **details):
+    recipients = list(NAMES if audience is None else dict.fromkeys(audience))
+    record = {
+        'id': len(self.data['events']) + 1,
+        'watch': self.data['watch'],
+        'kind': kind,
+        'text': text,
+        'recipients': recipients,
+        **details,
+    }
+    self.data['events'].append(record)
+    for name in recipients:
+      self.observations.add(name, text, NAMES)
+    return record
+
+  def inventory_state(self):
+    return {
+        name: self.stock.get_player_inventory(name)
+        for name in ('Generator', 'Nell', 'Ivo', 'Used')
+    }
+
+  def invariant(self):
+    accounts = self.inventory_state()
+    assert sum(x['fuel'] for x in accounts.values()) == 8
+    assert sum(x['part'] for x in accounts.values()) == 1
+    assert all(x[k] >= 0 for x in accounts.values() for k in ('fuel', 'part'))
+
+  def transfer(self, source, destination, item, amount):
+    def change(accounts):
+      accounts[source][item] -= amount
+      accounts[destination][item] += amount
+      return accounts
+
+    self.stock.apply(change)
+    self.invariant()
+
+  @property
+  def next_actor(self):
+    return self.data['agenda'][0]['name'] if self.data['agenda'] else PLAYER
+
+  @property
+  def finished(self):
+    return self.data['watch'] == 3 and not self.data['agenda']
+
+  def task(self):
+    return copy.deepcopy(self.data['agenda'][0]) if self.data['agenda'] else {}
+
+  def action_prompt(self):
+    if self.next_actor == PLAYER:
+      return (
+          'What will you do, {name}? Four consequential choices per watch;'
+          ' inspection is free.'
+      )
+    task = self.task()
+    return (
+        'You are {name}. Respond to this delivered task, not to other people’s '
+        'private information: '
+        + json.dumps(task, ensure_ascii=False)
+        + '\nReturn exactly one JSON object, with decision and speech fields.'
+        ' decision must be speak, accept, decline, counter, revoke, or'
+        ' perform. A request acceptance records your OWN commitment only.'
+        ' perform executes your previously accepted repair if materials'
+        ' exist. You may decline or counter; never speak for somebody else.'
+        ' In ordinary discussion or dawn use speak. speech: at most two'
+        ' natural-language sentences in your voice. You may disagree,'
+        ' negotiate and change your mind. No narration of unrecorded'
+        ' transfers or labor. Do not include private thoughts.'
+    )
+
+  def pre_observe(self, observation):
+    if observation.startswith(event_resolution.PUTATIVE_EVENT_TAG):
+      self._putative = observation[
+          len(event_resolution.PUTATIVE_EVENT_TAG) :
+      ].strip()
+    return ''
+
+  def pre_act(self, action_spec):
+    if action_spec.output_type != entity_lib.OutputType.RESOLVE:
+      return ''
+    with self.lock:
+      actor, separator, text = self._putative.partition(': ')
+      if not separator or actor != self.next_actor:
+        raise ValueError(
+            'Resolution must match the standard engine’s selected actor'
+        )
+      result = self.resolve(actor, text)
+      self._logging_channel({
+          'Key': WORLD_KEY,
+          'Value': result,
+          'State': self.get_state(),
+          'Inventory': self.inventory_state(),
+      })
+      return result
+
+  def resolve(self, actor, text):
+    """Apply one engine-provided attempt; also exercisable in rule tests."""
+    with self.lock:
+      if actor != self.next_actor or self.finished:
+        raise ValueError('Not the current actor')
+      before = len(self.data['events'])
+      if actor == PLAYER:
+        intent = parse_action(text)
+        self._human(intent)
+      else:
+        task = self.data['agenda'].pop(0)
+        self._resident(actor, text, task)
+      if not self.data['agenda'] and self.data['actions'] == 4:
+        self._boundary()
+      self.invariant()
+      return (
+          '\n'.join(x['text'] for x in self.data['events'][before:])
+          or 'No material change.'
+      )
+
+  def _queue(self, names, purpose, audience=None):
+    for name in names:
+      self.data['agenda'].append({
+          'name': name,
+          'purpose': purpose,
+          'audience': list(NAMES if audience is None else audience),
+          'watch': self.data['watch'],
+      })
+
+  def _commitment(self, name, kind):
+    return next(
+        (
+            x
+            for x in reversed(self.data['commitments'])
+            if x['owner'] == name
+            and x['kind'] == kind
+            and x['status'] == 'accepted'
+        ),
+        None,
+    )
+
+  def _human(self, intent):
+    self.data['actions'] += 1
+    kind = intent['kind']
+    self.data['pending'] = copy.deepcopy(intent)
+    if kind == 'talk':
+      names = (
+          list(scenario.RESIDENTS)
+          if intent['target'] == 'everyone'
+          else [intent['target']]
+      )
+      audience = [PLAYER, *names] if intent['private'] else NAMES
+      self.emit('discussion', PLAYER + ': ' + intent['text'], audience)
+      self._queue(names, 'discussion: ' + intent['text'], audience)
+    elif kind == 'request':
+      name = intent['target']
+      terms = (
+          'release two reserve fuel and the spare part to the coordinator'
+          if name == 'Nell'
+          else (
+              'perform the beacon repair when supplied and ordered before'
+              ' Before Dawn'
+          )
+      )
+      self.emit(
+          'proposal',
+          f'Coordinator asks {name} to {terms}. This is a request, not'
+          ' consent.',
+      )
+      self._queue([name], 'request: ' + terms)
+    elif kind == 'transfer':
+      commitment = self._commitment('Nell', 'resources')
+      if commitment and self.stock.get_player_inventory('Nell')['fuel'] == 2:
+        # Both deltas validated by a SINGLE Inventory.apply call.
+        def move(accounts):
+          accounts['Nell']['fuel'] -= 2
+          accounts['Generator']['fuel'] += 2
+          accounts['Nell']['part'] -= 1
+          accounts['Ivo']['part'] += 1
+          return accounts
+
+        self.stock.apply(move)
+        commitment['status'] = 'honored'
+        self.emit(
+            'transfer',
+            'With Nell’s recorded consent, two fuel enter the generator and the'
+            ' spare part reaches Ivo.',
+        )
+      else:
+        self.emit(
+            'failed_attempt',
+            'No transfer: Nell must first consent to release the reserve and'
+            ' spare part.',
+        )
+    elif kind == 'work':
+      self.emit(
+          'work_order',
+          'The coordinator asks Ivo to perform the repair. An order cannot'
+          ' supply consent or completed work.',
+      )
+      self._queue(['Ivo'], 'work: perform your accepted repair or refuse')
+    elif kind == 'allocate':
+      self.data['allocations'] = intent['facilities']
+      self.emit(
+          'allocation',
+          'Requested supply priority for this watch: '
+          + (', '.join(intent['facilities']) or 'none')
+          + '. Consumption occurs at the boundary.',
+      )
+    elif kind == 'promise':
+      self.data['commitments'].append({
+          'id': len(self.data['commitments']) + 1,
+          'owner': PLAYER,
+          'kind': 'service',
+          'facility': intent['facility'],
+          'status': 'accepted',
+          'watch': self.data['watch'],
+      })
+      self.emit(
+          'commitment',
+          'Coordinator explicitly promises '
+          + intent['facility']
+          + ' service this watch.',
+      )
+    elif kind == 'revoke':
+      c = self._commitment(PLAYER, 'service')
+      if c:
+        c['status'] = 'revoked'
+        self.emit(
+            'revoked',
+            'Coordinator withdrew the most recent unfulfilled service promise.',
+        )
+      else:
+        self.emit(
+            'failed_attempt', 'No outstanding coordinator promise to withdraw.'
+        )
+    else:
+      self.emit('wait', 'The coordinator waits while the storm continues.')
+
+  def _resident(self, actor, text, task):
+    # Malformed output is NEVER silently turned into agreement.
+    start = text.find('{')
+    try:
+      response, _ = json.JSONDecoder().raw_decode(text[start:])
+      if set(response) != {'decision', 'speech'} or not all(
+          isinstance(x, str) for x in response.values()
+      ):
+        raise ValueError('Expected decision and speech')
+      decision, speech = response['decision'].lower(), response['speech']
+      if decision not in (
+          'speak',
+          'accept',
+          'decline',
+          'counter',
+          'revoke',
+          'perform',
+      ):
+        raise ValueError('Unknown decision')
+    except (ValueError, TypeError, AttributeError):
+      decision, speech = 'speak', 'I cannot give a clear commitment right now.'
+      self.emit(
+          'invalid_resident_response',
+          f'{actor} returned an unsupported decision; no consent recorded.',
+          [actor],
+      )
+    self.emit(
+        'speech',
+        actor + ': ' + speech,
+        task['audience'],
+        actor=actor,
+        decision=decision,
+        purpose=task['purpose'],
+    )
+    self.data['dialogue'].append({
+        'actor': actor,
+        'decision': decision,
+        'watch': self.data['watch'],
+        'audience': task['audience'],
+        'speech': speech,
+    })
+    purpose = task['purpose']
+    if purpose.startswith('dawn'):
+      self.data['dawn_responses'][actor] = speech
+      return
+    if purpose.startswith('request:') and decision == 'accept':
+      kind = 'resources' if actor == 'Nell' else 'labor'
+      if not self._commitment(actor, kind):
+        self.data['commitments'].append({
+            'id': len(self.data['commitments']) + 1,
+            'owner': actor,
+            'kind': kind,
+            'status': 'accepted',
+            'watch': self.data['watch'],
+        })
+      self.emit(
+          'consent',
+          f'{actor} explicitly accepts the requested {kind} commitment.',
+      )
+    elif decision == 'revoke':
+      c = self._commitment(actor, 'resources' if actor == 'Nell' else 'labor')
+      if c:
+        c['status'] = 'revoked'
+        self.emit('revoked', f'{actor} withdraws their unfulfilled commitment.')
+    elif purpose.startswith('work:') and decision == 'perform':
+      labor = self._commitment('Ivo', 'labor')
+      if (
+          actor == 'Ivo'
+          and labor
+          and not self.data['repair']
+          and self.data['watch'] < 2
+          and self.stock.get_player_inventory('Ivo')['part'] == 1
+      ):
+        self.transfer('Ivo', 'Used', 'part', 1)
+        self.data['repair'] = True
+        labor['status'] = 'honored'
+        self.emit(
+            'repair',
+            'Ivo performs the accepted repair with the spare part. Before Dawn'
+            ' beacon demand is now zero.',
+        )
+      else:
+        self.emit(
+            'failed_attempt',
+            'No repair: accepted Ivo labor, delivered spare part and completion'
+            ' before Before Dawn are all required.',
+        )
+    if decision in ('accept', 'decline', 'counter', 'revoke'):
+      # Record interaction history, not a scalar theory of trust.
+      self.data['relationships'].append({
+          'from': actor,
+          'to': PLAYER,
+          'event': decision,
+          'watch': self.data['watch'],
+          'text': speech,
+          'recipients': task['audience'],
+      })
+
+  def _boundary(self):
+    watch = self.data['watch']
+    if watch >= 3:
+      return
+    supplied = []
+    consumption = 0
+    available = self.stock.get_player_inventory('Generator')['fuel']
+    for facility in self.data['allocations']:
+      demand = (
+          0
+          if facility == 'beacon' and watch == 2 and self.data['repair']
+          else 1
+      )
+      if consumption + demand <= available:
+        supplied.append(facility)
+        consumption += demand
+    if consumption:
+      self.transfer('Generator', 'Used', 'fuel', consumption)
+    for facility in FACILITIES:
+      served = facility in supplied
+      self.data['services'].append({
+          'watch': WATCHES[watch],
+          'facility': facility,
+          'served': served,
+          'demand': (
+              0
+              if facility == 'beacon' and watch == 2 and self.data['repair']
+              else 1
+          ),
+          'consequence': (
+              'Service maintained.' if served else CONSEQUENCES[facility]
+          ),
+      })
+    for c in self.data['commitments']:
+      if (
+          c['owner'] == PLAYER
+          and c['status'] == 'accepted'
+          and c['watch'] == watch
+      ):
+        c['status'] = 'honored' if c['facility'] in supplied else 'broken'
+    self.emit(
+        'watch_closed',
+        WATCHES[watch]
+        + ' closes. Supplied: '
+        + (', '.join(supplied) or 'none')
+        + f'. Fuel consumed: {consumption}.',
+    )
+    self.data['watch'] += 1
+    self.data['actions'] = 0
+    if self.data['watch'] == 1:
+      self.emit(
+          'disputed_account', self.dispute['text'], self.dispute['recipients']
+      )
+      for name in self.dispute['recipients']:
+        self.data['knowledge'][name].append('Previous storm dispute')
+    if self.data['watch'] == 3:
+      for c in self.data['commitments']:
+        if c['status'] == 'accepted':
+          c['status'] = 'unfulfilled'
+      failures = [x for x in self.data['services'] if not x['served']]
+      self.data['epilogue'] = {
+          'title': 'Dawn at Bellwether',
+          'services_maintained': 9 - len(failures),
+          'services_total': 9,
+          'fuel_used': self.stock.get_player_inventory('Used')['fuel'],
+          'repair_completed': self.data['repair'],
+          'consequences': failures,
+          'commitments': copy.deepcopy(self.data['commitments']),
+          'dispute_settled': False,
+      }
+      self.emit(
+          'dawn',
+          'Dawn. '
+          + str(9 - len(failures))
+          + '/9 facility-watches supplied. '
+          'The previous-storm dispute is not settled by this accounting. '
+          + ' '.join(x['facility'] + ': ' + x['consequence'] for x in failures),
+      )
+      self._queue(
+          list(scenario.RESIDENTS),
+          'dawn: respond to the recorded outcomes in your own voice',
+      )
+    else:
+      self.emit(
+          'watch_opened',
+          WATCHES[self.data['watch']] + ': four consequential choices remain.',
+      )
+
+  def view(self, viewer=PLAYER):
+    with self.lock:
+      data = self.data
+      return copy.deepcopy({
+          'watch': WATCHES[data['watch']] if data['watch'] < 3 else 'Dawn',
+          'remaining': max(0, 4 - data['actions']) if data['watch'] < 3 else 0,
+          'next_actor': self.next_actor if not self.finished else None,
+          'inventory': self.inventory_state(),
+          'repair': data['repair'],
+          'allocation': data['allocations'],
+          'commitments': data['commitments'],
+          'services': data['services'],
+          'epilogue': data['epilogue'],
+          'dawn_responses': data['dawn_responses'],
+          'journal': [x for x in data['events'] if viewer in x['recipients']],
+          'relationships': [
+              x for x in data['relationships'] if viewer in x['recipients']
+          ],
+          'institutions': INSTITUTIONS,
+          'knowledge': data['knowledge'][viewer],
+      })
+
+
+class Signal(entity_component.ContextComponent):
+  """Expose a single GM policy output from the scenario component."""
+
+  def __init__(self, world, output_type, value):
+    self.world = world
+    self.output_type = output_type
+    self.value = value
+
+  def pre_act(self, action_spec):
+    return self.value() if action_spec.output_type == self.output_type else ''
+
+  def get_state(self):
+    return {}
+
+  def set_state(self, state):
+    del state

--- a/concordia/examples/bellwether/game.py
+++ b/concordia/examples/bellwether/game.py
@@ -214,6 +214,27 @@ def parse_action(text):
   )
 
 
+def parse_resident_response(text):
+  """Validate the shared decision/speech contract before a human turn wakes."""
+  start = text.find('{')
+  response, _ = json.JSONDecoder().raw_decode(text[start:])
+  if set(response) != {'decision', 'speech'} or not all(
+      isinstance(x, str) for x in response.values()
+  ):
+    raise ValueError('Expected decision and speech')
+  decision, speech = response['decision'].lower(), response['speech']
+  if decision not in (
+      'speak',
+      'accept',
+      'decline',
+      'counter',
+      'revoke',
+      'perform',
+  ):
+    raise ValueError('Unknown decision')
+  return decision, speech
+
+
 class StormNight(
     entity_component.ContextComponent, entity_component.ComponentWithLogging
 ):
@@ -510,23 +531,8 @@ class StormNight(
 
   def _resident(self, actor, text, task):
     # Malformed output is NEVER silently turned into agreement.
-    start = text.find('{')
     try:
-      response, _ = json.JSONDecoder().raw_decode(text[start:])
-      if set(response) != {'decision', 'speech'} or not all(
-          isinstance(x, str) for x in response.values()
-      ):
-        raise ValueError('Expected decision and speech')
-      decision, speech = response['decision'].lower(), response['speech']
-      if decision not in (
-          'speak',
-          'accept',
-          'decline',
-          'counter',
-          'revoke',
-          'perform',
-      ):
-        raise ValueError('Unknown decision')
+      decision, speech = parse_resident_response(text)
     except (ValueError, TypeError, AttributeError):
       decision, speech = 'speak', 'I cannot give a clear commitment right now.'
       self.emit(
@@ -708,12 +714,20 @@ class StormNight(
           'services': data['services'],
           'epilogue': data['epilogue'],
           'dawn_responses': data['dawn_responses'],
-          'journal': [x for x in data['events'] if viewer in x['recipients']],
+          'journal': [
+              x
+              for x in data['events']
+              if (
+                  set(NAMES) <= set(x['recipients'])
+                  if viewer == 'spectator'
+                  else viewer in x['recipients']
+              )
+          ],
           'relationships': [
               x for x in data['relationships'] if viewer in x['recipients']
           ],
           'institutions': INSTITUTIONS,
-          'knowledge': data['knowledge'][viewer],
+          'knowledge': data['knowledge'].get(viewer, []),
       })
 
 

--- a/concordia/examples/bellwether/game.py
+++ b/concordia/examples/bellwether/game.py
@@ -240,7 +240,9 @@ class StormNight(
 ):
   """Resolve the scenario’s consent, agenda, watches and grounded records."""
 
-  def __init__(self, stock, observations, *, dispute=None, lock=None):
+  def __init__(
+      self, stock, observations, *, dispute=None, institutions=None, lock=None
+  ):
     super().__init__()
     self.stock = stock
     self.observations = observations
@@ -256,6 +258,10 @@ class StormNight(
         or any(x not in NAMES for x in self.dispute['recipients'])
     ):
       raise ValueError('dispute requires text and valid recipient names')
+    self.institutions = copy.deepcopy(
+        INSTITUTIONS if institutions is None else institutions
+    )
+    self._validate_institutions(self.institutions)
     self.data: dict[str, Any] = {
         'watch': 0,
         'actions': 0,
@@ -271,7 +277,7 @@ class StormNight(
         'epilogue': None,
         'dawn_responses': {},
         'knowledge': {
-            name: [x['name'] for x in INSTITUTIONS] for name in NAMES
+            name: [x['name'] for x in self.institutions] for name in NAMES
         },
     }
     self._putative = ''
@@ -282,18 +288,63 @@ class StormNight(
           'night': self.data,
           'putative': self._putative,
           'dispute': self.dispute,
+          'institutions': self.institutions,
       })
 
   def set_state(self, state):
     # Component serialization is not a full engine continuation contract.
+    institutions = copy.deepcopy(state.get('institutions', self.institutions))
+    self._validate_institutions(institutions)
+    night = copy.deepcopy(state['night'])
+    putative = state['putative']
+    dispute = copy.deepcopy(state['dispute'])
     with self.lock:
-      self.data = copy.deepcopy(state['night'])
-      self._putative = state['putative']
-      self.dispute = copy.deepcopy(state['dispute'])
+      self.institutions = institutions
+      self.data = night
+      self._putative = putative
+      self.dispute = dispute
 
-  def seed(self):
-    self.emit('opening', OPENING)
-    for name, (_, account) in scenario.RESIDENTS.items():
+  @staticmethod
+  def _validate_institutions(institutions):
+    if not isinstance(institutions, list):
+      raise ValueError('institutions must be a list')
+    names = set()
+    for item in institutions:
+      if (
+          not isinstance(item, dict)
+          or set(item) != {'name', 'members', 'rule', 'enforcement'}
+          or any(
+              not isinstance(item[key], str)
+              for key in ('name', 'rule', 'enforcement')
+          )
+          or not item['name'].strip()
+          or item['name'] in names
+          or not isinstance(item['members'], list)
+          or any(name not in NAMES for name in item['members'])
+      ):
+        raise ValueError(
+            'institutions require unique names, known members and text'
+            ' rules/enforcement'
+        )
+      names.add(item['name'])
+
+  def seed(self, *, opening=OPENING, accounts=None):
+    accounts = (
+        {name: values[1] for name, values in scenario.RESIDENTS.items()}
+        if accounts is None
+        else copy.deepcopy(accounts)
+    )
+    if (
+        not isinstance(opening, str)
+        or not isinstance(accounts, dict)
+        or set(accounts) != set(scenario.RESIDENTS)
+        or any(not isinstance(text, str) for text in accounts.values())
+    ):
+      raise ValueError(
+          'seed requires opening text and one text account per resident'
+      )
+    self.emit('opening', opening)
+    for name, account in accounts.items():
       self.emit('private_memory', account, [name])
 
   def emit(self, kind, text, audience=None, **details):
@@ -726,7 +777,7 @@ class StormNight(
           'relationships': [
               x for x in data['relationships'] if viewer in x['recipients']
           ],
-          'institutions': INSTITUTIONS,
+          'institutions': self.institutions,
           'knowledge': data['knowledge'].get(viewer, []),
       })
 

--- a/concordia/examples/bellwether/game_browser_test.py
+++ b/concordia/examples/bellwether/game_browser_test.py
@@ -1,0 +1,139 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chromium transport checks on a synthetic input, not simulation execution."""
+
+import json
+import pathlib
+import subprocess
+import sys
+import threading
+from unittest import mock
+
+from concordia.examples.bellwether import game_service
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+from concordia.utils import simulation_server
+import pytest
+
+playwright = pytest.importorskip('playwright.sync_api')
+
+
+def test_full_game_inspection_clarification_and_retry(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('This test never launches a simulation'),
+  ):
+    game = game_service.Game(tmp_path)
+    player = simulation_server.SimulationServer(
+        port=0,
+        operation_service=game.operations,
+        audience='player',
+        html_content=pathlib.Path(__file__)
+        .with_name('player.html')
+        .read_text(encoding='utf-8'),
+    )
+    results = []
+    request = human_input.HumanInputRequest(
+        request_id='synthetic-input',
+        entity_name='Coordinator',
+        action_spec=entity_lib.free_action_spec(
+            call_to_action='What do you do?'
+        ),
+        contexts={},
+        context='Only the coordinator’s available context.',
+    )
+    reader = threading.Thread(
+        target=lambda: results.append(game.inbox(request))
+    )
+    player.start()
+    reader.start()
+    try:
+      with playwright.sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        page = browser.new_page(viewport={'width': 390, 'height': 844})
+        errors = []
+        page.on('pageerror', lambda error: errors.append(str(error)))
+        url = f'http://127.0.0.1:{player.bound_port}'
+        page.goto(url)
+        playwright.expect(page.locator('#act')).to_be_enabled()
+        playwright.expect(page.locator('#watch')).to_have_text(
+            'Dusk · 4 choices remain'
+        )
+        initial = game.operations.snapshot('player')
+        for button in page.locator('#map button').all():
+          button.click()
+        assert game.operations.snapshot('player') == initial
+        page.click('#all-cast')
+        assert page.locator('#cast .card').count() == 4
+        page.locator('#cast .card').filter(has_text='Nell').get_by_text(
+            'Private', exact=True
+        ).click()
+        assert page.locator('#action').input_value() == 'message Nell: '
+        page.locator('#action').fill('ambiguous allocation')
+        page.reload()
+        playwright.expect(page.locator('#act')).to_be_enabled()
+        assert page.locator('#action').input_value() == 'ambiguous allocation'
+        page.click('#act')
+        playwright.expect(page.locator('#error')).to_contain_text(
+            'Nothing changed'
+        )
+        assert game.operations.snapshot('player') == initial
+        assert not results
+        words = 'message Nell: "A proposal" 🌊 & <img src=x onerror=alert(1)>'
+        page.locator('#action').fill(words)
+        with page.expect_request('**/api/dispatch') as sent:
+          page.click('#act')
+        reader.join(timeout=2)
+        assert results == [words]
+        body = sent.value.post_data_json
+        first = game.operations.dispatch('player', body)
+        # Noninteractive attached CLI retries the SAME effect/key.
+        retried = subprocess.run(
+            [
+                sys.executable,
+                '-m',
+                'concordia.command_line_interface.concordia_session',
+                '--url',
+                url,
+                'call',
+            ],
+            input=json.dumps(body),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert json.loads(retried.stdout) == first
+        assert results == [words]
+        assert page.locator('img').count() == 0
+        assert 'PRIVATE_NELL' not in page.content()
+        page.route('**/api/events', lambda route: route.abort('failed'))
+        page.reload()
+        playwright.expect(page.locator('#connection')).to_contain_text(
+            'Reconnecting'
+        )
+        playwright.expect(page.locator('#begin')).to_be_disabled()
+        page.unroute('**/api/events')
+        playwright.expect(page.locator('#connection')).to_contain_text(
+            'Connected', timeout=15000
+        )
+        assert page.evaluate(
+            'document.documentElement.scrollWidth <= innerWidth'
+        )
+        assert not errors
+        browser.close()
+    finally:
+      game.close()
+      player.stop()
+      reader.join(timeout=2)

--- a/concordia/examples/bellwether/game_prefab.py
+++ b/concordia/examples/bellwether/game_prefab.py
@@ -68,6 +68,7 @@ class Resident(prefab_lib.Prefab):
     params: dict[str, Any] = dict(self.params)
     style = params.pop('decision_logic')
     account = params.pop('account')
+    reader = params.pop('human_reader', None)
     params['extra_components'] = {
         scenario.ACCOUNT: constant.Constant(
             account, pre_act_label='Previous storm account'
@@ -92,10 +93,21 @@ class Resident(prefab_lib.Prefab):
           pre_act_label='Resident instructions',
       )
     builder = basic.Entity if style == 'basic' else minimal.Entity
-    return builder(params=params).build(model, memory_bank)
+    policy = (
+        (
+            lambda order: human_act_component.HumanActComponent(
+                reader, component_order=order
+            )
+        )
+        if reader is not None
+        else None
+    )
+    return builder(params=params).build(
+        model, memory_bank, act_component_factory=policy
+    )
 
 
-def configuration(reader, world, *, actor_logic='minimal'):
+def configuration(reader, world, *, actor_logic='minimal', human_readers=None):
   """Build fresh components per service; this Config is single-build only."""
   if actor_logic not in ('minimal', 'basic'):
     raise ValueError(
@@ -194,6 +206,11 @@ def configuration(reader, world, *, actor_logic='minimal'):
                 'goal': goal,
                 'account': account,
                 'decision_logic': actor_logic,
+                **(
+                    {'human_reader': human_readers[name]}
+                    if human_readers and name in human_readers
+                    else {}
+                ),
                 'custom_instructions': (
                     f'You are {name}, a resident of Bellwether. {goal} Make'
                     ' your own decisions based on your memories and delivered'

--- a/concordia/examples/bellwether/game_prefab.py
+++ b/concordia/examples/bellwether/game_prefab.py
@@ -1,0 +1,225 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trusted Bellwether configuration, using standard actor and GM build paths."""
+
+import json
+from typing import Any
+
+from concordia.components.agent import constant
+from concordia.components.agent import human_act_component
+from concordia.components.game_master import make_observation
+from concordia.components.game_master import switch_act
+from concordia.environment import engine
+from concordia.examples.bellwether import game
+from concordia.examples.bellwether import scenario
+from concordia.language_model import no_language_model
+from concordia.prefabs.entity import basic
+from concordia.prefabs.entity import minimal
+from concordia.typing import entity as entity_lib
+from concordia.typing import prefab as prefab_lib
+
+
+class FixtureModel(no_language_model.NoLanguageModel):
+  """Deliberately cooperative fixture, not live residents or social evidence."""
+
+  def sample_text(self, prompt, **kwargs):
+    del kwargs
+    # Read only the final task, not earlier observations. No external model.
+    task = prompt.rsplit('Respond to this delivered task', 1)[-1]
+    decision = 'speak'
+    if '"purpose": "request:' in task:
+      decision = 'accept'
+    elif '"purpose": "work:' in task:
+      decision = 'perform'
+    return json.dumps({
+        'decision': decision,
+        'speech': {
+            'speak': 'I am concerned for the people who rely on my facility.',
+            'accept': 'I accept this specific request. Record my commitment.',
+            'perform': (
+                'I choose to perform my accepted repair if the required part is'
+                ' here.'
+            ),
+        }[decision],
+    })
+
+
+class Resident(prefab_lib.Prefab):
+  """Fresh standard minimal/basic components and the normal ConcatAct policy."""
+
+  description = (
+      'A live Bellwether resident; identity and decision logic are'
+      ' configurable.'
+  )
+
+  def build(self, model, memory_bank):
+    params: dict[str, Any] = dict(self.params)
+    style = params.pop('decision_logic')
+    account = params.pop('account')
+    params['extra_components'] = {
+        scenario.ACCOUNT: constant.Constant(
+            account, pre_act_label='Previous storm account'
+        ),
+        'Affiliations': constant.Constant(
+            json.dumps(
+                [
+                    x
+                    for x in game.INSTITUTIONS
+                    if params['name'] in x['members']
+                ],
+                ensure_ascii=False,
+            ),
+            pre_act_label='Institutions known to me',
+        ),
+    }
+    if style == 'basic':
+      # Basic keeps its own standard instructions; add the resident's scenario
+      # instructions as a context, using the same extension mechanism.
+      params['extra_components']['ResidentInstructions'] = constant.Constant(
+          params.pop('custom_instructions'),
+          pre_act_label='Resident instructions',
+      )
+    builder = basic.Entity if style == 'basic' else minimal.Entity
+    return builder(params=params).build(model, memory_bank)
+
+
+def configuration(reader, world, *, actor_logic='minimal'):
+  """Build fresh components per service; this Config is single-build only."""
+  if actor_logic not in ('minimal', 'basic'):
+    raise ValueError(
+        'Choose standard minimal or basic resident decision logic.'
+    )
+
+  class Coordinator(prefab_lib.Prefab):
+    """Use the transport-neutral human policy with standard context."""
+
+    description = 'Human emergency coordinator.'
+
+    def build(self, model, memory_bank):
+      def human_policy(order):
+        return human_act_component.HumanActComponent(
+            reader, component_order=order
+        )
+
+      return minimal.Entity(params=self.params).build(
+          model, memory_bank, act_component_factory=human_policy
+      )
+
+  class GameMaster(prefab_lib.Prefab):
+    """Compose standard routing with the scenario’s explicit rules."""
+
+    description = (
+        'Explicit conservation and consent with standard SwitchAct routing.'
+    )
+
+    def build(self, model, memory_bank):
+      output = entity_lib.OutputType
+
+      def signal(kind, value):
+        return game.Signal(world, kind, value)
+
+      components = {
+          switch_act.DEFAULT_RESOLUTION_COMPONENT_KEY: world,
+          'Inventory': world.stock,
+          switch_act.DEFAULT_NEXT_ACTING_COMPONENT_KEY: signal(
+              output.NEXT_ACTING, lambda: world.next_actor
+          ),
+          switch_act.DEFAULT_NEXT_ACTION_SPEC_COMPONENT_KEY: signal(
+              output.NEXT_ACTION_SPEC,
+              lambda: engine.action_spec_to_string(
+                  entity_lib.free_action_spec(
+                      call_to_action=world.action_prompt()
+                  )
+              ),
+          ),
+          switch_act.DEFAULT_TERMINATE_COMPONENT_KEY: signal(
+              output.TERMINATE, lambda: 'Yes' if world.finished else 'No'
+          ),
+          switch_act.DEFAULT_MAKE_OBSERVATION_COMPONENT_KEY: (
+              make_observation.MakeObservation(
+                  model,
+                  player_names=game.NAMES,
+                  allow_llm_fallback=False,
+                  external_queue=world.observations,
+              )
+          ),
+      }
+      return minimal.Entity(
+          params={
+              'name': game.GM,
+              'custom_instructions': (
+                  'Enforce declared rules; never infer material or consent from'
+                  ' prose.'
+              ),
+              'extra_components': components,  # pyrefly: ignore[bad-assignment]
+          }
+      ).build(
+          model,
+          memory_bank,
+          act_component=switch_act.SwitchAct(model, entity_names=game.NAMES),
+      )
+
+  instances = [
+      prefab_lib.InstanceConfig(
+          prefab='coordinator',
+          role=prefab_lib.Role.ENTITY,
+          params={
+              'name': game.PLAYER,
+              'custom_instructions': (
+                  'Coordinate emergency response. Speak only for yourself.'
+                  ' Looking around is free.'
+              ),
+          },
+      )
+  ]
+  for name, (goal, account) in scenario.RESIDENTS.items():
+    instances.append(
+        prefab_lib.InstanceConfig(
+            prefab='resident',
+            role=prefab_lib.Role.ENTITY,
+            params={
+                'name': name,
+                'goal': goal,
+                'account': account,
+                'decision_logic': actor_logic,
+                'custom_instructions': (
+                    f'You are {name}, a resident of Bellwether. {goal} Make'
+                    ' your own decisions based on your memories and delivered'
+                    ' observations. No narrator may commit you without your'
+                    ' explicit acceptance. You may accept, refuse, negotiate'
+                    ' or revoke your unfulfilled commitment. A spoken claim is'
+                    ' not a completed physical action. Do not repeat internal'
+                    ' PRIVATE_ markers in speech.'
+                ),
+            },
+        )
+    )
+  instances.append(
+      prefab_lib.InstanceConfig(
+          prefab='game_master',
+          role=prefab_lib.Role.GAME_MASTER,
+          params={'name': game.GM},
+      )
+  )
+  return prefab_lib.Config(
+      default_max_steps=64,
+      default_premise='',
+      prefabs={
+          'coordinator': Coordinator(),
+          'resident': Resident(),
+          'game_master': GameMaster(),
+      },
+      instances=instances,
+  )

--- a/concordia/examples/bellwether/game_prefab.py
+++ b/concordia/examples/bellwether/game_prefab.py
@@ -68,6 +68,7 @@ class Resident(prefab_lib.Prefab):
     params: dict[str, Any] = dict(self.params)
     style = params.pop('decision_logic')
     account = params.pop('account')
+    institutions = params.pop('institutions', game.INSTITUTIONS)
     reader = params.pop('human_reader', None)
     params['extra_components'] = {
         scenario.ACCOUNT: constant.Constant(
@@ -75,11 +76,7 @@ class Resident(prefab_lib.Prefab):
         ),
         'Affiliations': constant.Constant(
             json.dumps(
-                [
-                    x
-                    for x in game.INSTITUTIONS
-                    if params['name'] in x['members']
-                ],
+                [x for x in institutions if params['name'] in x['members']],
                 ensure_ascii=False,
             ),
             pre_act_label='Institutions known to me',
@@ -206,6 +203,7 @@ def configuration(reader, world, *, actor_logic='minimal', human_readers=None):
                 'goal': goal,
                 'account': account,
                 'decision_logic': actor_logic,
+                'institutions': world.institutions,
                 **(
                     {'human_reader': human_readers[name]}
                     if human_readers and name in human_readers

--- a/concordia/examples/bellwether/game_service.py
+++ b/concordia/examples/bellwether/game_service.py
@@ -21,6 +21,7 @@ import time
 from concordia.components.game_master import make_observation
 from concordia.examples.bellwether import game
 from concordia.examples.bellwether import game_prefab
+from concordia.examples.bellwether import public_account
 from concordia.examples.bellwether import scenario
 from concordia.examples.bellwether import service
 from concordia.utils import operation_service as ops
@@ -82,6 +83,20 @@ class Game(service.Bellwether):
 
   def _register(self):
     super()._register()
+    self.operations.register(
+        ops.Operation(
+            'game.public_account',
+            'Download public events and accounting only, not a checkpoint.',
+            {'format': ops.Parameter('string', 'json or html', max_length=4)},
+            lambda args: public_account.export(
+                self.world,
+                fixture=self.fixture,
+                phase=self.phase,
+                format_name=args['format'],
+            ),
+            audiences=(*self.player_audiences, 'role:spectator', 'developer'),
+        )
+    )
     self.operations.register(
         ops.Operation(
             'game.begin',

--- a/concordia/examples/bellwether/game_service.py
+++ b/concordia/examples/bellwether/game_service.py
@@ -47,7 +47,8 @@ class Game(service.Bellwether):
       dispute=None,
       session_id=None,
       port=0,
-      profiler=None
+      profiler=None,
+      human_readers=None
   ):
     self.fixture = model is None
     self.backend = 'fixture' if self.fixture else 'live'
@@ -64,7 +65,10 @@ class Game(service.Bellwether):
         session_id=session_id,
         port=port,
         config_factory=lambda reader: game_prefab.configuration(
-            reader, self.world, actor_logic=actor_logic
+            reader,
+            self.world,
+            actor_logic=actor_logic,
+            human_readers=human_readers,
         ),
         model=model or game_prefab.FixtureModel(),
         max_steps=64,
@@ -84,7 +88,7 @@ class Game(service.Bellwether):
             'Begin the night. One run only; reload never restarts.',
             {},
             self._start,
-            audiences=('player',),
+            audiences=self.player_audiences,
             mutation=True,
         )
     )
@@ -98,7 +102,7 @@ class Game(service.Bellwether):
                 )
             },
             lambda args: game.parse_action(args['text']),
-            audiences=('player', 'developer'),
+            audiences=(*self.player_audiences, 'developer'),
         )
     )
     self.operations.register(

--- a/concordia/examples/bellwether/game_service.py
+++ b/concordia/examples/bellwether/game_service.py
@@ -1,0 +1,212 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Full-night specialization of the shared Bellwether service."""
+
+import copy
+import json
+import time
+
+from concordia.components.game_master import make_observation
+from concordia.examples.bellwether import game
+from concordia.examples.bellwether import game_prefab
+from concordia.examples.bellwether import scenario
+from concordia.examples.bellwether import service
+from concordia.utils import operation_service as ops
+
+
+class Game(service.Bellwether):
+  """Twelve human choices, bounded resident turns, one authoritative service."""
+
+  initial_status = 'Ready to begin the night'
+  run_description = (
+      'Run the three-watch night with twelve human choices and bounded resident'
+      ' turns.'
+  )
+  response_description = (
+      'Submit a clarified human attempt for standard Sequential resolution.'
+  )
+
+  def __init__(
+      self,
+      output,
+      *,
+      model=None,
+      actor_logic='minimal',
+      dispute=None,
+      session_id=None,
+      port=0,
+      profiler=None
+  ):
+    self.fixture = model is None
+    self.backend = 'fixture' if self.fixture else 'live'
+    self.world = game.StormNight(
+        game.new_inventory(),
+        make_observation.ObservationQueue(),
+        dispute=dispute,
+    )
+    self.profiler = profiler
+    self.step_times = []
+    self._action_started = None
+    super().__init__(
+        output,
+        session_id=session_id,
+        port=port,
+        config_factory=lambda reader: game_prefab.configuration(
+            reader, self.world, actor_logic=actor_logic
+        ),
+        model=model or game_prefab.FixtureModel(),
+        max_steps=64,
+    )
+    self.world.lock = self.operations.lock
+    self.operations.references['project_id'] = 'bellwether-night-v1'
+    self.inbox.add_observation(game.OPENING)
+
+  def _seed(self):
+    self.world.seed()
+
+  def _register(self):
+    super()._register()
+    self.operations.register(
+        ops.Operation(
+            'game.begin',
+            'Begin the night. One run only; reload never restarts.',
+            {},
+            self._start,
+            audiences=('player',),
+            mutation=True,
+        )
+    )
+    self.operations.register(
+        ops.Operation(
+            'game.preview',
+            'Clarify an ordinary-language attempt without effects.',
+            {
+                'text': ops.Parameter(
+                    'string', 'Proposed action, without a turn cost'
+                )
+            },
+            lambda args: game.parse_action(args['text']),
+            audiences=('player', 'developer'),
+        )
+    )
+    self.operations.register(
+        ops.Operation(
+            'run.resume',
+            'Resume the existing worker, never replay or replace it.',
+            {},
+            self._resume,
+            mutation=True,
+        )
+    )
+
+  def _resume(self, args):
+    del args
+    if self._worker is None or not self._worker.is_alive():
+      raise ops.OperationError(
+          'no_active_run', 'There is no paused active run.'
+      )
+    self.server.step_controller.play()
+    self.operations.publish({'kind': 'run.resumed'})
+    return {'phase': self.phase}
+
+  def player_view(self):
+    public = copy.deepcopy(scenario.PUBLIC)
+    public['opening'] = game.OPENING
+    public['watch'] = self.world.view()['watch']
+    return {
+        'scenario': public,
+        'night': self.world.view(),
+        'human': self.inbox.snapshot(),
+        'phase': self.phase,
+        'fixture': self.fixture,
+    }
+
+  def developer_view(self):
+    view = super().developer_view()
+    view.update({
+        'initial': {
+            'mechanics': copy.deepcopy(scenario.INITIAL),
+            'dispute': copy.deepcopy(self.world.dispute),
+            'institutions': copy.deepcopy(game.INSTITUTIONS),
+        },
+        'night': self.world.get_state(),
+        'inventory': self.world.inventory_state(),
+        'trace': copy.deepcopy(self.simulation.get_raw_log()),
+        'backend': 'fixture' if self.fixture else 'live',
+        'step_times': list(self.step_times),
+        'model_profile': self.profiler.get_stats() if self.profiler else None,
+        'capability_gaps': [
+            'checkpoint/restore',
+            'branches/experiments',
+            'in-flight edits/cancellation',
+            'initial-project authoring',
+            'multi-field transactions',
+            'undo/redo',
+        ],
+    })
+    return view
+
+  def _respond(self, args):
+    # Validate before waking the human component or spending a choice.
+    game.parse_action(args['response'])
+    result = super()._respond(args)
+    if result['accepted']:
+      self._action_started = time.monotonic()
+    return result
+
+  def _step(self, data):
+    super()._step(data)
+    with self.operations.lock:
+      self.step_times.append({
+          'step': data.step,
+          'actor': data.acting_entity,
+          'seconds_since_human_submission': (
+              time.monotonic() - self._action_started
+              if self._action_started is not None
+              else None
+          ),
+      })
+      self.operations.publish({
+          'kind': 'game.resolved',
+          'actor': data.acting_entity,
+          'watch': self.world.view()['watch'],
+      })
+
+  def _finish(self):
+    if not self.world.finished and not self._failure:
+      self.phase = 'failed'
+      self._failure = 'IncompleteNight'
+    self.inbox.finish(
+        'Dawn has come.'
+        if not self._failure
+        else 'The night paused unexpectedly; your journal is retained.'
+    )
+    self.output.mkdir(parents=True, exist_ok=True)
+    (self.output / 'outcome.json').write_text(
+        json.dumps(
+            {
+                'player': self.player_view(),
+                'backend': 'fixture' if self.fixture else 'live',
+                'step_times': self.step_times,
+                'model_profile': (
+                    self.profiler.get_stats() if self.profiler else None
+                ),
+                'model_cost': None,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding='utf-8',
+    )

--- a/concordia/examples/bellwether/game_service.py
+++ b/concordia/examples/bellwether/game_service.py
@@ -143,7 +143,7 @@ class Game(service.Bellwether):
         'initial': {
             'mechanics': copy.deepcopy(scenario.INITIAL),
             'dispute': copy.deepcopy(self.world.dispute),
-            'institutions': copy.deepcopy(game.INSTITUTIONS),
+            'institutions': copy.deepcopy(self.world.institutions),
         },
         'night': self.world.get_state(),
         'inventory': self.world.inventory_state(),

--- a/concordia/examples/bellwether/game_test.py
+++ b/concordia/examples/bellwether/game_test.py
@@ -1,0 +1,328 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fictional rule tests, not live-model or human-subject evidence."""
+
+# Verify the standard policy type; no simulation is launched.
+# pylint: disable=protected-access
+
+import copy
+import json
+import pathlib
+import tempfile
+from unittest import mock
+
+from concordia.agents import entity_agent
+from concordia.components.agent import concat_act_component
+from concordia.components.game_master import make_observation
+from concordia.examples.bellwether import game
+from concordia.examples.bellwether import game_service
+from concordia.utils import operation_service as ops
+import pytest
+
+FULL_SERVICE = [
+    'ask Nell for fuel and part',
+    'transfer reserve and part',
+    'ask Ivo to repair',
+    'wait',
+    'order repair',
+    'promise shelter',
+    'tell everyone: Let us keep every facility supplied.',
+    'wait',
+    'allocate all',
+    'promise beacon',
+    'message Mara: The boats have a safe signal.',
+    'wait',
+]
+PRIORITIZE = [
+    'allocate shelter and cold store',
+    'promise shelter',
+    'tell everyone: Protect shelter and livelihoods.',
+    'wait',
+    'allocate shelter and cold store',
+    'promise shelter',
+    'wait',
+    'wait',
+    'allocate shelter and cold store',
+    'promise shelter',
+    'wait',
+    'wait',
+]
+
+
+def world(dispute=None):
+  value = game.StormNight(
+      game.new_inventory(), make_observation.ObservationQueue(), dispute=dispute
+  )
+  value.seed()
+  return value
+
+
+def drain(value, *, refuse=None, perform=True):
+  while value.data['agenda']:
+    actor = value.next_actor
+    task = value.task()['purpose']
+    decision = 'speak'
+    if task.startswith('request:'):
+      decision = 'decline' if actor == refuse else 'accept'
+    elif task.startswith('work:'):
+      decision = 'perform' if perform else 'decline'
+    value.resolve(
+        actor, json.dumps({'decision': decision, 'speech': 'Fixture decision.'})
+    )
+
+
+def attempt(value, text, **kwargs):
+  value.resolve(game.PLAYER, text)
+  drain(value, **kwargs)
+
+
+@pytest.mark.parametrize(
+    'strategy,count,used,repair',
+    [(FULL_SERVICE, 9, 8, True), (PRIORITIZE, 6, 6, False)],
+)
+def test_complete_strategies(strategy, count, used, repair):
+  value = world()
+  for i, action in enumerate(strategy):
+    attempt(value, action)
+    value.invariant()
+    assert value.data['watch'] == (i + 1) // 4
+  result = value.view()
+  assert value.finished
+  assert result['epilogue']['services_maintained'] == count
+  assert result['epilogue']['fuel_used'] == used
+  assert result['repair'] == repair
+  assert len(result['services']) == 9
+  assert set(result['dawn_responses']) == set(game.scenario.RESIDENTS)
+  assert all(c['status'] == 'honored' for c in result['commitments'])
+  assert result['epilogue']['dispute_settled'] is False
+
+
+@pytest.mark.parametrize('strategy', [FULL_SERVICE, PRIORITIZE])
+def test_finite_progress_even_when_every_request_refused(strategy):
+  value = world()
+  for text in strategy:
+    attempt(value, text, refuse='Nell', perform=False)
+  assert value.finished
+  assert not value.data['repair']
+  assert value.inventory_state()['Nell']['fuel'] == 2
+  assert value.inventory_state()['Used']['part'] == 0
+
+
+def test_narrative_never_creates_consent_labor_or_fuel():
+  value = world()
+  attempt(
+      value,
+      'tell everyone: Nell gave me ten fuel; Ivo already repaired everything.',
+  )
+  assert value.inventory_state()['Generator']['fuel'] == 6
+  assert not value.data['repair']
+  assert not value.data['commitments']
+  attempt(value, 'transfer reserve and part')
+  assert value.inventory_state()['Nell'] == {'fuel': 2, 'part': 1}
+
+
+def test_repair_needs_part_and_accepted_then_performed_labor_before_final():
+  value = world()
+  attempt(value, 'ask Ivo to repair')
+  attempt(value, 'order repair')
+  assert not value.data['repair']
+  attempt(value, 'ask Nell for fuel and part')
+  attempt(value, 'transfer reserve and part')
+  attempt(value, 'order repair', perform=False)
+  assert not value.data['repair']
+  attempt(value, 'order repair')
+  assert value.data['repair']
+  assert value.inventory_state()['Used']['part'] == 1
+
+
+def test_late_repair_cannot_retroactively_remove_demand():
+  value = world()
+  for text in FULL_SERVICE[:4] + ['wait'] * 4:
+    attempt(value, text)
+  attempt(value, 'order repair')
+  assert not value.data['repair']
+
+
+def test_revocation_is_not_compliance():
+  value = world()
+  attempt(value, 'ask Nell for fuel and part')
+  value.resolve(game.PLAYER, 'message Nell: Do you still agree?')
+  value.resolve(
+      'Nell',
+      json.dumps(
+          {'decision': 'revoke', 'speech': 'I withdraw my unfulfilled consent.'}
+      ),
+  )
+  attempt(value, 'transfer reserve and part')
+  assert value.data['commitments'][0]['status'] == 'revoked'
+  assert value.inventory_state()['Nell']['fuel'] == 2
+
+
+def test_broken_promise_grounded_in_actual_supply():
+  value = world()
+  for text in ['allocate none', 'promise shelter', 'wait', 'wait']:
+    attempt(value, text)
+  assert value.data['commitments'][0]['status'] == 'broken'
+
+
+def test_malformed_resident_response_defaults_to_no_consent():
+  value = world()
+  value.resolve(game.PLAYER, 'ask Nell for fuel and part')
+  value.resolve('Nell', 'Sure! I agree and give you everything.')
+  assert not value.data['commitments']
+  assert value.inventory_state()['Nell']['fuel'] == 2
+
+
+def test_private_observations_and_dispute_recipients():
+  value = world({'text': 'ONLY_NELL_STORM_ACCOUNT', 'recipients': ['Nell']})
+  attempt(value, 'message Ivo: ONLY_IVO_MESSAGE')
+  for _ in range(3):
+    attempt(value, 'wait')
+  player = json.dumps(value.view())
+  assert 'PRIVATE_NELL' not in player
+  assert 'ONLY_NELL_STORM_ACCOUNT' not in player
+  assert 'ONLY_IVO_MESSAGE' in player
+  for other in ['Mara', 'Nell', 'Sam']:
+    assert 'ONLY_IVO_MESSAGE' not in json.dumps(value.view(other))
+  queue = value.observations.get_all()
+  assert 'ONLY_NELL_STORM_ACCOUNT' in '\n'.join(queue['Nell'])
+  assert 'ONLY_NELL_STORM_ACCOUNT' not in '\n'.join(queue[game.PLAYER])
+  assert 'ONLY_IVO_MESSAGE' not in '\n'.join(queue['Sam'])
+  assert 'Previous storm dispute' in value.data['knowledge']['Nell']
+  assert 'Previous storm dispute' not in value.data['knowledge']['Mara']
+
+
+@pytest.mark.parametrize(
+    'text',
+    [
+        '',
+        'give fuel',
+        'allocate all and make 5 extra',
+        'ask Sam to give Nell’s consent',
+        'allocate beacon,beacon',
+    ],
+)
+def test_clarification_atomic_and_free(text):
+  value = world()
+  before = (value.get_state(), value.inventory_state())
+  with pytest.raises(ops.OperationError, match='Nothing changed'):
+    value.resolve(game.PLAYER, text)
+  assert before == (value.get_state(), value.inventory_state())
+
+
+def envelope(service, operation, arguments, key='test'):
+  snap = service.operations.snapshot('player')
+  return {
+      'operation': operation,
+      'arguments': arguments,
+      'retry_key': key,
+      'references': snap['references'],
+      'revision': snap['revision'],
+  }
+
+
+def test_shared_operations_stale_retry_privacy_and_component_ownership():
+  with tempfile.TemporaryDirectory() as directory:
+    first = game_service.Game(pathlib.Path(directory) / 'first')
+    second = game_service.Game(pathlib.Path(directory) / 'second')
+    try:
+      assert first.world is not second.world
+      before = copy.deepcopy(second.world.get_state())
+      request = envelope(
+          first, 'component.edit', {'value': 'PRIVATE_NEW_ACCOUNT'}
+      )
+      result = first.operations.dispatch('developer', request)
+      assert first.operations.dispatch('developer', request) == result
+      assert second.world.get_state() == before
+      with pytest.raises(ops.OperationError) as stale:
+        first.operations.dispatch(
+            'developer', {**request, 'retry_key': 'another'}
+        )
+      assert stale.value.code == 'stale_revision'
+      with pytest.raises(ops.OperationError) as hidden:
+        first.operations.dispatch('player', request)
+      assert hidden.value.code == 'unsupported_operation'
+      assert 'PRIVATE_NEW_ACCOUNT' not in json.dumps(
+          first.operations.snapshot('player')
+      )
+      snap = first.operations.snapshot('player')
+      with pytest.raises(ops.OperationError):
+        first.operations.dispatch(
+            'player',
+            envelope(
+                first,
+                'human.respond',
+                {'request_id': 'missing', 'response': 'invent fuel'},
+            ),
+        )
+      assert first.operations.snapshot('player') == snap
+      # Standard actor policy, not HumanAct or the fixture's own engine.
+      actor = next(
+          e for e in first.simulation.get_entities() if e.name == 'Mara'
+      )
+      assert isinstance(actor, entity_agent.EntityAgent)
+      assert isinstance(
+          actor._act_component, concat_act_component.ConcatActComponent
+      )
+      with mock.patch.object(
+          first.simulation,
+          'play',
+          side_effect=AssertionError('No simulation in this test'),
+      ):
+        assert first.player_view()['night']['remaining'] == 4
+    finally:
+      first.close()
+      second.close()
+
+
+@pytest.mark.parametrize(
+    'dispute',
+    [
+        {},
+        [],
+        {'text': 'account', 'recipients': ['unknown']},
+        {'text': 123, 'recipients': []},
+    ],
+)
+def test_invalid_dispute_rejected_before_seeding(dispute):
+  stock = game.new_inventory()
+  observations = make_observation.ObservationQueue()
+  before = copy.deepcopy(stock.get_state())
+  with pytest.raises(ValueError, match='dispute requires'):
+    game.StormNight(stock, observations, dispute=dispute)
+  assert stock.get_state() == before
+  assert not observations.get_all()
+
+
+@pytest.mark.parametrize('style', ['minimal', 'basic'])
+def test_resident_decision_logic_uses_standard_contexts(tmp_path, style):
+  session = game_service.Game(tmp_path, actor_logic=style)
+  try:
+    residents = [
+        e for e in session.simulation.get_entities() if e.name != game.PLAYER
+    ]
+    assert len(residents) == 4
+    for resident in residents:
+      assert isinstance(resident, entity_agent.EntityAgent)
+      assert isinstance(
+          resident._act_component, concat_act_component.ConcatActComponent
+      )
+      components = resident.get_all_context_components()
+      assert ('SelfPerception' in components) == (style == 'basic')
+      assert ('SituationPerception' in components) == (style == 'basic')
+      assert ('PersonBySituation' in components) == (style == 'basic')
+      assert 'Affiliations' in components
+  finally:
+    session.close()

--- a/concordia/examples/bellwether/guidance_browser_test.py
+++ b/concordia/examples/bellwether/guidance_browser_test.py
@@ -1,0 +1,212 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""First-play browser checks on real services; no simulation starts."""
+
+import pathlib
+from unittest import mock
+
+from concordia.examples.bellwether import game_service
+from concordia.examples.bellwether import multiplayer
+from concordia.utils import simulation_server
+import pytest
+
+pwlib = pytest.importorskip('playwright.sync_api')
+
+
+@pytest.fixture(name='host')
+def host_fixture(tmp_path):
+  servers = []
+  games = []
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No simulation in guidance tests'),
+  ):
+
+    def make(shared=False):
+      game = (
+          multiplayer.SharedGame(tmp_path, secure=False)
+          if shared
+          else game_service.Game(tmp_path)
+      )
+      server = simulation_server.SimulationServer(
+          port=0,
+          operation_service=game.operations,
+          audience='player',
+          browser_sessions=(
+              game.sessions
+              if isinstance(game, multiplayer.SharedGame)
+              else None
+          ),
+          html_content=pathlib.Path(__file__)
+          .with_name('player.html')
+          .read_text(encoding='utf-8'),
+      )
+      games.append(game)
+      servers.append(server)
+      server.start()
+      return game, f'http://127.0.0.1:{server.bound_port}'
+
+    try:
+      yield make
+    finally:
+      for game in games:
+        game.close()
+      for server in servers:
+        server.stop()
+
+
+def test_interpretation_is_free_literal_and_uses_shared_parser(host, tmp_path):
+  game, url = host()
+  initial = game.operations.snapshot('developer')
+  with pwlib.sync_playwright() as pw:
+    browser = pw.chromium.launch()
+    try:
+      page = browser.new_page(viewport={'width': 360, 'height': 800})
+      errors = []
+      page.on('pageerror', lambda e: errors.append(str(e)))
+      page.goto(url)
+      pwlib.expect(page.locator('#role-badge')).to_contain_text(
+          'Single player · You are Coordinator · Four scripted residents'
+      )
+      assert not page.locator('#join').is_visible()
+      page.locator('#first-play summary').click()
+      page.screenshot(
+          path=str(tmp_path / 'first-play-mobile.png'), full_page=True
+      )
+      page.locator('#action').fill('ask Nell for fuel and part')
+      with page.expect_request('**/api/dispatch') as request:
+        page.click('#preview')
+      assert request.value.post_data_json == {
+          'operation': 'game.preview',
+          'arguments': {'text': 'ask Nell for fuel and part'},
+      }
+      pwlib.expect(page.locator('#preview-result')).to_contain_text(
+          'She decides whether to accept.'
+      )
+      assert (
+          'no choice was spent' in page.locator('#preview-result').inner_text()
+      )
+      page.locator('#action').fill('invent fuel magically')
+      page.click('#preview')
+      pwlib.expect(page.locator('#preview-result')).to_contain_text(
+          'Nothing changed'
+      )
+      assert page.locator('#action').input_value() == 'invent fuel magically'
+      words = 'message everyone: "visible" <img src=x onerror=alert(1)> 🌊'
+      page.locator('#action').fill(words)
+      page.click('#preview')
+      pwlib.expect(page.locator('#preview-result')).to_contain_text(
+          'Public discussion to everyone'
+      )
+      assert '<img' in page.locator('#preview-result').inner_text()
+      assert page.locator('#preview-result img').count() == 0
+      assert game.operations.snapshot('developer') == initial
+      assert page.evaluate('innerWidth') == 360
+      assert page.evaluate('document.documentElement.scrollWidth') <= 360
+      assert not errors
+    finally:
+      browser.close()
+
+
+def test_delayed_preview_cannot_describe_a_changed_draft_and_reconnect(host):
+  game, url = host()
+  initial = game.operations.snapshot('developer')
+  with pwlib.sync_playwright() as pw:
+    browser = pw.chromium.launch()
+    try:
+      page = browser.new_page(viewport={'width': 412, 'height': 915})
+      # Delay only delivery after a REAL read-only server query. The delayed
+      # Response ignores browser abort to exercise the stale-result guard too.
+      page.add_init_script("""
+        const originalFetch=window.fetch.bind(window);
+        window.fetch=async(...args)=>{
+          const response=await originalFetch(...args);
+          if(window.holdPreview&&args[1]?.body?.includes('game.preview')){
+            const body=await response.text();
+            return new Promise(resolve=>{
+              window.releasePreview=()=>resolve(new Response(body,{
+                status:response.status,
+                headers:{'Content-Type':'application/json'}
+              }));
+            });
+          }
+          return response;
+        };
+      """)
+      page.goto(url)
+      pwlib.expect(page.locator('#connection')).to_contain_text('Connected')
+      page.locator('#action').fill('ask Nell for fuel')
+      page.evaluate('window.holdPreview=true')
+      page.click('#preview')
+      page.wait_for_function('typeof window.releasePreview==="function"')
+      page.locator('#action').fill('wait')
+      page.evaluate("""async()=>{
+        window.releasePreview();
+        await new Promise(resolve=>setTimeout(resolve,50));
+      }""")
+      pwlib.expect(page.locator('#preview-result')).to_be_empty()
+      page.evaluate('window.holdPreview=false')
+      page.click('#preview')
+      pwlib.expect(page.locator('#preview-result')).to_contain_text(
+          'Spend one choice waiting when you send'
+      )
+      page.route('**/api/events', lambda route: route.abort('failed'))
+      page.reload()
+      pwlib.expect(page.locator('#connection')).to_contain_text('Reconnecting')
+      pwlib.expect(page.locator('#preview')).to_be_disabled()
+      # Draft is restored only after a session/role snapshot is known.
+      page.unroute('**/api/events')
+      pwlib.expect(page.locator('#connection')).to_contain_text(
+          'Connected', timeout=15000
+      )
+      pwlib.expect(page.locator('#preview')).to_be_enabled()
+      assert page.locator('#action').input_value() == 'wait'
+      assert game.operations.snapshot('developer') == initial
+    finally:
+      browser.close()
+
+
+@pytest.mark.parametrize('role', ['Nell', 'spectator'])
+def test_other_roles_have_specific_guidance_not_coordinator_preview(host, role):
+  game, url = host(shared=True)
+  assert isinstance(game, multiplayer.SharedGame)
+  with pwlib.sync_playwright() as pw:
+    browser = pw.chromium.launch()
+    try:
+      page = browser.new_page(viewport={'width': 412, 'height': 915})
+      page.goto(url)
+      page.locator('#join-name').fill('Test ' + role)
+      page.select_option('#join-role', role)
+      page.click('#join-submit')
+      pwlib.expect(page.locator('#join-status')).to_contain_text(
+          'Waiting for host'
+      )
+      row = next(
+          r for r in game.sessions.pending() if r['label'] == 'Test ' + role
+      )
+      game.sessions.approve(row['id'])
+      game.operations.publish({'kind': 'test.host_approved'})
+      pwlib.expect(page.locator('#join')).to_be_hidden()
+      pwlib.expect(page.locator('#preview')).to_be_hidden()
+      page.locator('#first-play summary').click()
+      pwlib.expect(page.locator('#role-guide')).to_contain_text(
+          'You control Nell' if role == 'Nell' else 'Watch public events'
+      )
+      if role == 'Nell':
+        assert 'Two human roles' in page.locator('#role-badge').inner_text()
+      else:
+        assert not page.locator('#composer').is_visible()
+    finally:
+      browser.close()

--- a/concordia/examples/bellwether/multiplayer.py
+++ b/concordia/examples/bellwether/multiplayer.py
@@ -1,0 +1,190 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two controlled roles in the existing Bellwether night, not a new engine.
+
+Only the local host approves browsers. A visitor cannot choose its authorized
+role, inspect another inbox or send another actor's response. Other residents
+retain standard prefabs and their normal acting policies.
+"""
+
+import copy
+import json
+
+from concordia.examples.astral_canticle import human_io
+from concordia.examples.bellwether import game
+from concordia.examples.bellwether import game_service
+from concordia.utils import browser_sessions
+from concordia.utils import operation_service as ops
+
+
+class SharedGame(game_service.Game):
+  """Human Coordinator and Nell; AI Mara/Ivo/Sam; read-only public spectator."""
+
+  player_audiences = ('role:Coordinator', 'role:Nell')
+
+  def __init__(self, output, *, secure=True, cookie_path='/', **kwargs):
+    self.sessions = browser_sessions.BrowserSessions(
+        (game.PLAYER, 'Nell', 'spectator'),
+        secure=secure,
+        cookie_path=cookie_path,
+    )
+    self.nell_inbox = human_io.HumanSession(
+        on_request=self._requested, initial_status='Waiting for your turn'
+    )
+    self.response_handlers = {
+        'role:' + role: lambda args, role=role: self.respond_for(role, args)
+        for role in (game.PLAYER, 'Nell')
+    }
+    self.view_handlers = {
+        'role:' + role: lambda _, role=role: self.view_for(role)
+        for role in (game.PLAYER, 'Nell')
+    }
+    super().__init__(output, human_readers={'Nell': self.nell_inbox}, **kwargs)
+    self.operations.audience_resolver = self.sessions.audience
+    self.operations.set_view('visitor', lambda: {'lobby': True})
+    for role in (game.PLAYER, 'Nell', 'spectator'):
+      self.operations.set_view(
+          'role:' + role, lambda role=role: self.view_for(role)
+      )
+
+  def _register(self):
+    super()._register()
+    for name, description, handler in (
+        (
+            'session.approve',
+            (
+                'Approve a browser only after confirming the participant with'
+                ' the host.'
+            ),
+            self._approve,
+        ),
+        (
+            'session.revoke',
+            (
+                'Revoke a browser role; retain the pending human turn for'
+                ' rejoining.'
+            ),
+            self._revoke,
+        ),
+    ):
+      self.operations.register(
+          ops.Operation(
+              name,
+              description,
+              {
+                  'request_id': ops.Parameter(
+                      'string',
+                      'Pending browser ID from host inspection (not a'
+                      ' credential)',
+                  )
+              },
+              handler,
+              mutation=True,
+          )
+      )
+
+  def _approve(self, args):
+    result = self.sessions.approve(args['request_id'])
+    self.operations.publish({'kind': 'browser.approved', **result})
+    return result
+
+  def _revoke(self, args):
+    result = self.sessions.revoke(args['request_id'])
+    self.operations.publish({'kind': 'browser.revoked'})
+    return result
+
+  def developer_view(self):
+    return {
+        **super().developer_view(),
+        'join_requests': self.sessions.pending(),
+    }
+
+  def _start(self, args):
+    if not self.sessions.ready((game.PLAYER, 'Nell')):
+      raise ops.OperationError(
+          'players_not_ready',
+          'The host must approve both players before the night begins.',
+      )
+    return super()._start(args)
+
+  def view_for(self, role):
+    state = super().player_view()
+    state['night'] = self.world.view(role)
+    state['role'] = role
+    state['multiplayer'] = True
+    state['players_ready'] = self.sessions.ready((game.PLAYER, 'Nell'))
+    if role == 'spectator':
+      state['human'] = {
+          'pending': None,
+          'entries': [],
+          'finished': self.phase == 'completed',
+          'status': 'Watching public events',
+      }
+    elif role == 'Nell':
+      state['human'] = self.nell_inbox.snapshot()
+      if state['human']['pending']:
+        task = self.world.task()
+        state['task'] = copy.deepcopy(task)
+        state['human']['pending']['prompt'] = task.get(
+            'purpose', 'Your response'
+        )
+        purpose = task.get('purpose', '')
+        state['decisions'] = ['speak', 'counter', 'revoke']
+        if purpose.startswith('request:'):
+          state['decisions'] = ['accept', 'decline', 'counter']
+        if purpose.startswith('dawn'):
+          state['decisions'] = ['speak']
+    # No other actor's pending ID, context, task, log or private journal enters
+    # this view. The UI receives a projection, not hidden developer data.
+    return state
+
+  def respond_for(self, role, args):
+    if self.world.next_actor != role:
+      raise ops.OperationError(
+          'wrong_turn', 'Wait for your own turn; nothing changed.'
+      )
+    if role == game.PLAYER:
+      return super()._respond(args)
+    try:
+      decision, _ = game.parse_resident_response(args['response'])
+      json.loads(
+          args['response']
+      )  # Human replies must be one exact JSON object.
+      purpose = self.world.task().get('purpose', '')
+      allowed = {'speak', 'counter', 'revoke'}
+      if purpose.startswith('request:'):
+        allowed = {'accept', 'decline', 'counter'}
+      if purpose.startswith('dawn'):
+        allowed = {'speak'}
+      if decision not in allowed:
+        raise ValueError('Choose an available decision for this turn.')
+      changed = self.nell_inbox.submit(args['request_id'], args['response'])
+    except (ValueError, TypeError, AttributeError) as error:
+      raise ops.OperationError('invalid_action', str(error)) from error
+    if changed:
+      self.operations.publish({'kind': 'human.accepted', 'actor': role})
+    return {'accepted': changed}
+
+  def _finish(self):
+    self.nell_inbox.finish(
+        'Dawn has come.'
+        if not self._failure
+        else 'The night stopped; your journal is retained.'
+    )
+    super()._finish()
+
+  def close(self):
+    self.nell_inbox.finish('Service closed.')
+    super().close()

--- a/concordia/examples/bellwether/multiplayer_browser_test.py
+++ b/concordia/examples/bellwether/multiplayer_browser_test.py
@@ -1,0 +1,211 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Three real browser contexts with synthetic prompts; zero simulation steps."""
+
+import json
+import threading
+
+from concordia.examples.bellwether import game as rules
+from concordia.examples.bellwether.multiplayer_test import envelope
+from concordia.examples.bellwether.multiplayer_test import hosted_fixture  # pylint: disable=unused-import
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+from concordia.utils import visual_interface
+import pytest
+
+pw = pytest.importorskip('playwright.sync_api')
+
+
+def join(page, url, name, role):
+  page.goto(url)
+  pw.expect(page.locator('#join')).to_be_visible()
+  page.fill('#join-name', name)
+  page.select_option('#join-role', role)
+  page.click('#join-submit')
+  pw.expect(page.locator('#join-status')).to_contain_text(
+      'Waiting for host approval'
+  )
+
+
+def approve_in_editor(host, name):
+  host.wait_for_function(
+      """name => {
+        const text = document.querySelector('#op-state').textContent;
+        return JSON.parse(text).result.join_requests.some(r=>r.label===name);
+      }""",
+      arg=name,
+  )
+  rows = json.loads(host.locator('#op-state').inner_text())['result'][
+      'join_requests'
+  ]
+  row = next(r for r in rows if r['label'] == name)
+  host.select_option('#op-name', 'session.approve')
+  host.locator('[data-key=request_id]').fill(row['id'])
+  host.click('#op-submit')
+  pw.expect(host.locator('#op-error')).to_have_text('')
+  return row['id']
+
+
+def test_two_players_host_approval_private_turn_reconnect_and_android(
+    hosted, tmp_path
+):
+  game, _, url = hosted
+  game.server.set_html_content(
+      visual_interface.visualize_operations_to_html(game.config)
+  )
+  game.server.start()
+  results = []
+  with pw.sync_playwright() as runner:
+    browser = runner.chromium.launch()
+    cctx = browser.new_context(
+        viewport={'width': 360, 'height': 800}, is_mobile=True, has_touch=True
+    )
+    nctx = browser.new_context(
+        viewport={'width': 412, 'height': 820}, is_mobile=True, has_touch=True
+    )
+    sctx = browser.new_context(
+        viewport={'width': 800, 'height': 360}, has_touch=True
+    )
+    host = browser.new_page()
+    coordinator, nell, spectator = (
+        cctx.new_page(),
+        nctx.new_page(),
+        sctx.new_page(),
+    )
+    pages = [coordinator, nell, spectator, host]
+    errors = []
+    for page in pages:
+      page.on('pageerror', lambda e: errors.append(str(e)))
+    host.goto(f'http://127.0.0.1:{game.server.bound_port}')
+    for page, name, role in [
+        (coordinator, 'A', 'Coordinator'),
+        (nell, 'B', 'Nell'),
+        (spectator, 'C', 'spectator'),
+    ]:
+      join(page, url, name, role)
+      assert 'PRIVATE_' not in page.content()
+      approve_in_editor(host, name)
+      pw.expect(page.locator('#role-badge')).to_contain_text(
+          'Spectator' if role == 'spectator' else role
+      )
+    for page in [coordinator, nell, spectator]:
+      assert page.evaluate('document.documentElement.scrollWidth <= innerWidth')
+    with game.operations.lock:
+      game.world.emit('speech', 'PUBLIC_FOR_ALL')
+      game.world.emit('speech', 'ONLY_COORDINATOR', ['Coordinator'])
+      game.world.emit('speech', 'ONLY_NELL', ['Nell'])
+      game.world.emit('speech', 'ONLY_MARA', ['Mara'])
+      game.operations.publish({'kind': 'synthetic.deliver'})
+    pw.expect(coordinator.locator('#journal')).to_contain_text(
+        'ONLY_COORDINATOR'
+    )
+    pw.expect(nell.locator('#journal')).to_contain_text('ONLY_NELL')
+    pw.expect(spectator.locator('#journal')).to_contain_text('PUBLIC_FOR_ALL')
+    assert 'ONLY_NELL' not in coordinator.content()
+    assert 'ONLY_COORDINATOR' not in nell.content()
+    assert all(
+        x not in spectator.content()
+        for x in ['ONLY_NELL', 'ONLY_MARA', 'ONLY_COORDINATOR', 'PRIVATE_']
+    )
+    pw.expect(spectator.locator('#composer')).to_be_hidden()
+    game.phase = 'running'
+    game.world.data['agenda'] = [{
+        'name': 'Nell',
+        'purpose': 'request: release reserve ' + 'unbroken' * 20,
+        'audience': rules.NAMES,
+        'watch': 0,
+    }]
+    request = human_input.HumanInputRequest(
+        request_id='synthetic-nell',
+        entity_name='Nell',
+        action_spec=entity_lib.free_action_spec(call_to_action='Your decision'),
+        contexts={},
+        context='OWN_CONTEXT_NELL',
+    )
+    thread = threading.Thread(
+        target=lambda: results.append(game.nell_inbox(request))
+    )
+    thread.start()
+    try:
+      pw.expect(nell.locator('#act')).to_be_enabled()
+      assert nell.evaluate('document.documentElement.scrollWidth') <= 412
+      pw.expect(coordinator.locator('#act')).to_be_disabled()
+      assert 'OWN_CONTEXT_NELL' not in coordinator.content()
+      nell.select_option('#decision', 'decline')
+      words = 'No — "reserve" is for members. 🌊 <img src=x onerror=alert(1)>'
+      nell.fill('#action', words)
+      nell.reload()
+      pw.expect(nell.locator('#act')).to_be_enabled()
+      assert nell.locator('#action').input_value() == words
+      nell.select_option('#decision', 'decline')
+      nell.route('**/api/events', lambda route: route.abort('failed'))
+      nell.reload()
+      pw.expect(nell.locator('#connection')).to_contain_text('Reconnecting')
+      nell.unroute('**/api/events')
+      pw.expect(nell.locator('#act')).to_be_enabled(timeout=15000)
+      assert nell.locator('#action').input_value() == words
+      nell.select_option('#decision', 'decline')
+      nell.locator('#act').scroll_into_view_if_needed()
+      assert nell.locator('#act').evaluate(
+          'el => {const r=el.getBoundingClientRect();return el.contains('
+          'document.elementFromPoint(r.x+r.width/2,r.y+r.height/2))}'
+      )
+      nell.set_viewport_size({'width': 800, 'height': 360})
+      nell.click('#jump-action')
+      assert nell.evaluate('document.documentElement.scrollWidth <= innerWidth')
+      with nell.expect_request('**/api/dispatch') as sent:
+        nell.click('#act')
+      thread.join(2)
+      assert results == [
+          json.dumps(
+              {'decision': 'decline', 'speech': words},
+              separators=(',', ':'),
+              ensure_ascii=False,
+          )
+      ]
+      body = sent.value.post_data_json
+      retried = nell.evaluate(
+          """async body => {
+            const response = await fetch('api/dispatch', {
+              method:'POST', headers:{'Content-Type':'application/json'},
+              body:JSON.stringify(body)
+            });
+            return await response.json();
+          }""",
+          body,
+      )
+      assert retried['result']['accepted'] is True
+      assert len(results) == 1
+      assert nell.locator('img').count() == 0
+      # Revocation invalidates an already subscribed browser, not just new tabs.
+      row = next(r for r in game.sessions.pending() if r['role'] == 'Nell')
+      game.operations.dispatch(
+          'developer',
+          envelope(game, 'session.revoke', {'request_id': row['id']}),
+      )
+      pw.expect(nell.locator('#join')).to_be_visible()
+      assert 'OWN_CONTEXT_NELL' not in nell.content()
+      assert 'ONLY_NELL' not in nell.content()
+      coordinator.screenshot(
+          path=str(tmp_path / 'android-coordinator.png'), full_page=True
+      )
+      spectator.screenshot(
+          path=str(tmp_path / 'spectator-landscape.png'), full_page=True
+      )
+      assert not errors
+    finally:
+      game.nell_inbox.finish('done')
+      thread.join(2)
+      browser.close()

--- a/concordia/examples/bellwether/multiplayer_test.py
+++ b/concordia/examples/bellwether/multiplayer_test.py
@@ -1,0 +1,304 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Privacy and role integrity using real HTTP/SSE; no simulation launches."""
+
+import json
+import pathlib
+import threading
+from unittest import mock
+import uuid
+
+from concordia.examples.bellwether import game as rules
+from concordia.examples.bellwether import multiplayer
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+from concordia.utils import browser_sessions
+from concordia.utils import operation_service as ops
+from concordia.utils import simulation_server
+import httpx
+import pytest
+
+
+def envelope(game, operation, args=None):
+  return dict(
+      operation=operation,
+      arguments=args or {},
+      references=game.operations.references.copy(),
+      revision=game.operations.revision,
+      retry_key=str(uuid.uuid4()),
+  )
+
+
+def approve(game, label):
+  row = next(r for r in game.sessions.pending() if r['label'] == label)
+  game.operations.dispatch(
+      'developer', envelope(game, 'session.approve', {'request_id': row['id']})
+  )
+  return row['id']
+
+
+@pytest.fixture(name='hosted')
+def hosted_fixture(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No simulation in transport tests'),
+  ):
+    game = multiplayer.SharedGame(tmp_path, secure=False)
+    server = simulation_server.SimulationServer(
+        port=0,
+        operation_service=game.operations,
+        browser_sessions=game.sessions,
+        html_content=pathlib.Path(__file__)
+        .with_name('player.html')
+        .read_text(encoding='utf-8'),
+    )
+    server.start()
+    url = f'http://127.0.0.1:{server.bound_port}'
+    try:
+      yield game, server, url
+    finally:
+      game.close()
+      server.stop()
+
+
+def joined(game, url, role, label=None):
+  client = httpx.Client()
+  client.headers['Origin'] = url
+  assert client.get(url).status_code == 200
+  label = label or role
+  assert (
+      client.post(
+          url + '/api/join', json={'label': label, 'role': role}
+      ).status_code
+      == 200
+  )
+  approve(game, label)
+  return client
+
+
+def test_only_two_humans_default_ai_policies(hosted):
+  game, _, _ = hosted
+  policies = {
+      e.name: type(e.get_act_component()).__name__
+      for e in game.simulation.get_entities()
+  }
+  assert policies == {
+      'Coordinator': 'HumanActComponent',
+      'Nell': 'HumanActComponent',
+      'Mara': 'ConcatActComponent',
+      'Ivo': 'ConcatActComponent',
+      'Sam': 'ConcatActComponent',
+  }
+
+
+def test_unauthenticated_forged_and_pending_receive_no_private_data(hosted):
+  game, _, url = hosted
+  for path in ['/api/state', '/api/events', '/api/operations']:
+    assert httpx.get(url + path).status_code == 403
+  visitor = httpx.Client()
+  assert visitor.get(url).status_code == 200
+  for path in ['/api/state', '/api/operations']:
+    assert 'PRIVATE_' not in visitor.get(url + path).text
+  assert visitor.get(url + '/api/state').json()['result'] == {'lobby': True}
+  result = visitor.post(
+      url + '/api/join',
+      json={'label': 'visitor', 'role': 'Nell'},
+      headers={'Origin': url},
+  )
+  assert result.status_code == 200
+  assert visitor.get(url + '/api/state').json()['result'] == {'lobby': True}
+  result = visitor.post(
+      url + '/api/dispatch',
+      json=envelope(
+          game,
+          'session.approve',
+          {'request_id': game.sessions.pending()[0]['id']},
+      ),
+      headers={'Origin': url},
+  )
+  assert result.status_code == 409
+  assert result.json()['error']['code'] == 'unsupported_operation'
+  for path in ['/events', '/status', '/cmd/set_component_state']:
+    assert visitor.get(url + path).status_code == 404
+
+
+def test_exact_origin_joins_and_mutations(hosted):
+  game, _, url = hosted
+  client = httpx.Client()
+  client.get(url)
+  for origin in [None, 'https://attacker.invalid', url + '.attacker.invalid']:
+    headers = {'Origin': origin} if origin else {}
+    response = client.post(
+        url + '/api/join',
+        json={'label': 'test', 'role': 'Nell'},
+        headers=headers,
+    )
+    assert response.status_code == 403
+  assert not game.sessions.pending()
+
+
+def test_cannot_steal_role_or_inject_developer_or_actor(hosted):
+  game, _, url = hosted
+  joined(game, url, 'Nell')
+  before = game.operations.revision
+  client = httpx.Client()
+  client.get(url)
+  for role in ['Nell', 'developer', 'Mara']:
+    response = client.post(
+        url + '/api/join',
+        json={'label': 'another', 'role': role},
+        headers={'Origin': url},
+    )
+    assert response.status_code == 409
+  assert game.operations.revision == before
+
+
+def test_projections_public_private_spectator_and_revocation(hosted):
+  game, _, url = hosted
+  c = joined(game, url, 'Coordinator')
+  n = joined(game, url, 'Nell')
+  s = joined(game, url, 'spectator')
+  with game.operations.lock:
+    game.world.emit('speech', 'PUBLIC_MARKER')
+    game.world.emit('speech', 'C_ONLY', ['Coordinator'])
+    game.world.emit('speech', 'N_ONLY', ['Nell'])
+    game.world.emit('speech', 'M_ONLY', ['Mara'])
+    game.operations.publish({'kind': 'fixture.observations'})
+  for client, visible, hidden in [
+      (c, ['PUBLIC_MARKER', 'C_ONLY'], ['N_ONLY', 'M_ONLY', 'PRIVATE_NELL']),
+      (
+          n,
+          ['PUBLIC_MARKER', 'N_ONLY', 'PRIVATE_NELL'],
+          ['C_ONLY', 'M_ONLY', 'PRIVATE_MARA'],
+      ),
+      (s, ['PUBLIC_MARKER'], ['C_ONLY', 'N_ONLY', 'M_ONLY', 'PRIVATE_']),
+  ]:
+    content = client.get(url + '/api/state').text
+    assert all(word in content for word in visible)
+    assert all(word not in content for word in hidden)
+  for operation in [
+      'game.begin',
+      'human.respond',
+      'session.approve',
+      'component.edit',
+  ]:
+    body = envelope(
+        game,
+        operation,
+        {'request_id': 'x', 'response': 'wait'}
+        if operation == 'human.respond'
+        else {},
+    )
+    assert s.post(url + '/api/dispatch', json=body).status_code == 409
+  with n.stream('GET', url + '/api/events', timeout=3) as stream:
+    lines = stream.iter_lines()
+    first = next(lines)
+    assert 'role' in first
+    row = next(r for r in game.sessions.pending() if r['role'] == 'Nell')
+    game.operations.dispatch(
+        'developer', envelope(game, 'session.revoke', {'request_id': row['id']})
+    )
+    next(lines)  # blank SSE separator
+    message = next(lines)
+    assert json.loads(message.removeprefix('data: '))['result'] == {
+        'lobby': True
+    }
+  assert n.get(url + '/api/state').json()['result'] == {'lobby': True}
+
+
+def test_nell_owns_pending_turn_retry_and_wrong_client_atomic(hosted):
+  game, _, url = hosted
+  c = joined(game, url, 'Coordinator')
+  n = joined(game, url, 'Nell')
+  game.world.data['agenda'] = [{
+      'name': 'Nell',
+      'purpose': 'request: release reserve',
+      'audience': rules.NAMES,
+      'watch': 0,
+  }]
+  request = human_input.HumanInputRequest(
+      request_id='nell-request',
+      entity_name='Nell',
+      action_spec=entity_lib.free_action_spec(call_to_action='Your decision'),
+      contexts={},
+      context='NELL_PROMPT_ONLY',
+  )
+  result = []
+  thread = threading.Thread(
+      target=lambda: result.append(game.nell_inbox(request))
+  )
+  thread.start()
+  try:
+    assert 'NELL_PROMPT_ONLY' in n.get(url + '/api/state').text
+    assert 'NELL_PROMPT_ONLY' not in c.get(url + '/api/state').text
+    response = json.dumps(
+        {'decision': 'decline', 'speech': 'I keep my reserve.'}
+    )
+    body = envelope(
+        game,
+        'human.respond',
+        {'request_id': request.request_id, 'response': response},
+    )
+    before = game.operations.revision
+    assert (
+        c.post(url + '/api/dispatch', json=body).json()['error']['code']
+        == 'wrong_turn'
+    )
+    assert game.operations.revision == before
+    bad = envelope(
+        game,
+        'human.respond',
+        {'request_id': request.request_id, 'response': 'not a decision'},
+    )
+    assert n.post(url + '/api/dispatch', json=bad).status_code == 409
+    assert game.operations.revision == before
+    stale = {**body, 'revision': -1}
+    assert (
+        n.post(url + '/api/dispatch', json=stale).json()['error']['code']
+        == 'stale_revision'
+    )
+    accepted = n.post(url + '/api/dispatch', json=body)
+    assert accepted.status_code == 200
+    thread.join(2)
+    assert result == [response]
+    assert n.post(url + '/api/dispatch', json=body).json() == accepted.json()
+    assert result == [response]
+  finally:
+    game.nell_inbox.finish('done')
+    thread.join(2)
+
+
+def test_cookie_attributes_and_unknown_session_fail_closed():
+
+  store = browser_sessions.BrowserSessions(
+      ('Nell',), cookie_path='/bellwether/'
+  )
+  _, cookie = store.identify('', create=True)
+  assert all(
+      word in cookie
+      for word in ['HttpOnly', 'Secure', 'SameSite=Strict', 'Path=/bellwether/']
+  )
+  with pytest.raises(ops.OperationError):
+    store.identify('unknown=forged')
+
+
+def test_requires_both_players_before_start(hosted):
+  game, _, url = hosted
+  client = joined(game, url, 'Coordinator')
+  response = client.post(
+      url + '/api/dispatch', json=envelope(game, 'game.begin')
+  )
+  assert response.json()['error']['code'] == 'players_not_ready'
+  assert game.developer_view()['quiescent']

--- a/concordia/examples/bellwether/player.html
+++ b/concordia/examples/bellwether/player.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Last Light at Bellwether</title><style>
+:root {color-scheme:dark;font:17px/1.55 system-ui;background:#0b1720;color:#eadfca}
+body {margin:0 auto;max-width:800px;padding:24px 18px 120px}h1{font:2.2rem Georgia,serif;margin-bottom:6px} h2{font-size:1.2rem}
+.subtle{color:#acb9bc} .badge {border:1px solid #a99566;padding:4px 12px;border-radius:20px;font-size:.8rem}
+#map{display:grid;grid-template-columns:1fr 1fr;gap:12px;background:radial-gradient(ellipse,#28454a,#122634);padding:18px;border-radius:12px}
+button{font:inherit;cursor:pointer;color:inherit;background:#203642;border:1px solid #5d797a;border-radius:8px;padding:12px}button:hover{background:#314d55}button:disabled{opacity:.5;cursor:wait}
+.card{border-left:3px solid #c7a566;padding:8px 14px;background:#14252e;margin:10px 0}.card p{margin:4px 0}
+pre,.story{white-space:pre-wrap;overflow-wrap:anywhere;font:inherit}.story{border-top:1px solid #30434d;padding:16px 0}
+textarea{box-sizing:border-box;width:100%;min-height:100px;padding:12px;background:#11222c;color:inherit;border:1px solid #799093;border-radius:8px;font:inherit}
+#act{background:#dfbd76;color:#15222a;font-weight:bold}#error{color:#ffc1a8}#connection{font-size:.85rem}
+</style></head><body>
+<span class="badge">Dusk · one-turn fixture</span><h1>Last Light at Bellwether</h1>
+<p class="subtle">An island community. One stormy night.</p>
+<p id="connection" role="status">Connecting…</p><p id="opening"></p>
+<h2>Inspect the island</h2><div id="map"></div><p id="location" class="subtle">Select a location to see who is there. Inspection does not move time.</p>
+<div id="cast"></div><h2>Your account of the night</h2><div id="journal" aria-live="polite"></div>
+<details><summary>Your available context</summary><pre id="context"></pre></details>
+<h2 id="prompt">Waiting for this fixture to begin</h2>
+<form id="action-form"><label for="action">Your proposal or action</label><textarea id="action" placeholder="Ask Mara what the harbor needs, propose a discussion, or wait…"></textarea>
+<p><button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form>
+<p id="error" role="alert"></p><p class="subtle">This first slice records one action with a fixed response. It does not yet simulate negotiation, fuel allocation or the full night.</p>
+<script>
+(() => {
+ const $=id=>document.getElementById(id); let current, retry, sending=false, picked, connected=false;
+ $('action').value=sessionStorage.getItem('bellwether-draft')||'';
+ $('action').oninput=()=>{sessionStorage.setItem('bellwether-draft',$('action').value);retry=null};
+ $('wait').onclick=()=>{$('action').value='Wait and listen.';$('action').oninput()};
+ function render(data) {
+   if(current && data.revision < current.revision) return;
+   current=data; const state=data.result, world=state.scenario, human=state.human;
+   $('connection').textContent=!connected?'Reconnecting… your draft is kept':human.finished?'Fixture complete':'Connected · '+human.status;
+   $('opening').textContent=world.opening;
+   if(!$('map').children.length) for(const location of world.locations){
+     const button=document.createElement('button');button.textContent=location;
+     button.onclick=()=>{picked=location;render(current)};$('map').append(button);
+   }
+   $('cast').replaceChildren();
+   for(const resident of world.cast.filter(x=>!picked||x.location===picked)){
+     const card=document.createElement('article');card.className='card';
+     const name=document.createElement('strong');name.textContent=resident.name;
+     const description=document.createElement('p');description.textContent=resident.role+' · '+resident.location;
+     card.append(name,description);$('cast').append(card);
+   }
+   if(picked) $('location').textContent=picked+' · inspection only';
+   $('journal').replaceChildren();for(const entry of human.entries){
+     const p=document.createElement('p');p.className='story';p.textContent=entry.text;$('journal').append(p);
+   }
+   $('context').textContent=human.pending?.context||'';
+   $('prompt').textContent=human.pending?.prompt||(human.finished?'The fixture is complete':'Waiting for the next prompt');
+   $('act').disabled=!connected||sending||!human.pending;
+ }
+ $('action-form').onsubmit=async e=>{
+   e.preventDefault();if(!connected||!current||!current.result.human.pending||sending)return;
+   $('error').textContent=''; const draft=$('action').value;
+   retry=retry||{operation:'human.respond',arguments:{request_id:current.result.human.pending.id,response:draft},
+      references:current.references,revision:current.revision,retry_key:crypto.randomUUID()};
+   sending=true;$('act').disabled=true;
+   try{
+     const response=await fetch('/api/dispatch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(retry)});
+     const result=await response.json();if(!response.ok){retry=null;throw new Error(result.error.message)}
+     retry=null;if($('action').value===draft){$('action').value='';sessionStorage.removeItem('bellwether-draft')}
+   }catch(error){$('error').textContent=error.message+' Your draft is kept.'}
+   finally{sending=false;render(current)}
+ };
+ const stream=new EventSource('/api/events');stream.onmessage=e=>{connected=true;render(JSON.parse(e.data))};
+ stream.onerror=()=>{connected=false;$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true};
+})();
+</script></body></html>

--- a/concordia/examples/bellwether/player.html
+++ b/concordia/examples/bellwether/player.html
@@ -42,6 +42,7 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
 <section id="join" hidden><h2>Join the night</h2><p>Choose a role and ask the host to approve this browser. Reloading keeps your place. No private information is shared until approval.</p><form id="join-form"><label for="join-name">Your name for the host</label><input id="join-name" maxlength="80" autocomplete="nickname" required><label for="join-role">Role</label><select id="join-role"><option>Coordinator</option><option>Nell</option><option value="spectator">Spectator · public events only</option></select><button id="join-submit">Request to join</button></form><p id="join-status" role="status"></p></section>
 <div id="play"><header><p id="role-badge"></p><span class="badge" id="watch">Dusk</span><span class="badge" id="fixture" hidden>Fixture · AI residents scripted</span>
 <h1>Last Light<br>at Bellwether</h1><p class="subtle">An island community. One stormy night.</p>
+<details id="first-play" hidden><summary>How to play your role</summary><p id="role-guide"></p></details>
 <p id="connection" role="status">Connecting…</p><p id="opening"></p><button id="begin" hidden>Begin the night</button></header>
 <section aria-labelledby="map-title"><h2 id="map-title">The island</h2><div id="resources"></div><p id="supply-note" class="subtle"></p>
 <div id="map" aria-label="Locations around Bellwether harbor"></div><p id="location" class="subtle">Choose a place. Looking around does not move time.</p>
@@ -63,11 +64,13 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
 <p id="export-status" role="status"></p></section>
 <section id="composer"><h2 id="prompt">Waiting to begin</h2><p id="role-wait" role="status"></p><p id="turn-note" class="subtle"></p><label id="decision-label" for="decision" hidden>Your decision</label><select id="decision" hidden></select><div id="choices"></div>
 <form id="action-form"><label for="action">What do you do or say?</label><textarea id="action" placeholder="Choose a suggestion, or write your own words…"></textarea>
-<p><button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form></section>
+<p id="preview-result" role="status"></p>
+<p><button type="button" id="preview" hidden disabled>Check interpretation · free</button> <button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form></section>
 </div><button id="jump-action" type="button" hidden>Go to your action</button><p id="error" role="alert"></p>
 <script>
 (() => {
  const $=id=>document.getElementById(id);let current,retry,sending=false,picked,connected=false,identity='',draftKey='bellwether-draft';
+ let previewController=null,previewSerial=0,previewScope='';
  const api=name=>new URL('api/'+name,location.origin+location.pathname.replace(/\/?$/,'/')).href;
  const announceError=message=>{$('error').textContent=message};
  $('jump-action').onclick=()=>{$('composer').scrollIntoView({block:'start',behavior:'auto'});$('action').focus({preventScroll:true})};
@@ -81,7 +84,7 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
  const facility={'Harbor beacon':'beacon','Storm shelter':'shelter','Cooperative cold store':'cold store'};
  const descriptions={Mara:'Harbor master · boats and safe passage',Nell:'Cooperative custodian · reserves and livelihoods',Ivo:'Engineer · repairs and working conditions',Sam:'Shelter steward · displaced residents'};
  $('action').value='';
- $('action').oninput=()=>{sessionStorage.setItem(draftKey,$('action').value);retry=null};
+ $('action').oninput=()=>{sessionStorage.setItem(draftKey,$('action').value);retry=null;updatePreview()};
  function suggest(words){$('action').value=words;$('action').oninput();$('action').focus()}
  $('wait').onclick=()=>suggest(current?.result.night?'wait':'Wait and listen.');
  $('all-cast').onclick=()=>{picked=null;render(current)};
@@ -188,7 +191,7 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
  function render(data){
   if(!data||(current&&data.revision<current.revision))return;current=data;
   const state=data.result;
-  if(state.lobby){voice.disconnect();$('join').hidden=false;$('play').hidden=true;$('jump-action').hidden=true;
+  if(state.lobby){voice.disconnect();invalidatePreview();previewScope='';$('join').hidden=false;$('play').hidden=true;$('jump-action').hidden=true;
    for(const id of ['context','journal','prompt','outcome','responses'])$(id).replaceChildren();
    if(identity){$('action').value='';retry=null;identity='';}ownJoin();return;}
   $('join').hidden=true;$('play').hidden=false;
@@ -196,7 +199,10 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
   const role=state.role||'Coordinator',spectator=role==='spectator',isResident=state.multiplayer&&role!=='Coordinator'&&!spectator;
   const nextIdentity=data.references.session_id+':'+role;
   if(identity!==nextIdentity){identity=nextIdentity;draftKey='bellwether-draft:'+identity;$('action').value=sessionStorage.getItem(draftKey)||'';retry=null;}
-  $('role-badge').textContent=state.multiplayer?(spectator?'Spectator · public events only':'You are '+role):'';
+  $('role-badge').textContent=night?(state.multiplayer?(spectator?'Spectator · public events only':'Shared night · You are '+role+' · Two human roles and '+(state.fixture?'three scripted residents':'three AI residents')):'Single player · You are Coordinator · '+(state.fixture?'Four scripted residents':'Four AI residents')):'One-turn fixture · You are Coordinator';
+  $('first-play').hidden=!night;
+  $('role-guide').textContent=spectator?'Watch public events and material consequences. Private journals and action controls are not available to spectators.':isResident?'You control Nell’s words and decisions. Accept, decline or offer different terms when addressed. Accepting records consent; the Coordinator still has to carry out any transfer. Only you can submit your turn. Reloading keeps your approved browser role.':'Coordinate three watches of service. Ask for consent, arrange transfers and work, and choose what to supply. A request, an accepted commitment and a performed action are different. Every valid sent attempt costs one choice, including refusal. Looking around and checking an interpretation are free. Send only when ready; partial outcomes are possible.';
+  updatePreview();
   $('jump-action').hidden=!human.pending||spectator;
 
   $('fixture').hidden=!state.fixture;$('watch').textContent=night?night.watch+' · '+night.remaining+' choices remain':'Dusk · one-turn fixture';
@@ -274,6 +280,41 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
   }catch(error){$('error').textContent=error.message+' Your draft is kept.'}
   finally{sending=false;render(current)}
  }
+ function invalidatePreview(){previewSerial++;previewController?.abort();previewController=null;$('preview-result').textContent=''}
+ function updatePreview(){
+  if(!current||current.result.lobby)return;
+  const state=current.result,scope=JSON.stringify([identity,state.human.pending?.id||'',$('action').value]);
+  if(scope!==previewScope){invalidatePreview();previewScope=scope}
+  $('preview').hidden=!state.night||(state.role&&state.role!=='Coordinator');
+  $('preview').disabled=!connected||sending||Boolean(previewController)||!$('action').value.trim();
+ }
+ function interpretation(intent){
+  switch(intent.kind){
+   case 'request':return intent.target==='Nell'?'Ask Nell for reserve fuel and the spare part. She decides whether to accept.':'Ask Ivo to commit to a repair. He decides whether to accept.';
+   case 'transfer':return 'Attempt the transfer of reserve fuel and the spare part. Nell’s current consent is required.';
+   case 'work':return 'Attempt Ivo’s repair. Accepted labor, the spare part and the repair deadline still matter.';
+   case 'allocate':return 'Set this watch’s requested service to '+(intent.facilities.join(', ')||'none')+'. Supply is resolved at the watch boundary, subject to resources.';
+   case 'promise':return 'Promise service for the '+intent.facility+'. Making a promise does not supply it.';
+   case 'revoke':return 'Withdraw your unfulfilled service promise.';
+   case 'wait':return 'Spend one choice waiting when you send this action.';
+   case 'talk':return (intent.private&&intent.target!=='everyone'?'Private message':'Public discussion')+' to '+intent.target+': '+intent.text;
+   default:throw new Error('No supported interpretation returned.');
+  }
+ }
+ $('preview').onclick=async()=>{
+  if(!connected||!current||previewController)return;
+  const serial=++previewSerial,scope=previewScope,words=$('action').value;
+  previewController=new AbortController();updatePreview();$('preview-result').textContent='Checking interpretation…';
+  try{
+   const response=await fetch(api('dispatch'),{method:'POST',headers:{'Content-Type':'application/json'},signal:previewController.signal,body:JSON.stringify({operation:'game.preview',arguments:{text:words}})});
+   const data=await response.json();
+   if(serial!==previewSerial||scope!==previewScope||!connected)return;
+   if(!response.ok)throw new Error(data.error?.message||'Interpretation unavailable.');
+   $('preview-result').textContent=interpretation(data.result)+' Interpretation only: no action was sent and no choice was spent. It does not guarantee success or consent.';
+  }catch(error){if(serial===previewSerial&&error.name!=='AbortError')$('preview-result').textContent=error.message+' Your draft is kept; nothing was sent.'}
+  finally{if(serial===previewSerial){previewController=null;updatePreview()}}
+ };
+ window.addEventListener('pagehide',invalidatePreview);
  let exporting=false;
  async function downloadAccount(format){
   if(!connected||!current||exporting)return;
@@ -294,6 +335,6 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
  $('begin').onclick=()=>dispatch('game.begin',{});
  const stream=new EventSource(api('events'));
  stream.onmessage=e=>{connected=true;render(JSON.parse(e.data))};
- stream.onerror=()=>{connected=false;voice.disconnect();$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true;$('begin').disabled=true;if(current)render(current)};
+ stream.onerror=()=>{connected=false;voice.disconnect();invalidatePreview();$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true;$('begin').disabled=true;if(current)render(current)};
 })();
 </script></body></html>

--- a/concordia/examples/bellwether/player.html
+++ b/concordia/examples/bellwether/player.html
@@ -56,6 +56,11 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
 <h2>The night’s account</h2><div id="journal" aria-live="polite"></div>
 <details id="agreements" hidden><summary>Commitments and institutions</summary><div id="commitments"></div><div id="institutions"></div></details>
 <details><summary>Your available context</summary><pre id="context"></pre></details>
+<section id="public-account" hidden><h2>Keep a public account</h2>
+<p>Save public events and material consequences. Private messages are excluded. Public speech may still identify people. This is not a saved game.</p>
+<button id="export-html" type="button">Download readable account</button>
+<button id="export-json" type="button">Download public JSON</button>
+<p id="export-status" role="status"></p></section>
 <section id="composer"><h2 id="prompt">Waiting to begin</h2><p id="role-wait" role="status"></p><p id="turn-note" class="subtle"></p><label id="decision-label" for="decision" hidden>Your decision</label><select id="decision" hidden></select><div id="choices"></div>
 <form id="action-form"><label for="action">What do you do or say?</label><textarea id="action" placeholder="Choose a suggestion, or write your own words…"></textarea>
 <p><button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form></section>
@@ -196,6 +201,8 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
 
   $('fixture').hidden=!state.fixture;$('watch').textContent=night?night.watch+' · '+night.remaining+' choices remain':'Dusk · one-turn fixture';
   $('connection').textContent=!connected?'Reconnecting… your draft is kept':human.finished?'The account is complete':'Connected · '+(human.pending?'Your turn':spectator?'Watching public events':night?.next_actor&&night.next_actor!==role?'Waiting for '+night.next_actor:human.status);
+  $('public-account').hidden=!night;
+  $('export-html').disabled=$('export-json').disabled=!connected||exporting;
   $('opening').textContent=world.opening;$('begin').hidden=!night||state.phase!=='paused'||spectator;$('begin').disabled=!connected||sending||(state.multiplayer&&!state.players_ready);if(state.multiplayer&&!state.players_ready)$('connection').textContent='Waiting for the host to approve both players';
   $('resources').replaceChildren();
   if(night){
@@ -267,6 +274,22 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
   }catch(error){$('error').textContent=error.message+' Your draft is kept.'}
   finally{sending=false;render(current)}
  }
+ let exporting=false;
+ async function downloadAccount(format){
+  if(!connected||!current||exporting)return;
+  const owner=identity;exporting=true;render(current);$('export-status').textContent='Preparing public account…';
+  try{
+   const response=await fetch(api('dispatch'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({operation:'game.public_account',arguments:{format}})});
+   const data=await response.json();
+   if(!response.ok)throw new Error(data.error?.message||'Download unavailable.');
+   if(owner!==identity||current.result.lobby||!connected)throw new Error('Connection or role changed; retry when connected.');
+   const artifact=data.result,url=URL.createObjectURL(new Blob([artifact.content],{type:artifact.media_type})),link=document.createElement('a');
+   link.href=url;link.download=artifact.filename;document.body.append(link);link.click();link.remove();setTimeout(()=>URL.revokeObjectURL(url),1000);
+   $('export-status').textContent='Public account downloaded. Your draft and the night are unchanged.';
+  }catch(error){$('export-status').textContent=error.message.replace(/[.!?]$/,'')+'. Your draft is kept.'}
+  finally{exporting=false;if(current)render(current)}
+ }
+ $('export-html').onclick=()=>downloadAccount('html');$('export-json').onclick=()=>downloadAccount('json');
  $('action-form').onsubmit=e=>{e.preventDefault();if(current?.result.human.pending)dispatch('human.respond',{request_id:current.result.human.pending.id,response:current.result.role==='Nell'?JSON.stringify({decision:$('decision').value,speech:$('action').value}):$('action').value})};
  $('begin').onclick=()=>dispatch('game.begin',{});
  const stream=new EventSource(api('events'));

--- a/concordia/examples/bellwether/player.html
+++ b/concordia/examples/bellwether/player.html
@@ -1,70 +1,133 @@
 <!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Last Light at Bellwether</title><style>
-:root {color-scheme:dark;font:17px/1.55 system-ui;background:#0b1720;color:#eadfca}
-body {margin:0 auto;max-width:800px;padding:24px 18px 120px}h1{font:2.2rem Georgia,serif;margin-bottom:6px} h2{font-size:1.2rem}
-.subtle{color:#acb9bc} .badge {border:1px solid #a99566;padding:4px 12px;border-radius:20px;font-size:.8rem}
-#map{display:grid;grid-template-columns:1fr 1fr;gap:12px;background:radial-gradient(ellipse,#28454a,#122634);padding:18px;border-radius:12px}
-button{font:inherit;cursor:pointer;color:inherit;background:#203642;border:1px solid #5d797a;border-radius:8px;padding:12px}button:hover{background:#314d55}button:disabled{opacity:.5;cursor:wait}
-.card{border-left:3px solid #c7a566;padding:8px 14px;background:#14252e;margin:10px 0}.card p{margin:4px 0}
-pre,.story{white-space:pre-wrap;overflow-wrap:anywhere;font:inherit}.story{border-top:1px solid #30434d;padding:16px 0}
-textarea{box-sizing:border-box;width:100%;min-height:100px;padding:12px;background:#11222c;color:inherit;border:1px solid #799093;border-radius:8px;font:inherit}
-#act{background:#dfbd76;color:#15222a;font-weight:bold}#error{color:#ffc1a8}#connection{font-size:.85rem}
+:root{color-scheme:dark;font:17px/1.6 system-ui;background:#091721;color:#f2e6cf;--muted:#b6c8cb;--gold:#edc984}
+*{box-sizing:border-box}body{margin:0 auto;max-width:940px;padding:26px 18px 60px}
+h1{font:clamp(2.4rem,7vw,4.3rem)/1.1 Georgia,serif;margin:18px 0 10px;max-width:720px}
+h2{font:1.5rem Georgia,serif;margin-top:32px}h3{font:1.2rem Georgia,serif}
+.subtle,small{color:var(--muted)}.badge{border:1px solid #998d6b;padding:5px 12px;border-radius:30px;font-size:.8rem;display:inline-block}
+#fixture{background:#483627;margin-left:6px}#connection{font-size:.85rem;color:var(--muted);min-height:1.5em}
+#opening{max-width:760px}button{font:inherit;cursor:pointer;color:inherit;background:#203b48;border:1px solid #638084;border-radius:9px;padding:10px 14px}
+button:hover{background:#345664}button:focus-visible,textarea:focus-visible{outline:3px solid var(--gold);outline-offset:3px}
+button:disabled{opacity:.5;cursor:default}#begin,#act{background:var(--gold);color:#15222a;font-weight:700}
+#map{position:relative;display:grid;grid-template-columns:1fr 1fr;gap:28px 40px;background:radial-gradient(ellipse at 25% 55%,#2e4d4a 0%,#1b353b 46%,#0d2335 48%,#123247 63%,#0b2032 66%);border:1px solid #416570;border-radius:45% 18% 30% 18%;padding:46px 20px;min-height:250px}
+#map button{z-index:1;font-size:.95rem;background:#102734eb;box-shadow:0 2px 10px #0008;min-height:75px}
+#map button.lit{border-color:#efc276;box-shadow:0 0 24px #eab86b50;background:#3d3728}
+#map button[aria-pressed=true]{outline:2px solid var(--gold)}#map small{display:block;font-size:.72rem}
+#cast{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}
+.card{border-left:3px solid #c7a566;padding:14px;background:#132a35;border-radius:4px}.card p{margin:5px 0}.card button{font-size:.85rem;padding:7px 10px;margin:5px 6px 0 0}
+#resources{display:flex;flex-wrap:wrap;gap:10px}#resources span{background:#19313b;padding:8px 12px;border-radius:8px}
+pre,.story{white-space:pre-wrap;overflow-wrap:anywhere;font:inherit}.story{border-top:1px solid #304852;padding:13px 0;margin:0}
+.story small{display:block}.private{border-left:2px solid #7ca6ba;padding-left:12px}
+#journal{max-height:600px;overflow:auto;padding-right:10px}
+textarea{width:100%;min-height:116px;padding:12px;background:#102732;color:inherit;border:1px solid #819ca1;border-radius:8px;font:inherit;resize:vertical}
+#choices{display:flex;flex-wrap:wrap;gap:8px;margin:14px 0}#choices button{font-size:.85rem}
+#error{color:#ffc1a8;white-space:pre-wrap}#epilogue{background:#192f37;border:1px solid #ad9e77;border-radius:12px;padding:20px;margin-top:26px}
+table{width:100%;border-collapse:collapse;font-size:.85rem}td,th{text-align:left;border-bottom:1px solid #42606b;padding:7px}
+details{margin:20px 0}summary{cursor:pointer;color:var(--muted)}#context{max-height:350px;overflow:auto}#prompt{margin:28px 0 8px}
+[hidden]{display:none!important}@media(max-width:460px){body{padding:20px 14px 40px}#map{gap:20px 12px;padding:30px 12px}#cast{grid-template-columns:1fr 1fr}.card{padding:10px}.card p{font-size:.8rem}button{min-height:44px}}
 </style></head><body>
-<span class="badge">Dusk · one-turn fixture</span><h1>Last Light at Bellwether</h1>
-<p class="subtle">An island community. One stormy night.</p>
-<p id="connection" role="status">Connecting…</p><p id="opening"></p>
-<h2>Inspect the island</h2><div id="map"></div><p id="location" class="subtle">Select a location to see who is there. Inspection does not move time.</p>
-<div id="cast"></div><h2>Your account of the night</h2><div id="journal" aria-live="polite"></div>
+<header><span class="badge" id="watch">Dusk</span><span class="badge" id="fixture" hidden>Fixture · scripted residents</span>
+<h1>Last Light<br>at Bellwether</h1><p class="subtle">An island community. One stormy night.</p>
+<p id="connection" role="status">Connecting…</p><p id="opening"></p><button id="begin" hidden>Begin the night</button></header>
+<section aria-labelledby="map-title"><h2 id="map-title">The island</h2><div id="resources"></div><p id="supply-note" class="subtle"></p>
+<div id="map" aria-label="Locations around Bellwether harbor"></div><p id="location" class="subtle">Choose a place. Looking around does not move time.</p>
+<button id="all-cast" type="button">All residents</button><div id="cast"></div></section>
+<section id="epilogue" hidden aria-labelledby="dawn-title"><h2 id="dawn-title">Dawn at Bellwether</h2><div id="outcome"></div><div id="responses"></div></section>
+<h2>The night’s account</h2><div id="journal" aria-live="polite"></div>
+<details id="agreements" hidden><summary>Commitments and institutions</summary><div id="commitments"></div><div id="institutions"></div></details>
 <details><summary>Your available context</summary><pre id="context"></pre></details>
-<h2 id="prompt">Waiting for this fixture to begin</h2>
-<form id="action-form"><label for="action">Your proposal or action</label><textarea id="action" placeholder="Ask Mara what the harbor needs, propose a discussion, or wait…"></textarea>
-<p><button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form>
-<p id="error" role="alert"></p><p class="subtle">This first slice records one action with a fixed response. It does not yet simulate negotiation, fuel allocation or the full night.</p>
+<section id="composer"><h2 id="prompt">Waiting to begin</h2><p id="turn-note" class="subtle"></p><div id="choices"></div>
+<form id="action-form"><label for="action">What do you do or say?</label><textarea id="action" placeholder="Choose a suggestion, or write your own words…"></textarea>
+<p><button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form></section>
+<p id="error" role="alert"></p>
 <script>
 (() => {
- const $=id=>document.getElementById(id); let current, retry, sending=false, picked, connected=false;
+ const $=id=>document.getElementById(id);let current,retry,sending=false,picked,connected=false;
+ const labels=['Harbor beacon','Storm shelter','Cooperative cold store','Generator yard'];
+ const facility={'Harbor beacon':'beacon','Storm shelter':'shelter','Cooperative cold store':'cold store'};
+ const descriptions={Mara:'Harbor master · boats and safe passage',Nell:'Cooperative custodian · reserves and livelihoods',Ivo:'Engineer · repairs and working conditions',Sam:'Shelter steward · displaced residents'};
  $('action').value=sessionStorage.getItem('bellwether-draft')||'';
  $('action').oninput=()=>{sessionStorage.setItem('bellwether-draft',$('action').value);retry=null};
- $('wait').onclick=()=>{$('action').value='Wait and listen.';$('action').oninput()};
- function render(data) {
-   if(current && data.revision < current.revision) return;
-   current=data; const state=data.result, world=state.scenario, human=state.human;
-   $('connection').textContent=!connected?'Reconnecting… your draft is kept':human.finished?'Fixture complete':'Connected · '+human.status;
-   $('opening').textContent=world.opening;
-   if(!$('map').children.length) for(const location of world.locations){
-     const button=document.createElement('button');button.textContent=location;
-     button.onclick=()=>{picked=location;render(current)};$('map').append(button);
-   }
-   $('cast').replaceChildren();
-   for(const resident of world.cast.filter(x=>!picked||x.location===picked)){
-     const card=document.createElement('article');card.className='card';
-     const name=document.createElement('strong');name.textContent=resident.name;
-     const description=document.createElement('p');description.textContent=resident.role+' · '+resident.location;
-     card.append(name,description);$('cast').append(card);
-   }
-   if(picked) $('location').textContent=picked+' · inspection only';
-   $('journal').replaceChildren();for(const entry of human.entries){
-     const p=document.createElement('p');p.className='story';p.textContent=entry.text;$('journal').append(p);
-   }
-   $('context').textContent=human.pending?.context||'';
-   $('prompt').textContent=human.pending?.prompt||(human.finished?'The fixture is complete':'Waiting for the next prompt');
-   $('act').disabled=!connected||sending||!human.pending;
+ function suggest(words){$('action').value=words;$('action').oninput();$('action').focus()}
+ $('wait').onclick=()=>suggest(current?.result.night?'wait':'Wait and listen.');
+ $('all-cast').onclick=()=>{picked=null;render(current)};
+ function text(parent,tag,value,cls){const el=document.createElement(tag);el.textContent=value;if(cls)el.className=cls;parent.append(el);return el}
+ function render(data){
+  if(!data||(current&&data.revision<current.revision))return;current=data;
+  const state=data.result,world=state.scenario,human=state.human,night=state.night;
+  $('fixture').hidden=!state.fixture;$('watch').textContent=night?night.watch+' · '+night.remaining+' choices remain':'Dusk · one-turn fixture';
+  $('connection').textContent=!connected?'Reconnecting… your draft is kept':human.finished?'The account is complete':'Connected · '+(night?.next_actor&&night.next_actor!=='Coordinator'?night.next_actor+' is considering a response':human.status);
+  $('opening').textContent=world.opening;$('begin').hidden=!night||state.phase!=='paused';$('begin').disabled=!connected||sending;
+  $('resources').replaceChildren();
+  if(night){
+   const stock=night.inventory;
+   for(const value of ['Generator: '+stock.Generator.fuel+' fuel','Nell: '+stock.Nell.fuel+' reserve',night.repair?'Beacon repair complete':'Spare part: '+(stock.Nell.part?'with Nell':stock.Ivo.part?'with Ivo':'installed')])text($('resources'),'span',value);
+   $('supply-note').textContent='Requested this watch: '+(night.allocation.join(', ')||'none')+'. Lights show the last resolved watch, not promises.';
+   $('agreements').hidden=false;$('commitments').replaceChildren();
+   for(const c of night.commitments)text($('commitments'),'p',c.owner+' · '+(c.facility||c.kind)+' · '+c.status);
+   if(!night.commitments.length)text($('commitments'),'p','No accepted commitments yet.');
+   $('institutions').replaceChildren();
+   for(const institution of night.institutions){text($('institutions'),'h3',institution.name);text($('institutions'),'p',institution.rule);text($('institutions'),'p',institution.enforcement,'subtle')}
+  }
+  if(!$('map').children.length)for(const loc of world.locations){
+   const button=document.createElement('button');button.dataset.location=loc;button.type='button';text(button,'span',loc);text(button,'small','Inspect · free');
+   button.onclick=()=>{picked=loc;render(current)};$('map').append(button);
+  }
+  for(const b of $('map').children){
+   const loc=b.dataset.location;b.setAttribute('aria-pressed',String(picked===loc));
+   b.classList.toggle('lit',Boolean(night?.services.filter(x=>x.facility===facility[loc]).at(-1)?.served));
+  }
+  $('location').textContent=picked?picked+' · inspection only':'Choose a place. Looking around does not move time.';
+  $('cast').replaceChildren();
+  for(const resident of world.cast.filter(x=>!picked||x.location===picked)){
+   const card=text($('cast'),'article','','card');text(card,'strong',resident.name);text(card,'p',descriptions[resident.name]||resident.role);text(card,'small',resident.location);
+   if(night&&!human.finished){const talk=text(card,'button','Discuss');talk.type='button';talk.onclick=()=>suggest('tell '+resident.name+': ');const pm=text(card,'button','Private');pm.type='button';pm.onclick=()=>suggest('message '+resident.name+': ')}
+  }
+  const journal=$('journal'),atEnd=journal.scrollTop+ journal.clientHeight>=journal.scrollHeight-40;
+  journal.replaceChildren();
+  const entries=night?night.journal:human.entries;
+  for(const entry of entries){
+   const p=text(journal,'p','','story'+(entry.recipients?.length<5?' private':''));
+   if(night)text(p,'small',(entry.watch<3?['Dusk','High Tide','Before Dawn'][entry.watch]:'Dawn')+(entry.recipients.length<5?' · Private':''));
+   text(p,'span',entry.text);
+  }
+  if(atEnd)journal.scrollTop=journal.scrollHeight;
+  $('context').textContent=human.pending?.context||'';
+  $('prompt').textContent=human.pending?.prompt||(human.finished?'The night has ended':night?'The island is responding…':'Waiting for the next prompt');
+  $('turn-note').textContent=night?'Every valid attempt costs one choice, even a refused request. Ambiguous actions ask for clarification without an effect.':'One-turn fixture only.';
+  $('act').disabled=!connected||sending||!human.pending;$('composer').hidden=Boolean(night?.epilogue);
+  $('choices').replaceChildren();
+  if(night&&!human.finished){
+   const suggestions=['ask Nell for fuel and part','ask Ivo to repair','transfer reserve and part','order repair','allocate all','allocate shelter and cold store','promise shelter','propose to everyone: '];
+   for(const words of suggestions){const b=text($('choices'),'button',words);b.type='button';b.onclick=()=>suggest(words)}
+  }
+  if(night?.epilogue){
+   $('epilogue').hidden=false;const end=night.epilogue;$('outcome').replaceChildren();$('responses').replaceChildren();
+   text($('outcome'),'p',end.services_maintained+' of 9 facility-watches supplied. '+end.fuel_used+' fuel consumed. '+(end.repair_completed?'Ivo’s repair lowered final beacon demand.':'The beacon was not repaired.'));
+   const table=text($('outcome'),'table',''),head=text(table,'tr','');for(const h of ['Watch','Facility','Consequence'])text(head,'th',h);
+   for(const record of night.services){const row=text(table,'tr','');for(const value of [record.watch,record.facility,record.consequence])text(row,'td',value)}
+   text($('outcome'),'p','The previous-storm accounts remain disputed. Tonight’s accounting cannot decide who was right.');
+   for(const [name,speech] of Object.entries(night.dawn_responses)){text($('responses'),'h3',name);text($('responses'),'p',speech)}
+  }
  }
- $('action-form').onsubmit=async e=>{
-   e.preventDefault();if(!connected||!current||!current.result.human.pending||sending)return;
-   $('error').textContent=''; const draft=$('action').value;
-   retry=retry||{operation:'human.respond',arguments:{request_id:current.result.human.pending.id,response:draft},
-      references:current.references,revision:current.revision,retry_key:crypto.randomUUID()};
-   sending=true;$('act').disabled=true;
-   try{
-     const response=await fetch('/api/dispatch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(retry)});
-     const result=await response.json();if(!response.ok){retry=null;throw new Error(result.error.message)}
-     retry=null;if($('action').value===draft){$('action').value='';sessionStorage.removeItem('bellwether-draft')}
-   }catch(error){$('error').textContent=error.message+' Your draft is kept.'}
-   finally{sending=false;render(current)}
- };
- const stream=new EventSource('/api/events');stream.onmessage=e=>{connected=true;render(JSON.parse(e.data))};
- stream.onerror=()=>{connected=false;$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true};
+ async function dispatch(operation,args){
+  if(!connected||!current||sending)return;const draft=$('action').value;$('error').textContent='';
+  retry=retry||{operation,arguments:args,references:current.references,revision:current.revision,retry_key:crypto.randomUUID()};
+  sending=true;render(current);
+  try{
+   const response=await fetch('/api/dispatch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(retry)});
+   const result=await response.json();
+   if(!response.ok){retry=null;throw new Error(result.error.message)}
+   retry=null;
+   if(operation==='human.respond'&&$('action').value===draft){$('action').value='';sessionStorage.removeItem('bellwether-draft')}
+  }catch(error){$('error').textContent=error.message+' Your draft is kept.'}
+  finally{sending=false;render(current)}
+ }
+ $('action-form').onsubmit=e=>{e.preventDefault();if(current?.result.human.pending)dispatch('human.respond',{request_id:current.result.human.pending.id,response:$('action').value})};
+ $('begin').onclick=()=>dispatch('game.begin',{});
+ const stream=new EventSource('/api/events');
+ stream.onmessage=e=>{connected=true;render(JSON.parse(e.data))};
+ stream.onerror=()=>{connected=false;$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true;$('begin').disabled=true;if(current)render(current)};
 })();
 </script></body></html>

--- a/concordia/examples/bellwether/player.html
+++ b/concordia/examples/bellwether/player.html
@@ -37,6 +37,7 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
 #journal{overscroll-behavior:contain}#role-wait{font-size:1.05rem;color:#edc984}
 @media(max-width:460px){#composer{padding:12px}#map button{overflow-wrap:anywhere;font-size:.85rem}#cast{grid-template-columns:1fr}.card p{font-size:.95rem}body{padding-bottom:84px}th,td{overflow-wrap:anywhere}#epilogue{padding:12px}table{table-layout:fixed}#map{gap:16px 12px}}
 @media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;animation:none!important;transition:none!important}}
+#voice label{display:block;margin:14px 0}#voice input{width:24px;height:24px;min-height:24px;vertical-align:middle}#voice button{min-height:48px;margin:5px 4px 5px 0}#transcript{min-height:100px}
 </style></head><body>
 <section id="join" hidden><h2>Join the night</h2><p>Choose a role and ask the host to approve this browser. Reloading keeps your place. No private information is shared until approval.</p><form id="join-form"><label for="join-name">Your name for the host</label><input id="join-name" maxlength="80" autocomplete="nickname" required><label for="join-role">Role</label><select id="join-role"><option>Coordinator</option><option>Nell</option><option value="spectator">Spectator · public events only</option></select><button id="join-submit">Request to join</button></form><p id="join-status" role="status"></p></section>
 <div id="play"><header><p id="role-badge"></p><span class="badge" id="watch">Dusk</span><span class="badge" id="fixture" hidden>Fixture · AI residents scripted</span>
@@ -46,6 +47,12 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
 <div id="map" aria-label="Locations around Bellwether harbor"></div><p id="location" class="subtle">Choose a place. Looking around does not move time.</p>
 <button id="all-cast" type="button">All residents</button><div id="cast"></div></section>
 <section id="epilogue" hidden aria-labelledby="dawn-title"><h2 id="dawn-title">Dawn at Bellwether</h2><div id="outcome"></div><div id="responses"></div></section>
+<details id="voice"><summary>Voice options · optional, on-device only</summary>
+<label><input id="voice-enabled" type="checkbox"> Enable voice controls for this page</label>
+<p class="subtle">Text always works. Dictation is editable and is never sent automatically. Microphone and local language support are checked only when you choose Dictate. No remote speech fallback is used.</p>
+<button id="listen" type="button" disabled>Read latest observation</button> <button id="stop-audio" type="button" disabled>Stop audio</button><p id="latest-spoken" class="subtle"></p>
+<button id="dictate" type="button" disabled>Dictate on this device</button> <button id="finish-dictation" type="button" disabled>Finish dictation</button> <button id="cancel-dictation" type="button" disabled>Cancel dictation</button>
+<label for="transcript">Transcript · review and edit before adding</label><textarea id="transcript" placeholder="Your speech transcript stays here until you add it to your action draft."></textarea><button id="use-transcript" type="button" disabled>Add to action draft</button><p id="voice-status" role="status">Voice is off. Text always works.</p></details>
 <h2>The night’s account</h2><div id="journal" aria-live="polite"></div>
 <details id="agreements" hidden><summary>Commitments and institutions</summary><div id="commitments"></div><div id="institutions"></div></details>
 <details><summary>Your available context</summary><pre id="context"></pre></details>
@@ -74,10 +81,109 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
  $('wait').onclick=()=>suggest(current?.result.night?'wait':'Wait and listen.');
  $('all-cast').onclick=()=>{picked=null;render(current)};
  function text(parent,tag,value,cls){const el=document.createElement(tag);el.textContent=value;if(cls)el.className=cls;parent.append(el);return el}
+ // Optional presentation voice; game inputs remain text, never microphone data.
+ const voice=(() => {
+  const synth=window.speechSynthesis;
+  const Recognition=window.SpeechRecognition||window.webkitSpeechRecognition;
+  const language=navigator.language||'en-US';
+  let enabled=false,scope='',canDictate=false,latest='',recognition=null,generation=0,spoken=null,checking=false;
+  const status=message=>$('voice-status').textContent=message;
+  const localVoices=()=>synth?.getVoices().filter(v=>v.localService===true)||[];
+  function controls(){
+   const available=enabled&&Boolean(scope);
+   $('dictate').disabled=!available||!canDictate||Boolean(recognition)||checking;
+   $('finish-dictation').disabled=!recognition;
+   $('cancel-dictation').disabled=!recognition&&!checking;
+   $('use-transcript').disabled=!available||!canDictate||!$('transcript').value.trim();
+   $('listen').disabled=!available||!latest||!localVoices().length||!window.SpeechSynthesisUtterance;
+   $('stop-audio').disabled=!spoken;
+  }
+  function stopSpeech(){
+   if(spoken){spoken.onend=spoken.onerror=null;spoken=null;synth?.cancel();}
+   controls();
+  }
+  function cancelDictation(clear=true){
+   generation++;checking=false;
+   if(recognition){const old=recognition;recognition=null;old.onresult=old.onend=old.onerror=null;old.abort();}
+   if(clear)$('transcript').value='';
+   controls();
+  }
+  function reset(){
+   cancelDictation();stopSpeech();status(enabled?'Audio stopped. Text controls remain available.':'Voice is off. Text always works.');
+  }
+  $('voice-enabled').onchange=()=>{
+   enabled=$('voice-enabled').checked;reset();controls();
+   if(enabled)status('Choose Dictate or Read latest observation. Only on-device speech is used; nothing plays automatically.');
+  };
+  $('transcript').oninput=controls;
+  $('cancel-dictation').onclick=()=>{cancelDictation();status('Dictation cancelled. Your action draft is unchanged.')};
+  $('finish-dictation').onclick=()=>{recognition?.stop();status('Finishing dictation… review the transcript before adding it.')};
+  $('use-transcript').onclick=()=>{
+   if(!enabled||!canDictate||!scope)return;
+   const transcript=$('transcript').value.trim();if(!transcript)return;
+   const draft=$('action');draft.value+=(draft.value&&!/\s$/.test(draft.value)?' ':'')+transcript;
+   draft.oninput();cancelDictation();status('Transcript added to your draft. Edit it, then choose Send action.');draft.focus();
+  };
+  $('dictate').onclick=async()=>{
+   if(!enabled||!canDictate||!scope||recognition||checking)return;
+   stopSpeech();cancelDictation();const attempt=generation,expected=scope;checking=true;status('Checking for an installed on-device language…');controls();
+   const stillHere=()=>attempt===generation&&expected===scope&&enabled&&canDictate;
+   try{
+    if(!Recognition||typeof Recognition.available!=='function'||!('processLocally' in Recognition.prototype))
+     throw new Error('On-device dictation is unavailable in this browser. Please type instead.');
+    const availability=await Recognition.available({langs:[language],processLocally:true});
+    if(!stillHere())return;
+    if(availability!=='available')throw new Error('An on-device '+language+' language pack is not installed. Please type instead; no remote fallback or download was started.');
+    const rec=new Recognition();rec.processLocally=true;
+    if(rec.processLocally!==true)throw new Error('On-device processing could not be enabled. Please type instead.');
+    recognition=rec;rec.lang=language;rec.interimResults=false;rec.continuous=true;rec.maxAlternatives=1;
+    rec.onresult=event=>{
+     if(!stillHere()||recognition!==rec)return;
+     for(let i=event.resultIndex;i<event.results.length;i++)if(event.results[i].isFinal){
+      const value=event.results[i][0].transcript;
+      $('transcript').value+=($('transcript').value?' ':'')+value;
+     }
+     status('Review your transcript. It has not been added or sent.');controls();
+    };
+    rec.onerror=event=>{
+     if(!stillHere())return;
+     recognition=null;checking=false;generation++;rec.onresult=rec.onend=rec.onerror=null;rec.abort();
+     status(event.error==='not-allowed'?'Microphone permission was declined. Please type instead.':'Dictation stopped. Review any transcript or continue typing.');controls();
+    };
+    rec.onend=()=>{if(!stillHere())return;recognition=null;status('Dictation finished. Edit the transcript, then Add to draft.');controls()};
+    rec.start();status('Listening on this device… Finish or Cancel when ready.');
+   }catch(error){if(stillHere()){cancelDictation(false);status(error.message||'Dictation unavailable. Please type instead.')}}
+   finally{if(attempt===generation){checking=false;controls()}}
+  };
+  $('listen').onclick=()=>{
+   if(!enabled||!scope||!latest||!window.SpeechSynthesisUtterance)return;
+   const voices=localVoices(),chosen=voices.find(v=>v.lang===language)||voices.find(v=>v.lang.split('-')[0]===language.split('-')[0])||voices[0];
+   if(!chosen){status('No local speaking voice is available. The observation remains readable.');return}
+   stopSpeech();cancelDictation(false);
+   const utterance=new SpeechSynthesisUtterance(latest);utterance.voice=chosen;utterance.lang=chosen.lang;spoken=utterance;
+   utterance.onend=()=>{if(spoken===utterance){spoken=null;status('Reading finished.');controls()}};
+   utterance.onerror=()=>{if(spoken===utterance){spoken=null;status('Audio unavailable. Read the observation in the journal.');controls()}};
+   synth.speak(utterance);status('Reading your latest visible observation. Stop audio at any time.');controls();
+  };
+  $('stop-audio').onclick=()=>{stopSpeech();status('Audio stopped.')};
+  synth?.addEventListener('voiceschanged',controls);
+  document.addEventListener('visibilitychange',()=>{if(document.hidden)reset()});
+  window.addEventListener('pagehide',reset);
+  return {
+   update(nextScope,allowed,observation){
+    if(nextScope!==scope){scope=nextScope;reset();}
+    canDictate=allowed;latest=observation||'';
+    $('latest-spoken').textContent=!localVoices().length?'No local speaking voice is available here. Read the journal below.':latest?'Read aloud uses the latest observation visible in your journal.':'No observation available yet.';
+    controls();
+   },
+   disconnect(){scope='';canDictate=false;latest='';reset();controls()}
+  };
+ })();
+
  function render(data){
   if(!data||(current&&data.revision<current.revision))return;current=data;
   const state=data.result;
-  if(state.lobby){$('join').hidden=false;$('play').hidden=true;$('jump-action').hidden=true;
+  if(state.lobby){voice.disconnect();$('join').hidden=false;$('play').hidden=true;$('jump-action').hidden=true;
    for(const id of ['context','journal','prompt','outcome','responses'])$(id).replaceChildren();
    if(identity){$('action').value='';retry=null;identity='';}ownJoin();return;}
   $('join').hidden=true;$('play').hidden=false;
@@ -119,6 +225,7 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
   const journal=$('journal'),atEnd=journal.scrollTop+ journal.clientHeight>=journal.scrollHeight-40;
   journal.replaceChildren();
   const entries=night?night.journal:human.entries;
+  voice.update(connected?identity+':'+(human.pending?.id||'waiting'):'',Boolean(connected&&human.pending&&!spectator),entries.at(-1)?.text||'');
   for(const entry of entries){
    const p=text(journal,'p','','story'+(entry.recipients?.length<5?' private':''));
    if(night)text(p,'small',(entry.watch<3?['Dusk','High Tide','Before Dawn'][entry.watch]:'Dawn')+(entry.recipients.length<5?' · Private':''));
@@ -164,6 +271,6 @@ input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819
  $('begin').onclick=()=>dispatch('game.begin',{});
  const stream=new EventSource(api('events'));
  stream.onmessage=e=>{connected=true;render(JSON.parse(e.data))};
- stream.onerror=()=>{connected=false;$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true;$('begin').disabled=true;if(current)render(current)};
+ stream.onerror=()=>{connected=false;voice.disconnect();$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true;$('begin').disabled=true;if(current)render(current)};
 })();
 </script></body></html>

--- a/concordia/examples/bellwether/player.html
+++ b/concordia/examples/bellwether/player.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content">
 <title>Last Light at Bellwether</title><style>
 :root{color-scheme:dark;font:17px/1.6 system-ui;background:#091721;color:#f2e6cf;--muted:#b6c8cb;--gold:#edc984}
-*{box-sizing:border-box}body{margin:0 auto;max-width:940px;padding:26px 18px 60px}
+*{box-sizing:border-box}body{overflow-wrap:anywhere;margin:0 auto;max-width:940px;padding:26px 18px 60px}
 h1{font:clamp(2.4rem,7vw,4.3rem)/1.1 Georgia,serif;margin:18px 0 10px;max-width:720px}
 h2{font:1.5rem Georgia,serif;margin-top:32px}h3{font:1.2rem Georgia,serif}
 .subtle,small{color:var(--muted)}.badge{border:1px solid #998d6b;padding:5px 12px;border-radius:30px;font-size:.8rem;display:inline-block}
@@ -26,8 +26,20 @@ textarea{width:100%;min-height:116px;padding:12px;background:#102732;color:inher
 table{width:100%;border-collapse:collapse;font-size:.85rem}td,th{text-align:left;border-bottom:1px solid #42606b;padding:7px}
 details{margin:20px 0}summary{cursor:pointer;color:var(--muted)}#context{max-height:350px;overflow:auto}#prompt{margin:28px 0 8px}
 [hidden]{display:none!important}@media(max-width:460px){body{padding:20px 14px 40px}#map{gap:20px 12px;padding:30px 12px}#cast{grid-template-columns:1fr 1fr}.card{padding:10px}.card p{font-size:.8rem}button{min-height:44px}}
+
+#join{background:#132a35;border:1px solid #638084;border-radius:12px;padding:20px;margin-top:20px}
+#join label,#join input,#join select{display:block;width:100%;margin:8px 0}
+input,select{font:inherit;background:#102732;color:inherit;border:1px solid #819ca1;border-radius:8px;padding:12px;min-height:48px;max-width:100%}
+#role-badge{font-weight:700;color:var(--gold)}#jump-action{position:fixed;bottom:max(12px,env(safe-area-inset-bottom));right:16px;z-index:5;background:var(--gold);color:#15222a;box-shadow:0 4px 20px #0008}
+#composer{scroll-margin:16px;background:#0f2530;border:1px solid #416570;padding:16px;border-radius:12px;margin-top:24px}
+#action-form>p{position:relative;background:#0f2530;padding:10px 0;margin-bottom:0}
+#action{max-height:40dvh}#act{min-width:136px}#choices button,.card button{min-height:48px}
+#journal{overscroll-behavior:contain}#role-wait{font-size:1.05rem;color:#edc984}
+@media(max-width:460px){#composer{padding:12px}#map button{overflow-wrap:anywhere;font-size:.85rem}#cast{grid-template-columns:1fr}.card p{font-size:.95rem}body{padding-bottom:84px}th,td{overflow-wrap:anywhere}#epilogue{padding:12px}table{table-layout:fixed}#map{gap:16px 12px}}
+@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;animation:none!important;transition:none!important}}
 </style></head><body>
-<header><span class="badge" id="watch">Dusk</span><span class="badge" id="fixture" hidden>Fixture · scripted residents</span>
+<section id="join" hidden><h2>Join the night</h2><p>Choose a role and ask the host to approve this browser. Reloading keeps your place. No private information is shared until approval.</p><form id="join-form"><label for="join-name">Your name for the host</label><input id="join-name" maxlength="80" autocomplete="nickname" required><label for="join-role">Role</label><select id="join-role"><option>Coordinator</option><option>Nell</option><option value="spectator">Spectator · public events only</option></select><button id="join-submit">Request to join</button></form><p id="join-status" role="status"></p></section>
+<div id="play"><header><p id="role-badge"></p><span class="badge" id="watch">Dusk</span><span class="badge" id="fixture" hidden>Fixture · AI residents scripted</span>
 <h1>Last Light<br>at Bellwether</h1><p class="subtle">An island community. One stormy night.</p>
 <p id="connection" role="status">Connecting…</p><p id="opening"></p><button id="begin" hidden>Begin the night</button></header>
 <section aria-labelledby="map-title"><h2 id="map-title">The island</h2><div id="resources"></div><p id="supply-note" class="subtle"></p>
@@ -37,28 +49,48 @@ details{margin:20px 0}summary{cursor:pointer;color:var(--muted)}#context{max-hei
 <h2>The night’s account</h2><div id="journal" aria-live="polite"></div>
 <details id="agreements" hidden><summary>Commitments and institutions</summary><div id="commitments"></div><div id="institutions"></div></details>
 <details><summary>Your available context</summary><pre id="context"></pre></details>
-<section id="composer"><h2 id="prompt">Waiting to begin</h2><p id="turn-note" class="subtle"></p><div id="choices"></div>
+<section id="composer"><h2 id="prompt">Waiting to begin</h2><p id="role-wait" role="status"></p><p id="turn-note" class="subtle"></p><label id="decision-label" for="decision" hidden>Your decision</label><select id="decision" hidden></select><div id="choices"></div>
 <form id="action-form"><label for="action">What do you do or say?</label><textarea id="action" placeholder="Choose a suggestion, or write your own words…"></textarea>
 <p><button type="button" id="wait">Suggest waiting</button> <button id="act" disabled>Send action</button></p></form></section>
-<p id="error" role="alert"></p>
+</div><button id="jump-action" type="button" hidden>Go to your action</button><p id="error" role="alert"></p>
 <script>
 (() => {
- const $=id=>document.getElementById(id);let current,retry,sending=false,picked,connected=false;
+ const $=id=>document.getElementById(id);let current,retry,sending=false,picked,connected=false,identity='',draftKey='bellwether-draft';
+ const api=name=>new URL('api/'+name,location.origin+location.pathname.replace(/\/?$/,'/')).href;
+ const announceError=message=>{$('error').textContent=message};
+ $('jump-action').onclick=()=>{$('composer').scrollIntoView({block:'start',behavior:'auto'});$('action').focus({preventScroll:true})};
+ $('join-form').onsubmit=async e=>{e.preventDefault();$('join-submit').disabled=true;
+  try{const response=await fetch(api('join'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({label:$('join-name').value,role:$('join-role').value})});const result=await response.json();if(!response.ok)throw new Error(result.error.message);$('join-status').textContent='Waiting for host approval as '+result.requested_role;}
+  catch(error){announceError(error.message)}finally{$('join-submit').disabled=false}
+ };
+ async function ownJoin(){try{const response=await fetch(api('session'));if(response.ok){const own=await response.json();if(own.requested_role)$('join-status').textContent='Waiting for host approval as '+own.requested_role;}}catch{}}
+
  const labels=['Harbor beacon','Storm shelter','Cooperative cold store','Generator yard'];
  const facility={'Harbor beacon':'beacon','Storm shelter':'shelter','Cooperative cold store':'cold store'};
  const descriptions={Mara:'Harbor master · boats and safe passage',Nell:'Cooperative custodian · reserves and livelihoods',Ivo:'Engineer · repairs and working conditions',Sam:'Shelter steward · displaced residents'};
- $('action').value=sessionStorage.getItem('bellwether-draft')||'';
- $('action').oninput=()=>{sessionStorage.setItem('bellwether-draft',$('action').value);retry=null};
+ $('action').value='';
+ $('action').oninput=()=>{sessionStorage.setItem(draftKey,$('action').value);retry=null};
  function suggest(words){$('action').value=words;$('action').oninput();$('action').focus()}
  $('wait').onclick=()=>suggest(current?.result.night?'wait':'Wait and listen.');
  $('all-cast').onclick=()=>{picked=null;render(current)};
  function text(parent,tag,value,cls){const el=document.createElement(tag);el.textContent=value;if(cls)el.className=cls;parent.append(el);return el}
  function render(data){
   if(!data||(current&&data.revision<current.revision))return;current=data;
-  const state=data.result,world=state.scenario,human=state.human,night=state.night;
+  const state=data.result;
+  if(state.lobby){$('join').hidden=false;$('play').hidden=true;$('jump-action').hidden=true;
+   for(const id of ['context','journal','prompt','outcome','responses'])$(id).replaceChildren();
+   if(identity){$('action').value='';retry=null;identity='';}ownJoin();return;}
+  $('join').hidden=true;$('play').hidden=false;
+  const world=state.scenario,human=state.human,night=state.night;
+  const role=state.role||'Coordinator',spectator=role==='spectator',isResident=state.multiplayer&&role!=='Coordinator'&&!spectator;
+  const nextIdentity=data.references.session_id+':'+role;
+  if(identity!==nextIdentity){identity=nextIdentity;draftKey='bellwether-draft:'+identity;$('action').value=sessionStorage.getItem(draftKey)||'';retry=null;}
+  $('role-badge').textContent=state.multiplayer?(spectator?'Spectator · public events only':'You are '+role):'';
+  $('jump-action').hidden=!human.pending||spectator;
+
   $('fixture').hidden=!state.fixture;$('watch').textContent=night?night.watch+' · '+night.remaining+' choices remain':'Dusk · one-turn fixture';
-  $('connection').textContent=!connected?'Reconnecting… your draft is kept':human.finished?'The account is complete':'Connected · '+(night?.next_actor&&night.next_actor!=='Coordinator'?night.next_actor+' is considering a response':human.status);
-  $('opening').textContent=world.opening;$('begin').hidden=!night||state.phase!=='paused';$('begin').disabled=!connected||sending;
+  $('connection').textContent=!connected?'Reconnecting… your draft is kept':human.finished?'The account is complete':'Connected · '+(human.pending?'Your turn':spectator?'Watching public events':night?.next_actor&&night.next_actor!==role?'Waiting for '+night.next_actor:human.status);
+  $('opening').textContent=world.opening;$('begin').hidden=!night||state.phase!=='paused'||spectator;$('begin').disabled=!connected||sending||(state.multiplayer&&!state.players_ready);if(state.multiplayer&&!state.players_ready)$('connection').textContent='Waiting for the host to approve both players';
   $('resources').replaceChildren();
   if(night){
    const stock=night.inventory;
@@ -82,7 +114,7 @@ details{margin:20px 0}summary{cursor:pointer;color:var(--muted)}#context{max-hei
   $('cast').replaceChildren();
   for(const resident of world.cast.filter(x=>!picked||x.location===picked)){
    const card=text($('cast'),'article','','card');text(card,'strong',resident.name);text(card,'p',descriptions[resident.name]||resident.role);text(card,'small',resident.location);
-   if(night&&!human.finished){const talk=text(card,'button','Discuss');talk.type='button';talk.onclick=()=>suggest('tell '+resident.name+': ');const pm=text(card,'button','Private');pm.type='button';pm.onclick=()=>suggest('message '+resident.name+': ')}
+   if(night&&!human.finished&&!isResident&&!spectator){const talk=text(card,'button','Discuss');talk.type='button';talk.onclick=()=>suggest('tell '+resident.name+': ');const pm=text(card,'button','Private');pm.type='button';pm.onclick=()=>suggest('message '+resident.name+': ')}
   }
   const journal=$('journal'),atEnd=journal.scrollTop+ journal.clientHeight>=journal.scrollHeight-40;
   journal.replaceChildren();
@@ -95,10 +127,14 @@ details{margin:20px 0}summary{cursor:pointer;color:var(--muted)}#context{max-hei
   if(atEnd)journal.scrollTop=journal.scrollHeight;
   $('context').textContent=human.pending?.context||'';
   $('prompt').textContent=human.pending?.prompt||(human.finished?'The night has ended':night?'The island is responding…':'Waiting for the next prompt');
-  $('turn-note').textContent=night?'Every valid attempt costs one choice, even a refused request. Ambiguous actions ask for clarification without an effect.':'One-turn fixture only.';
-  $('act').disabled=!connected||sending||!human.pending;$('composer').hidden=Boolean(night?.epilogue);
+  $('role-wait').textContent=isResident&&!human.pending?'Waiting for a conversation or request addressed to Nell. Other players cannot act for you.':'';
+  $('turn-note').textContent=isResident?'Choose your own decision and words. Acceptance records consent; it does not perform a transfer.':night?'Every valid attempt costs one choice, even a refused request. Ambiguous actions ask for clarification without an effect.':'One-turn fixture only.';
+  $('act').disabled=!connected||sending||!human.pending;$('composer').hidden=spectator||Boolean(night?.epilogue&&!human.pending);
+  $('decision').hidden=$('decision-label').hidden=!isResident;
+  if(isResident){const chosen=$('decision').value;$('decision').replaceChildren();for(const decision of state.decisions||['speak']){const option=text($('decision'),'option',({accept:'Accept this request',decline:'Decline',counter:'Offer different terms',revoke:'Revoke my unfulfilled commitment',speak:'Speak'})[decision]);option.value=decision;}if([...(state.decisions||[])].includes(chosen))$('decision').value=chosen;}
+  $('wait').hidden=isResident;
   $('choices').replaceChildren();
-  if(night&&!human.finished){
+  if(night&&!human.finished&&!isResident&&!spectator){
    const suggestions=['ask Nell for fuel and part','ask Ivo to repair','transfer reserve and part','order repair','allocate all','allocate shelter and cold store','promise shelter','propose to everyone: '];
    for(const words of suggestions){const b=text($('choices'),'button',words);b.type='button';b.onclick=()=>suggest(words)}
   }
@@ -116,17 +152,17 @@ details{margin:20px 0}summary{cursor:pointer;color:var(--muted)}#context{max-hei
   retry=retry||{operation,arguments:args,references:current.references,revision:current.revision,retry_key:crypto.randomUUID()};
   sending=true;render(current);
   try{
-   const response=await fetch('/api/dispatch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(retry)});
+   const response=await fetch(api('dispatch'),{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(retry)});
    const result=await response.json();
    if(!response.ok){retry=null;throw new Error(result.error.message)}
    retry=null;
-   if(operation==='human.respond'&&$('action').value===draft){$('action').value='';sessionStorage.removeItem('bellwether-draft')}
+   if(operation==='human.respond'&&$('action').value===draft){$('action').value='';sessionStorage.removeItem(draftKey)}
   }catch(error){$('error').textContent=error.message+' Your draft is kept.'}
   finally{sending=false;render(current)}
  }
- $('action-form').onsubmit=e=>{e.preventDefault();if(current?.result.human.pending)dispatch('human.respond',{request_id:current.result.human.pending.id,response:$('action').value})};
+ $('action-form').onsubmit=e=>{e.preventDefault();if(current?.result.human.pending)dispatch('human.respond',{request_id:current.result.human.pending.id,response:current.result.role==='Nell'?JSON.stringify({decision:$('decision').value,speech:$('action').value}):$('action').value})};
  $('begin').onclick=()=>dispatch('game.begin',{});
- const stream=new EventSource('/api/events');
+ const stream=new EventSource(api('events'));
  stream.onmessage=e=>{connected=true;render(JSON.parse(e.data))};
  stream.onerror=()=>{connected=false;$('connection').textContent='Reconnecting… your draft is kept';$('act').disabled=true;$('begin').disabled=true;if(current)render(current)};
 })();

--- a/concordia/examples/bellwether/public_account.py
+++ b/concordia/examples/bellwether/public_account.py
@@ -1,0 +1,207 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Portable public records, not executable replay or component checkpoints."""
+
+import html
+import json
+
+from concordia.examples.bellwether import game
+from concordia.utils import operation_service as ops
+
+NOTICE = (
+    'Public events only. Private journals, component state and service identity'
+    ' are excluded. Public speech can still disclose identifying information;'
+    ' this is not anonymization. This account is not a checkpoint, executable'
+    ' replay, or evidence about real people.'
+)
+
+
+def document(world: game.StormNight, *, fixture: bool, phase: str) -> dict:
+  """Project an explicit public allowlist from the standard spectator view."""
+  public = world.view('spectator')
+  epilogue = public['epilogue']
+  return {
+      'schema': 'bellwether-public-account/v1',
+      'scope': 'public',
+      'backend': 'fixture' if fixture else 'live',
+      'status': (
+          'completed'
+          if phase == 'completed'
+          else 'interrupted'
+          if phase == 'failed'
+          else 'in_progress'
+      ),
+      'watch': public['watch'],
+      'notice': NOTICE,
+      'events': [
+          {
+              'number': index,
+              'watch': (
+                  game.WATCHES[event['watch']] if event['watch'] < 3 else 'Dawn'
+              ),
+              'kind': event['kind'],
+              'text': event['text'],
+          }
+          for index, event in enumerate(public['journal'], start=1)
+      ],
+      'accounting': {
+          'inventory': {
+              owner: {
+                  item: public['inventory'][owner][item]
+                  for item in ('fuel', 'part')
+              }
+              for owner in ('Generator', 'Nell', 'Ivo', 'Used')
+          },
+          'repair_completed': public['repair'],
+          'services': [
+              {
+                  key: record[key]
+                  for key in ('watch', 'facility', 'served', 'consequence')
+              }
+              for record in public['services']
+          ],
+      },
+      'dawn': (
+          {
+              key: epilogue[key]
+              for key in (
+                  'services_maintained',
+                  'services_total',
+                  'fuel_used',
+                  'repair_completed',
+                  'dispute_settled',
+              )
+          }
+          if epilogue
+          else None
+      ),
+  }
+
+
+def render_html(account: dict) -> str:
+  """Render only a projected document as inert, offline UTF-8 HTML."""
+  escape = html.escape
+  events = ''.join(
+      '<li><h3>'
+      + escape(event['watch'])
+      + '</h3><p>'
+      + escape(event['text'])
+      + '</p><small>'
+      + escape(event['kind'])
+      + '</small></li>'
+      for event in account['events']
+  )
+  if not events:
+    events = '<li>No public events recorded yet.</li>'
+
+  def cells(values):
+    return ''.join('<td>' + escape(str(value)) + '</td>' for value in values)
+
+  material = account['accounting']
+  stocks = ''.join(
+      '<tr>' + cells((owner, items['fuel'], items['part'])) + '</tr>'
+      for owner, items in material['inventory'].items()
+  )
+  services = (
+      ''.join(
+          '<li><strong>'
+          + escape(record['watch'])
+          + ' · '
+          + escape(record['facility'])
+          + '</strong><p>'
+          + escape(record['consequence'])
+          + '</p></li>'
+          for record in material['services']
+      )
+      or '<li>No watch boundary has been resolved yet.</li>'
+  )
+  dawn = account['dawn']
+  conclusion = (
+      str(dawn['services_maintained'])
+      + ' of '
+      + str(dawn['services_total'])
+      + ' facility-watches supplied. '
+      + str(dawn['fuel_used'])
+      + ' fuel consumed. '
+      + (
+          'The beacon was repaired.'
+          if dawn['repair_completed']
+          else 'The beacon was not repaired.'
+      )
+      + ' These records do not settle the previous-storm dispute.'
+      if dawn
+      else 'No dawn outcome has been recorded yet.'
+  )
+  accounting = (
+      '<table><caption>Recorded stocks</caption><thead><tr>'
+      '<th scope="col">Holder</th><th scope="col">Fuel</th>'
+      '<th scope="col">Spare parts</th></tr></thead><tbody>'
+      + stocks
+      + '</tbody></table><h3>Service consequences</h3><ul>'
+      + services
+      + '</ul><h3>Dawn</h3><p>'
+      + escape(conclusion)
+      + '</p>'
+  )
+  return (
+      '<!doctype html><html lang="en"><meta charset="utf-8">'
+      '<meta name="viewport" content="width=device-width,initial-scale=1">'
+      '<meta http-equiv="Content-Security-Policy" '
+      "content=\"default-src 'none'; style-src 'unsafe-inline';"
+      " base-uri 'none'; form-action 'none'\">"
+      '<title>Bellwether · Public account</title><style>'
+      'body{font:1.1rem/1.6 system-ui,sans-serif;max-width:48rem;'
+      'margin:auto;padding:1.2rem;color:#162934;background:#f8faf9;'
+      'overflow-wrap:anywhere}li{margin-bottom:1.5rem}'
+      'p{white-space:pre-wrap;overflow-wrap:anywhere}'
+      'table{border-collapse:collapse;width:100%}'
+      'td,th{text-align:left;padding:.4rem;border-bottom:1px solid #aabbb8}'
+      'caption{text-align:left;font-weight:bold}small{color:#465a64}</style>'
+      '<main><h1>Bellwether · Public account</h1><p>'
+      + escape(account['backend'].capitalize())
+      + ' · '
+      + escape(account['status'].replace('_', ' ').capitalize())
+      + ' · '
+      + escape(account['watch'])
+      + '</p><p>'
+      + escape(account['notice'])
+      + '</p><h2>Public timeline</h2><ol>'
+      + events
+      + '</ol><h2>Recorded material consequences</h2>'
+      + accounting
+      + '</main></html>'
+  )
+
+
+def export(
+    world: game.StormNight, *, fixture: bool, phase: str, format_name: str
+) -> dict:
+  """Return artifact content without transport/session envelope identifiers."""
+  if format_name not in ('json', 'html'):
+    raise ops.OperationError('invalid_format', 'Choose json or html.')
+  account = document(world, fixture=fixture, phase=phase)
+  return {
+      'filename': 'bellwether-public-account.' + format_name,
+      'media_type': (
+          'application/json; charset=utf-8'
+          if format_name == 'json'
+          else 'text/html; charset=utf-8'
+      ),
+      'content': (
+          json.dumps(account, ensure_ascii=False, indent=2) + '\n'
+          if format_name == 'json'
+          else render_html(account)
+      ),
+  }

--- a/concordia/examples/bellwether/public_account_test.py
+++ b/concordia/examples/bellwether/public_account_test.py
@@ -1,0 +1,250 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public export/CLI/browser evidence; seeded records, never simulation runs."""
+
+import json
+import pathlib
+import subprocess
+import sys
+from unittest import mock
+
+from concordia.examples.bellwether import game_service
+from concordia.examples.bellwether import multiplayer
+from concordia.utils import operation_service as ops
+from concordia.utils import simulation_server
+import pytest
+
+PRIVATE = 'PRIVATE_EXPORT_SENTINEL'
+LITERAL = 'Public "words"\n</script><img src=x onerror=alert(1)> & café 🌊'
+
+
+@pytest.fixture(name='game')
+def game_fixture(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No simulation in export checks'),
+  ):
+    game = game_service.Game(tmp_path)
+    game.world.emit('private_message', PRIVATE, ['Coordinator', 'Nell'])
+    game.world.emit('speech', LITERAL, secret_extra=PRIVATE)
+    try:
+      yield game
+    finally:
+      game.close()
+
+
+def call(game, audience='player', format_name='json'):
+  return game.operations.dispatch(
+      audience,
+      {
+          'operation': 'game.public_account',
+          'arguments': {'format': format_name},
+      },
+  )['result']
+
+
+def test_public_allowlist_no_identifiers_or_effects(game):
+  before = game.operations.snapshot('developer')
+  result = call(game)
+  document = json.loads(result['content'])
+  assert PRIVATE not in result['content']
+  assert document['events'][-1]['text'] == LITERAL
+  assert [x['number'] for x in document['events']] == list(
+      range(1, len(document['events']) + 1)
+  )
+  assert set(document['events'][-1]) == {'number', 'watch', 'kind', 'text'}
+  assert 'recipients' not in result['content']
+  assert 'session_id' not in result['content']
+  assert 'request_id' not in result['content']
+  assert 'secret_extra' not in result['content']
+  assert call(game, 'developer') == result
+  assert call(game, 'role:spectator') == result
+  assert game.operations.snapshot('developer') == before
+
+
+@pytest.mark.parametrize(
+    ('phase', 'expected'),
+    [
+        ('paused', 'in_progress'),
+        ('running', 'in_progress'),
+        ('failed', 'interrupted'),
+        ('completed', 'completed'),
+    ],
+)
+def test_status_does_not_claim_incomplete_as_complete(game, phase, expected):
+  game.phase = phase
+  data = json.loads(call(game)['content'])
+  assert data['status'] == expected
+  assert data['backend'] == 'fixture'
+  game.fixture = False
+  assert json.loads(call(game)['content'])['backend'] == 'live'
+
+
+def test_empty_public_timeline_and_explicit_non_replay_limits(game):
+  game.world.data['events'] = []
+  content = call(game, format_name='html')['content']
+  assert 'No public events recorded yet.' in content
+  assert 'not a checkpoint' in content
+  assert 'not anonymization' in content
+
+
+def test_invalid_format_and_scope_fail_without_changes(game):
+  before = game.operations.snapshot('developer')
+  with pytest.raises(ops.OperationError, match='json or html'):
+    call(game, format_name='xml')
+  with pytest.raises(ops.OperationError, match='unavailable'):
+    call(game, audience='visitor')
+  assert game.operations.snapshot('developer') == before
+
+
+def test_multiplayer_public_bytes_equal_and_revocation_denies(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No run'),
+  ):
+    game = multiplayer.SharedGame(tmp_path, secure=False)
+    try:
+      game.world.emit('private_message', PRIVATE, ['Coordinator', 'Nell'])
+      expected = call(game, 'developer')
+      for role in ('Coordinator', 'Nell', 'spectator'):
+        principal, _ = game.sessions.identify(None, create=True)
+        game.sessions.request(principal, role, role)
+        game.sessions.approve(principal)
+        assert call(game, principal) == expected
+        game.sessions.revoke(principal)
+        with pytest.raises(ops.OperationError, match='unavailable'):
+          call(game, principal)
+    finally:
+      game.close()
+
+
+def test_html_escape_and_material_projection(game):
+  game.world.data['services'] = [{
+      'watch': 'Dusk',
+      'facility': 'shelter',
+      'served': False,
+      'consequence': LITERAL,
+      'private_debug': PRIVATE,
+  }]
+  game.world.data['epilogue'] = {
+      'services_maintained': 0,
+      'services_total': 9,
+      'fuel_used': 0,
+      'repair_completed': False,
+      'dispute_settled': False,
+      'commitments': [{'private_text': PRIVATE}],
+  }
+  artifact = call(game, format_name='html')
+  assert '<script' not in artifact['content']
+  assert '<img' not in artifact['content']
+  assert '&lt;img' in artifact['content']
+  assert PRIVATE not in artifact['content']
+  account = json.loads(call(game)['content'])
+  assert account['dawn']['dispute_settled'] is False
+  assert account['accounting']['services'][0]['consequence'] == LITERAL
+
+
+def test_chromium_download_cli_parity_and_offline_inertness(game, tmp_path):
+  pwlib = pytest.importorskip('playwright.sync_api')
+  game.server.start()
+  player = simulation_server.SimulationServer(
+      port=0,
+      operation_service=game.operations,
+      audience='player',
+      html_content=pathlib.Path(__file__)
+      .with_name('player.html')
+      .read_text(encoding='utf-8'),
+  )
+  player.start()
+  before = game.operations.snapshot('developer')
+  try:
+    with pwlib.sync_playwright() as pw:
+      browser = pw.chromium.launch()
+      try:
+        page = browser.new_page(viewport={'width': 360, 'height': 800})
+        errors = []
+        page.on('pageerror', lambda e: errors.append(str(e)))
+        page.goto(f'http://127.0.0.1:{player.bound_port}')
+        pwlib.expect(page.locator('#export-html')).to_be_enabled()
+        page.locator('#action').fill('private draft remains in this browser')
+        with page.expect_download() as json_download:
+          page.click('#export-json')
+        json_path = tmp_path / 'public.json'
+        json_download.value.save_as(json_path)
+        with page.expect_download() as html_download:
+          page.click('#export-html')
+        html_path = tmp_path / 'public.html'
+        html_download.value.save_as(html_path)
+        assert page.locator('#action').input_value().startswith('private draft')
+        page.route(
+            '**/api/dispatch',
+            lambda route: route.fulfill(
+                status=409,
+                content_type='application/json',
+                body=json.dumps({'error': {'message': 'Export unavailable'}}),
+            ),
+        )
+        page.click('#export-json')
+        pwlib.expect(page.locator('#export-status')).to_contain_text(
+            'Export unavailable. Your draft is kept.'
+        )
+        assert page.locator('#action').input_value().startswith('private draft')
+        page.unroute('**/api/dispatch')
+        assert game.operations.snapshot('developer') == before
+        result = subprocess.run(
+            [
+                sys.executable,
+                '-m',
+                'concordia.command_line_interface.concordia_session',
+                '--url',
+                f'http://127.0.0.1:{game.server.bound_port}',
+                'call',
+            ],
+            input=json.dumps({
+                'operation': 'game.public_account',
+                'arguments': {'format': 'json'},
+            }),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert json.loads(result.stdout)['result']['content'] == (
+            json_path.read_text(encoding='utf-8')
+        )
+        assert 'private draft' not in html_path.read_text(encoding='utf-8')
+        assert PRIVATE not in html_path.read_text(encoding='utf-8')
+        assert PRIVATE not in json_path.read_text(encoding='utf-8')
+        page.reload()
+        pwlib.expect(page.locator('#export-html')).to_be_enabled()
+        assert page.locator('#action').input_value().startswith('private draft')
+        resource_requests = []
+        offline = browser.new_page(viewport={'width': 360, 'height': 800})
+        offline.on('pageerror', lambda e: errors.append(str(e)))
+        offline.on('request', lambda r: resource_requests.append(r.url))
+        offline.context.set_offline(True)
+        offline.goto(html_path.as_uri())
+        assert offline.locator('script,img,iframe,a,form').count() == 0
+        assert LITERAL in offline.locator('body').inner_text()
+        assert offline.evaluate('innerWidth') == 360
+        assert offline.evaluate('document.documentElement.scrollWidth') <= 360
+        offline.screenshot(
+            path=str(tmp_path / 'public-account-mobile.png'), full_page=True
+        )
+        assert resource_requests == [html_path.as_uri()]
+        assert not errors
+      finally:
+        browser.close()
+  finally:
+    player.stop()

--- a/concordia/examples/bellwether/researcher.py
+++ b/concordia/examples/bellwether/researcher.py
@@ -1,0 +1,179 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trusted teaching recipes; no model calls or simulation on import/build.
+
+These analogous cases keep Bellwether's fixed roster/action vocabulary and
+physical accounting. They are not general-purpose project serialization or
+empirically validated social models. See RESEARCHER.md for extension boundaries.
+"""
+
+from collections.abc import Mapping
+import copy
+from dataclasses import dataclass
+from dataclasses import replace
+from typing import Any
+
+from concordia.components.game_master import make_observation
+from concordia.examples.bellwether import game
+from concordia.examples.bellwether import game_prefab
+from concordia.examples.bellwether import scenario
+from concordia.typing import prefab
+
+RECIPES = (
+    'bellwether',
+    'mutual-aid',
+    'resource-governance',
+    'institutional-dispute',
+)
+
+
+@dataclass
+class Case:
+  """One build's config/world, never shared between runs or checkpoint forks."""
+
+  config: prefab.Config
+  world: game.StormNight
+  manifest: dict[str, Any]
+
+
+def prepare_case(name, reader, *, actor_logic='minimal', human_readers=None):
+  """Return standard Config + owned world, ready for generic.Simulation.
+
+  Values are declared in this trusted module, not loaded as Python from user
+  documents. Each call creates its own Inventory, ObservationQueue, GM rules
+  and prefab parameters. Human readers are runtime objects, never serialized.
+  """
+  if name not in RECIPES:
+    raise ValueError('Choose a supported recipe: ' + ', '.join(RECIPES))
+  if not callable(reader):
+    raise ValueError('reader must be a runtime HumanInput callable')
+  if human_readers is not None and (
+      not isinstance(human_readers, Mapping)
+      or any(name not in scenario.RESIDENTS for name in human_readers)
+      or any(not callable(value) for value in human_readers.values())
+  ):
+    raise ValueError('human_readers must map known resident names to callables')
+  accounts = {n: v[1] for n, v in scenario.RESIDENTS.items()}
+  goals = {n: v[0] for n, v in scenario.RESIDENTS.items()}
+  institutions = copy.deepcopy(game.INSTITUTIONS)
+  dispute = copy.deepcopy(game.DEFAULT_DISPUTE)
+  opening = game.OPENING
+  preconsumed = 0
+  if name == 'mutual-aid':
+    preconsumed = 2
+    opening = (
+        'Teaching scenario: mutual aid after a ferry evacuation. Four fuel'
+        ' remain in the generator, two in Nell’s reserve, and two were used'
+        ' BEFORE play. One spare part is with Nell. Three watches, three'
+        ' facilities, four choices each; baseline demand is nine.'
+        ' Fixed Bellwether names and mechanics remain. A timely consented'
+        ' repair can save one unit, so some unmet demand is unavoidable.'
+    )
+    goals['Sam'] = 'Represent newly displaced families and seek mutual aid.'
+    accounts['Sam'] = (
+        'Private initial assumption: I have heard an unverified report that'
+        ' some evacuees need warm accommodation. I must not present rumor as'
+        ' fact.'
+    )
+  elif name == 'resource-governance':
+    opening += (
+        ' Teaching variation: the cooperative is debating a transparent reserve'
+        ' reporting charter. Stated rules are not proof of member compliance.'
+    )
+    institutions[1]['rule'] = (
+        'Proposed charter: report reserve requests to members and hear'
+        ' objections. Nell still controls release; Ivo still controls his'
+        ' labor.'
+    )
+    institutions[1]['enforcement'] = (
+        'The proposal invites notice and deliberation. No new automatic veto,'
+        ' voting rule or sanction is implemented. Existing consent gates apply.'
+    )
+    goals['Nell'] = (
+        'Consider a transparent reserve policy while protecting members.'
+    )
+  elif name == 'institutional-dispute':
+    opening += (
+        ' Teaching variation: the previous-storm accounts are delivered only'
+        ' to Mara and Nell at High Tide. The coordinator is not omniscient.'
+    )
+    dispute = {
+        'text': (
+            'A disputed note: Mara recalls a promise of boat support; Nell'
+            ' recalls an unresolved request. These are incompatible claims,'
+            ' not an adjudicated historical fact.'
+        ),
+        'recipients': ['Mara', 'Nell'],
+    }
+    accounts['Mara'] = (
+        'Private initial account: I recall a promise; my recollection may be'
+        ' wrong.'
+    )
+    accounts['Nell'] = (
+        'Private initial account: I recall no agreement; my recollection may be'
+        ' wrong.'
+    )
+
+  world = game.StormNight(
+      game.new_inventory(),
+      make_observation.ObservationQueue(),
+      institutions=institutions,
+      dispute=dispute,
+  )
+  config = game_prefab.configuration(
+      reader, world, actor_logic=actor_logic, human_readers=human_readers
+  )
+  instances = []
+  for instance in config.instances:
+    params = dict(instance.params)
+    actor = params['name']
+    if actor in accounts:
+      params['account'] = accounts[actor]
+      params['goal'] = goals[actor]
+      params['custom_instructions'] += (
+          ' This teaching variation asks you to consider: ' + goals[actor]
+      )
+    instances.append(replace(instance, params=params))
+  config = replace(config, instances=instances)
+  world.seed(opening=opening, accounts=accounts)
+  if preconsumed:
+    world.transfer('Generator', 'Used', 'fuel', preconsumed)
+    world.emit(
+        'initial_condition',
+        'Declared initial condition: two fuel were already consumed before'
+        ' play. Subtract two from cumulative Used when reporting in-run'
+        ' consumption.',
+    )
+  return Case(
+      config,
+      world,
+      {
+          'recipe': name,
+          'actor_logic': actor_logic,
+          'human_roles': [game.PLAYER, *(human_readers or {})],
+          'engine': 'concordia.environment.engines.sequential.Sequential',
+          'fuel_total_including_preconsumed': 8,
+          'fuel_consumed_before_play': preconsumed,
+          'available_fuel_at_start': 8 - preconsumed,
+          'fixed_roster': list(game.NAMES),
+          'fixed_facilities': list(game.FACILITIES),
+          'fixed_enforcement': (
+              'owner consent, explicit labor, conservation and watch boundaries'
+          ),
+          'evidence_class': (
+              'fictional teaching configuration, not empirical evidence'
+          ),
+      },
+  )

--- a/concordia/examples/bellwether/researcher_test.py
+++ b/concordia/examples/bellwether/researcher_test.py
@@ -1,0 +1,205 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recipe construction/accounting tests, not social validation or live runs."""
+
+import copy
+from unittest import mock
+
+from concordia.agents import entity_agent
+from concordia.environment.engines import sequential
+from concordia.examples.bellwether import game
+from concordia.examples.bellwether import game_prefab
+from concordia.examples.bellwether import researcher
+from concordia.prefabs.simulation import generic
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize('name', researcher.RECIPES)
+def test_build_each_recipe_with_standard_policies_and_private_accounts(name):
+  case = researcher.prepare_case(name, lambda request: 'wait')
+  with mock.patch.object(
+      generic.Simulation, 'play', side_effect=AssertionError('No run')
+  ):
+    simulation = generic.Simulation(
+        case.config,
+        game_prefab.FixtureModel(),
+        lambda text: np.zeros(8),
+        engine=sequential.Sequential(),
+    )
+  actors: dict[str, entity_agent.EntityAgent] = {}
+  for actor in simulation.get_entities():
+    assert isinstance(actor, entity_agent.EntityAgent)
+    actors[actor.name] = actor
+  assert (
+      type(actors['Coordinator'].get_act_component()).__name__
+      == 'HumanActComponent'
+  )
+  assert all(
+      type(actors[n].get_act_component()).__name__ == 'ConcatActComponent'
+      for n in game.scenario.RESIDENTS
+  )
+  for name in game.scenario.RESIDENTS:
+    params = next(
+        i.params for i in case.config.instances if i.params['name'] == name
+    )
+    assert (
+        actors[name].get_component('PreviousStormAccount').get_state()['state']
+        == params['account']
+    )
+    entries = case.world.view(name)['journal']
+    assert any(
+        x['kind'] == 'private_memory' and x['text'] == params['account']
+        for x in entries
+    )
+  assert all(
+      x['kind'] != 'private_memory'
+      for x in case.world.view('Coordinator')['journal']
+  )
+  assert all(
+      x['kind'] != 'private_memory'
+      for x in case.world.view('spectator')['journal']
+  )
+  case.world.invariant()
+
+
+def test_scarcity_is_declared_preconsumption_not_deleted_material():
+  case = researcher.prepare_case('mutual-aid', lambda request: 'wait')
+  assert case.world.inventory_state()['Generator']['fuel'] == 4
+  assert case.world.inventory_state()['Nell']['fuel'] == 2
+  assert case.world.inventory_state()['Used']['fuel'] == 2
+  assert case.manifest['available_fuel_at_start'] == 6
+  assert case.manifest['fuel_consumed_before_play'] == 2
+  opening = case.world.view()['journal'][0]['text']
+  assert 'Four fuel' in opening and 'BEFORE play' in opening
+  assert game.OPENING not in opening
+  case.world.invariant()
+
+
+def test_institution_prose_is_not_consent_and_views_match_actor_context():
+  case = researcher.prepare_case('resource-governance', lambda request: 'wait')
+  simulation = generic.Simulation(
+      case.config,
+      game_prefab.FixtureModel(),
+      lambda text: np.zeros(8),
+      engine=sequential.Sequential(),
+  )
+  nell = next(e for e in simulation.get_entities() if e.name == 'Nell')
+  assert isinstance(nell, entity_agent.EntityAgent)
+  affiliation = nell.get_component('Affiliations').get_state()['state']
+  assert isinstance(affiliation, str)
+  assert 'Proposed charter' in affiliation
+  assert 'Proposed charter' in case.world.view()['institutions'][1]['rule']
+  before = case.world.inventory_state()
+  case.world.resolve('Coordinator', 'transfer reserve and part')
+  assert case.world.inventory_state() == before
+  assert not case.world.data['commitments']
+
+
+def test_private_dispute_recipient_recipe_is_delivered_at_boundary():
+  case = researcher.prepare_case(
+      'institutional-dispute', lambda request: 'wait'
+  )
+  for _ in range(4):
+    case.world.resolve('Coordinator', 'wait')
+  for name in ['Mara', 'Nell']:
+    assert any(
+        x['kind'] == 'disputed_account'
+        for x in case.world.view(name)['journal']
+    )
+  for name in ['Coordinator', 'Ivo', 'Sam', 'spectator']:
+    assert not any(
+        x['kind'] == 'disputed_account'
+        for x in case.world.view(name)['journal']
+    )
+
+
+@pytest.mark.parametrize('logic', ['minimal', 'basic'])
+def test_fresh_ownership_and_human_actor_injection(logic):
+  one = researcher.prepare_case(
+      'resource-governance',
+      lambda r: 'wait',
+      actor_logic=logic,
+      human_readers={'Nell': lambda r: '{}'},
+  )
+  two = researcher.prepare_case(
+      'resource-governance', lambda r: 'wait', actor_logic=logic
+  )
+  models = []
+  for case in [one, two]:
+    models.append(
+        generic.Simulation(
+            case.config,
+            game_prefab.FixtureModel(),
+            lambda t: np.zeros(8),
+            engine=sequential.Sequential(),
+        )
+    )
+  first, second = [
+      {e.name: e for e in model.get_entities()} for model in models
+  ]
+  assert type(first['Nell'].get_act_component()).__name__ == 'HumanActComponent'
+  assert (
+      type(second['Nell'].get_act_component()).__name__ == 'ConcatActComponent'
+  )
+  assert first['Nell'].get_component('__memory__') is not second[
+      'Nell'
+  ].get_component('__memory__')
+  one.world.institutions[1]['rule'] = 'Only this run'
+  assert 'Only this run' not in str(two.world.get_state())
+  assert 'Only this run' not in str(game.INSTITUTIONS)
+  assert one.world.observations is not two.world.observations
+
+
+@pytest.mark.parametrize(
+    'bad',
+    [
+        None,
+        {'Mara': 'partial'},
+        {**{n: '' for n in game.scenario.RESIDENTS}, 'intruder': 'text'},
+    ],
+)
+def test_invalid_seed_atomic(bad):
+  world = game.StormNight(
+      game.new_inventory(), game_prefab.make_observation.ObservationQueue()
+  )
+  before = copy.deepcopy(world.get_state())
+  # None is the default; a malformed opening must still reject atomically.
+  with pytest.raises(ValueError):
+    world.seed(opening=None if bad is None else 'intro', accounts=bad)
+  assert world.get_state() == before
+
+
+def test_invalid_institution_restore_atomic_and_roundtrip():
+  one = researcher.prepare_case('resource-governance', lambda r: 'wait').world
+  two = researcher.prepare_case('bellwether', lambda r: 'wait').world
+  two.set_state(one.get_state())
+  assert two.get_state() == one.get_state()
+  before = two.get_state()
+  invalid = copy.deepcopy(before)
+  invalid['institutions'][0]['members'] = ['unknown']
+  with pytest.raises(ValueError):
+    two.set_state(invalid)
+  assert two.get_state() == before
+
+
+@pytest.mark.parametrize(
+    'mapping', [{'Unknown': lambda r: 'wait'}, {'Nell': None}, ['Nell']]
+)
+def test_unknown_or_noncallable_human_mapping_rejected(mapping):
+  with pytest.raises(ValueError):
+    researcher.prepare_case(
+        'bellwether', lambda r: 'wait', human_readers=mapping
+    )

--- a/concordia/examples/bellwether/run.py
+++ b/concordia/examples/bellwether/run.py
@@ -1,0 +1,70 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serve Bellwether; only explicit editor Run executes the one-turn fixture."""
+
+import argparse
+import pathlib
+import time
+
+from concordia.examples.bellwether import service
+from concordia.utils import simulation_server
+from concordia.utils import visual_interface
+
+
+def main(argv=None):
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('--editor-port', type=int, default=8784)
+  parser.add_argument('--player-port', type=int, default=8785)
+  parser.add_argument(
+      '--output',
+      type=pathlib.Path,
+      default=pathlib.Path('runs/bellwether-fixture'),
+  )
+  args = parser.parse_args(argv)
+  game = service.Bellwether(args.output, port=args.editor_port)
+  player = simulation_server.SimulationServer(
+      port=args.player_port,
+      html_content=pathlib.Path(__file__)
+      .with_name('player.html')
+      .read_text(encoding='utf-8'),
+      operation_service=game.operations,
+      audience='player',
+  )
+  game.server.set_html_content(
+      visual_interface.visualize_operations_to_html(
+          game.config, title='Bellwether · fixture editor'
+      )
+  )
+  try:
+    game.server.start()
+    player.start()
+    print(f'Editor: http://127.0.0.1:{game.server.bound_port}', flush=True)
+    print(f'Player: http://127.0.0.1:{player.bound_port}', flush=True)
+    print(
+        'Fixture only. Explicit run.start executes one human turn; no live'
+        ' resident decisions.',
+        flush=True,
+    )
+    while True:
+      time.sleep(0.5)
+  except KeyboardInterrupt:
+    pass
+  finally:
+    game.close()
+    player.stop()
+
+
+if __name__ == '__main__':
+  main()

--- a/concordia/examples/bellwether/run.py
+++ b/concordia/examples/bellwether/run.py
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Serve Bellwether; only explicit editor Run executes the one-turn fixture."""
+"""Serve Bellwether through the standard shared player/editor/CLI service."""
 
 import argparse
+import json
 import pathlib
 import time
 
+from concordia.contrib.language_models.ollama import ollama_model
+from concordia.examples.bellwether import game_service
 from concordia.examples.bellwether import service
+from concordia.language_model import call_limit_wrapper
+from concordia.language_model import profiled_language_model
+from concordia.utils import profiler
 from concordia.utils import simulation_server
 from concordia.utils import visual_interface
 
@@ -32,8 +38,62 @@ def main(argv=None):
       type=pathlib.Path,
       default=pathlib.Path('runs/bellwether-fixture'),
   )
+  parser.add_argument(
+      '--mode',
+      choices=('slice', 'fixture', 'live'),
+      default='slice',
+      help=(
+          'slice: original one-turn demo; fixture: scripted full night; live:'
+          ' local model residents'
+      ),
+  )
+  parser.add_argument(
+      '--resident-prefab', choices=('minimal', 'basic'), default='minimal'
+  )
+  parser.add_argument('--model', default='llama3.2:3b')
+  parser.add_argument(
+      '--dispute-file',
+      type=pathlib.Path,
+      help='Optional JSON with text and recipients for High Tide.',
+  )
   args = parser.parse_args(argv)
-  game = service.Bellwether(args.output, port=args.editor_port)
+  dispute = (
+      json.loads(args.dispute_file.read_text(encoding='utf-8'))
+      if args.dispute_file
+      else None
+  )
+  profile = profiler.ProfilerContext()
+  profile.enable()
+  model = None
+  if args.mode == 'live':
+    model = call_limit_wrapper.CallLimitLanguageModel(
+        profiled_language_model.ProfiledLanguageModel(
+            ollama_model.OllamaLanguageModel(
+                args.model,
+                request_timeout=90,
+                max_output_tokens=256,
+                system_message=(
+                    'Respond as the instructed resident, with one JSON decision'
+                    ' object. No markdown.'
+                ),
+            ),
+            model_name=args.model,
+            profiler_instance=profile,
+        ),
+        max_calls=256,
+    )
+  game = (
+      service.Bellwether(args.output, port=args.editor_port)
+      if args.mode == 'slice'
+      else game_service.Game(
+          args.output,
+          port=args.editor_port,
+          model=model,
+          actor_logic=args.resident_prefab,
+          dispute=dispute,
+          profiler=profile,
+      )
+  )
   player = simulation_server.SimulationServer(
       port=args.player_port,
       html_content=pathlib.Path(__file__)
@@ -44,7 +104,7 @@ def main(argv=None):
   )
   game.server.set_html_content(
       visual_interface.visualize_operations_to_html(
-          game.config, title='Bellwether · fixture editor'
+          game.config, title='Bellwether · ' + args.mode + ' editor'
       )
   )
   try:
@@ -53,8 +113,10 @@ def main(argv=None):
     print(f'Editor: http://127.0.0.1:{game.server.bound_port}', flush=True)
     print(f'Player: http://127.0.0.1:{player.bound_port}', flush=True)
     print(
-        'Fixture only. Explicit run.start executes one human turn; no live'
-        ' resident decisions.',
+        'Mode: '
+        + args.mode
+        + '. Explicit Begin / run.start starts this session. No automatic'
+        ' replay.',
         flush=True,
     )
     while True:

--- a/concordia/examples/bellwether/run.py
+++ b/concordia/examples/bellwether/run.py
@@ -21,6 +21,7 @@ import time
 
 from concordia.contrib.language_models.ollama import ollama_model
 from concordia.examples.bellwether import game_service
+from concordia.examples.bellwether import multiplayer
 from concordia.examples.bellwether import service
 from concordia.language_model import call_limit_wrapper
 from concordia.language_model import profiled_language_model
@@ -52,11 +53,33 @@ def main(argv=None):
   )
   parser.add_argument('--model', default='llama3.2:3b')
   parser.add_argument(
+      '--multiplayer',
+      action='store_true',
+      help=(
+          'Host-approved Coordinator and Nell browser sessions; three AI'
+          ' residents.'
+      ),
+  )
+  parser.add_argument(
+      '--public-origin',
+      help=(
+          'Exact HTTPS origin when proxying the player listener; never proxy'
+          ' the editor.'
+      ),
+  )
+  parser.add_argument(
+      '--cookie-path',
+      default='/',
+      help='Player mount path, including leading and trailing slash.',
+  )
+  parser.add_argument(
       '--dispute-file',
       type=pathlib.Path,
       help='Optional JSON with text and recipients for High Tide.',
   )
   args = parser.parse_args(argv)
+  if args.multiplayer and args.mode == 'slice':
+    parser.error('--multiplayer requires --mode fixture or live')
   dispute = (
       json.loads(args.dispute_file.read_text(encoding='utf-8'))
       if args.dispute_file
@@ -85,13 +108,21 @@ def main(argv=None):
   game = (
       service.Bellwether(args.output, port=args.editor_port)
       if args.mode == 'slice'
-      else game_service.Game(
+      else (multiplayer.SharedGame if args.multiplayer else game_service.Game)(
           args.output,
           port=args.editor_port,
           model=model,
           actor_logic=args.resident_prefab,
           dispute=dispute,
           profiler=profile,
+          **(
+              {
+                  'secure': bool(args.public_origin),
+                  'cookie_path': args.cookie_path,
+              }
+              if args.multiplayer
+              else {}
+          ),
       )
   )
   player = simulation_server.SimulationServer(
@@ -101,6 +132,10 @@ def main(argv=None):
       .read_text(encoding='utf-8'),
       operation_service=game.operations,
       audience='player',
+      browser_sessions=(
+          game.sessions if isinstance(game, multiplayer.SharedGame) else None
+      ),
+      public_origin=args.public_origin,
   )
   game.server.set_html_content(
       visual_interface.visualize_operations_to_html(

--- a/concordia/examples/bellwether/scenario.py
+++ b/concordia/examples/bellwether/scenario.py
@@ -1,0 +1,248 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bellwether prefab scaffold. All entity state lives in standard components."""
+
+import copy
+import json
+from typing import Any
+
+from concordia.components.agent import constant
+from concordia.components.agent import human_act_component
+from concordia.components.game_master import make_observation
+from concordia.components.game_master import next_acting
+from concordia.components.game_master import switch_act
+from concordia.prefabs.entity import minimal
+from concordia.typing import entity as entity_lib
+from concordia.typing import prefab as prefab_lib
+
+PLAYER = 'Coordinator'
+GM = 'Bellwether fixture'
+ACCOUNT = 'PreviousStormAccount'
+RESOLUTION = (
+    'Fixture receipt: the coordinator’s request was recorded. '
+    'No resident has accepted a commitment; no fuel, labor or spare '
+    'part has moved. Resident negotiation and watch resolution are '
+    'not implemented in this one-turn fixture.'
+)
+PUBLIC = {
+    'title': 'Last Light at Bellwether',
+    'watch': 'Dusk',
+    'locations': [
+        'Harbor beacon',
+        'Storm shelter',
+        'Cooperative cold store',
+        'Generator yard',
+    ],
+    'cast': [
+        {'name': 'Mara', 'role': 'Harbor master', 'location': 'Harbor beacon'},
+        {
+            'name': 'Nell',
+            'role': 'Cooperative custodian',
+            'location': 'Cooperative cold store',
+        },
+        {
+            'name': 'Ivo',
+            'role': 'Engineer · cooperative member',
+            'location': 'Generator yard',
+        },
+        {
+            'name': 'Sam',
+            'role': 'Shelter steward · cooperative member',
+            'location': 'Storm shelter',
+        },
+    ],
+    'opening': (
+        'Rain crosses the harbor. You are temporary emergency coordinator. '
+        'The beacon, shelter and cold store each need fuel tonight. '
+        'Begin with a proposal or wait; inspection is free.'
+    ),
+}
+INITIAL = {
+    'watch': 'Dusk',
+    'watches': ['Dusk', 'High Tide', 'Before Dawn'],
+    'generator_fuel': 6,
+    'reserve_owner': 'Nell',
+    'reserve_fuel': 2,
+    'total_fuel': 8,
+    'demand_per_facility_per_watch': 1,
+    'baseline_demand': 9,
+    'actions_per_watch': 4,
+    'repair': {
+        'spare_part_owner': 'Nell',
+        'labor_required': 'Ivo',
+        'completed': False,
+        'final_beacon_demand_reduction': 1,
+    },
+    'commitments': [],
+    'transfers': [],
+    'services': [],
+    'harbor_charter': (
+        'Harbor Office represents boat safety; it cannot compel cooperative'
+        ' consent.'
+    ),
+    'cooperative_charter': (
+        'Members decide reserve use; authority, notice and acceptance are'
+        ' separate.'
+    ),
+}
+RESIDENTS = {
+    'Mara': (
+        'Protect boats and harbor safety.',
+        'The cooperative failed to help us last storm.',
+    ),
+    'Nell': (
+        'Protect members’ livelihoods.',
+        (
+            'PRIVATE_NELL: two reserve fuel and a spare part; I dispute Mara’s'
+            ' account.'
+        ),
+    ),
+    'Ivo': (
+        'Repair safely, with an accepted labor commitment.',
+        'PRIVATE_IVO: no labor commitment yet.',
+    ),
+    'Sam': (
+        'Represent displaced residents.',
+        'PRIVATE_SAM: shelter residents need representation.',
+    ),
+}
+
+
+class Resident(prefab_lib.Prefab):
+  """Reuse the minimal actor build; each build owns its own memory component."""
+
+  description = 'Bellwether resident using the standard minimal prefab.'
+
+  def build(self, model, memory_bank, **kwargs):
+    params: dict[str, Any] = dict(self.params)
+    account = params.pop('account', '')
+    params['extra_components'] = {
+        ACCOUNT: constant.Constant(
+            account, pre_act_label='Previous storm account'
+        )
+    }
+    return minimal.Entity(params=params).build(model, memory_bank, **kwargs)
+
+
+class FixtureGameMaster(prefab_lib.Prefab):
+  """Standard SwitchAct + fixed context components; no alternative engine."""
+
+  description = 'Fixed-response fixture, not a live negotiation model.'
+
+  def build(self, model, memory_bank):
+    world = copy.deepcopy(self.params['world'])
+    extra = {
+        switch_act.DEFAULT_NEXT_ACTING_COMPONENT_KEY: (
+            next_acting.NextActingInFixedOrder([PLAYER])
+        ),
+        switch_act.DEFAULT_NEXT_ACTION_SPEC_COMPONENT_KEY: (
+            next_acting.FixedActionSpec(
+                entity_lib.free_action_spec(
+                    call_to_action='What do you propose, {name}?'
+                )
+            )
+        ),
+        switch_act.DEFAULT_TERMINATE_COMPONENT_KEY: constant.Constant(
+            'No', pre_act_label=''
+        ),
+        switch_act.DEFAULT_NEXT_GAME_MASTER_COMPONENT_KEY: constant.Constant(
+            GM, pre_act_label=''
+        ),
+        switch_act.DEFAULT_MAKE_OBSERVATION_COMPONENT_KEY: (
+            make_observation.MakeObservation(
+                model,
+                player_names=[PLAYER, *RESIDENTS],
+                allow_llm_fallback=False,
+            )
+        ),
+        switch_act.DEFAULT_RESOLUTION_COMPONENT_KEY: constant.Constant(
+            RESOLUTION, pre_act_label=''
+        ),
+        'InitialMechanics': constant.Constant(
+            json.dumps(world), pre_act_label='Fixture mechanics'
+        ),
+    }
+    params: dict[str, Any] = {
+        'name': GM,
+        'custom_instructions': 'Fixture only; no social prediction.',
+        'extra_components': extra,
+    }
+    return minimal.Entity(params=params).build(
+        model,
+        memory_bank,
+        act_component=switch_act.SwitchAct(model, entity_names=[PLAYER]),
+    )
+
+
+def configuration(reader):
+  """A fresh Config of trusted prefab objects; input is runtime-only wiring."""
+
+  class HumanCoordinator(prefab_lib.Prefab):
+    description = 'Human coordinator with standard minimal context.'
+
+    def build(self, model, memory_bank):
+      def acting_policy(order):
+        return human_act_component.HumanActComponent(
+            reader, component_order=order
+        )
+
+      return minimal.Entity(params=self.params).build(
+          model, memory_bank, act_component_factory=acting_policy
+      )
+
+  instances = [
+      prefab_lib.InstanceConfig(
+          prefab='coordinator',
+          role=prefab_lib.Role.ENTITY,
+          params={
+              'name': PLAYER,
+              'custom_instructions': (
+                  'You coordinate emergency response; you cannot supply others’'
+                  ' consent.'
+              ),
+          },
+      )
+  ]
+  for name, (goal, account) in RESIDENTS.items():
+    instances.append(
+        prefab_lib.InstanceConfig(
+            prefab='resident',
+            role=prefab_lib.Role.ENTITY,
+            params={
+                'name': name,
+                'goal': goal,
+                'account': account,
+                'custom_instructions': f'You are {name}. {goal}',
+            },
+        )
+    )
+  gm_params: dict[str, Any] = {'name': GM, 'world': copy.deepcopy(INITIAL)}
+  instances.append(
+      prefab_lib.InstanceConfig(
+          prefab='fixture',
+          role=prefab_lib.Role.GAME_MASTER,
+          params=gm_params,
+      )
+  )
+  return prefab_lib.Config(
+      default_premise=PUBLIC['opening'],
+      default_max_steps=1,
+      prefabs={
+          'coordinator': HumanCoordinator(),
+          'resident': Resident(),
+          'fixture': FixtureGameMaster(),
+      },
+      instances=instances,
+  )

--- a/concordia/examples/bellwether/service.py
+++ b/concordia/examples/bellwether/service.py
@@ -15,6 +15,7 @@
 """One authoritative Bellwether fixture service used by all three transports."""
 
 import copy
+import logging
 import pathlib
 import threading
 
@@ -37,18 +38,36 @@ class Bellwether:
   advertised. Pause requests do not authorize edits while any worker is alive.
   """
 
-  def __init__(self, output: pathlib.Path, *, session_id=None, port=0):
+  backend = 'fixture'
+  initial_status = 'Ready for the Bellwether fixture'
+  run_description = (
+      'Run one fixture turn through standard Sequential. Cannot restart or'
+      ' replace.'
+  )
+  response_description = 'Submit the pending coordinator action (fixture only).'
+
+  def __init__(
+      self,
+      output: pathlib.Path,
+      *,
+      session_id=None,
+      port=0,
+      config_factory=None,
+      model=None,
+      max_steps=1
+  ):
     self.operations = ops.OperationService(
         project_id='bellwether-fixture-v1', session_id=session_id
     )
     self.inbox = human_io.HumanSession(
         on_request=self._requested,
-        initial_status='Ready for the Bellwether fixture',
+        initial_status=self.initial_status,
     )
-    self.config = scenario.configuration(self.inbox)
+    self.config = (config_factory or scenario.configuration)(self.inbox)
+    self.max_steps = max_steps
     self.simulation = generic.Simulation(
         self.config,
-        no_language_model.NoLanguageModel(),
+        model or no_language_model.NoLanguageModel(),
         lambda _: np.ones(8),
         engine=sequential.Sequential(),
     )
@@ -62,15 +81,18 @@ class Bellwether:
         port=port, operation_service=self.operations
     )
     self.server.set_simulation(self.simulation)
+    self._seed()
+    self._checkpoint = self.simulation.make_checkpoint_data()
+    self.operations.set_view('developer', self.developer_view)
+    self.operations.set_view('player', self.player_view)
+    self._register()
+
+  def _seed(self):
     for actor in self.simulation.get_entities():
       if actor.name == scenario.PLAYER:
         actor.observe(scenario.PUBLIC['opening'])
       else:
         actor.observe(scenario.RESIDENTS[actor.name][1])
-    self._checkpoint = self.simulation.make_checkpoint_data()
-    self.operations.set_view('developer', self.developer_view)
-    self.operations.set_view('player', self.player_view)
-    self._register()
 
   def _register(self):
     register = self.operations.register
@@ -109,8 +131,7 @@ class Bellwether:
     register(
         ops.Operation(
             'run.start',
-            'Run one fixture turn through standard Sequential. Cannot restart'
-            ' or replace.',
+            self.run_description,
             {},
             self._start,
             mutation=True,
@@ -129,7 +150,7 @@ class Bellwether:
     register(
         ops.Operation(
             'human.respond',
-            'Submit the pending coordinator action (fixture only).',
+            self.response_description,
             {
                 'request_id': ops.Parameter(
                     'string', 'Current pending request ID'
@@ -221,15 +242,15 @@ class Bellwether:
     self._worker.start()
     self._monitor = threading.Thread(target=self._join, daemon=True)
     self._monitor.start()
-    self.operations.publish({'kind': 'run.started', 'backend': 'fixture'})
+    self.operations.publish({'kind': 'run.started', 'backend': self.backend})
     return {'phase': self.phase}
 
   def _execute(self):
     try:
       self._log = self.simulation.play(
-          max_steps=1,
+          max_steps=self.max_steps,
           step_controller=self.server.step_controller,
-          step_callback=self.server.broadcast_step,
+          step_callback=self._step,
       )
       self.output.mkdir(parents=True, exist_ok=True)
       (self.output / 'simulation.json').write_text(
@@ -239,6 +260,7 @@ class Bellwether:
           self._log.to_html(), encoding='utf-8'
       )
     except Exception as error:  # pylint: disable=broad-exception-caught
+      logging.exception('Bellwether execution failed')
       self._failure = type(error).__name__
 
   def _join(self):
@@ -248,16 +270,20 @@ class Bellwether:
       self.phase = 'failed' if self._failure else 'completed'
       self.server.broadcast_completion()
       self._checkpoint = self.simulation.make_checkpoint_data()
-      if not self._failure:
-        self.inbox.add_observation(scenario.RESOLUTION)
-      self.inbox.finish(
-          'Fixture complete.'
-          if not self._failure
-          else 'Fixture stopped; inspect the developer surface.'
-      )
+      self._finish()
       self.operations.publish(
-          {'kind': 'run.' + self.phase, 'backend': 'fixture'}
+          {'kind': 'run.' + self.phase, 'backend': self.backend}
       )
+
+  def _step(self, data):
+    self.server.broadcast_step(data)
+
+  def _finish(self):
+    if not self._failure:
+      self.inbox.add_observation(scenario.RESOLUTION)
+    self.inbox.finish(
+        'Fixture complete.' if not self._failure else 'Fixture stopped.'
+    )
 
   def _pause(self, args):
     del args

--- a/concordia/examples/bellwether/service.py
+++ b/concordia/examples/bellwether/service.py
@@ -1,0 +1,284 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One authoritative Bellwether fixture service used by all three transports."""
+
+import copy
+import pathlib
+import threading
+
+from concordia.environment.engines import sequential
+from concordia.examples.astral_canticle import human_io
+from concordia.examples.bellwether import scenario
+from concordia.language_model import no_language_model
+from concordia.prefabs.simulation import generic
+from concordia.typing import entity_component
+from concordia.utils import operation_service as ops
+from concordia.utils import simulation_server
+import numpy as np
+
+
+class Bellwether:
+  """One-turn fixture; residents are built but do not yet make live decisions.
+
+  The only editable target is a designated Constant on Mara. No general memory,
+  cancellation, branching, checkpoint restore or multi-field transactions are
+  advertised. Pause requests do not authorize edits while any worker is alive.
+  """
+
+  def __init__(self, output: pathlib.Path, *, session_id=None, port=0):
+    self.operations = ops.OperationService(
+        project_id='bellwether-fixture-v1', session_id=session_id
+    )
+    self.inbox = human_io.HumanSession(
+        on_request=self._requested,
+        initial_status='Ready for the Bellwether fixture',
+    )
+    self.config = scenario.configuration(self.inbox)
+    self.simulation = generic.Simulation(
+        self.config,
+        no_language_model.NoLanguageModel(),
+        lambda _: np.ones(8),
+        engine=sequential.Sequential(),
+    )
+    self.output = output
+    self.phase = 'paused'
+    self._worker: threading.Thread | None = None
+    self._monitor = None
+    self._failure = None
+    self._log = None
+    self.server = simulation_server.SimulationServer(
+        port=port, operation_service=self.operations
+    )
+    self.server.set_simulation(self.simulation)
+    for actor in self.simulation.get_entities():
+      if actor.name == scenario.PLAYER:
+        actor.observe(scenario.PUBLIC['opening'])
+      else:
+        actor.observe(scenario.RESIDENTS[actor.name][1])
+    self._checkpoint = self.simulation.make_checkpoint_data()
+    self.operations.set_view('developer', self.developer_view)
+    self.operations.set_view('player', self.player_view)
+    self._register()
+
+  def _register(self):
+    register = self.operations.register
+    register(
+        ops.Operation(
+            'session.inspect',
+            'Inspect last safe runtime snapshot, initial mechanics and trace.',
+            {},
+            lambda _: self.developer_view(),
+        )
+    )
+    register(
+        ops.Operation(
+            'player.view',
+            'Only the human coordinator’s delivered information.',
+            {},
+            lambda _: self.player_view(),
+            audiences=('player',),
+        )
+    )
+    register(
+        ops.Operation(
+            'component.edit',
+            'Edit Mara’s designated previous-storm account at a quiescent'
+            ' boundary.',
+            {
+                'value': ops.Parameter(
+                    'string',
+                    'Exact replacement account; does not inform anyone else.',
+                )
+            },
+            self._edit,
+            mutation=True,
+        )
+    )
+    register(
+        ops.Operation(
+            'run.start',
+            'Run one fixture turn through standard Sequential. Cannot restart'
+            ' or replace.',
+            {},
+            self._start,
+            mutation=True,
+        )
+    )
+    register(
+        ops.Operation(
+            'run.pause',
+            'Request pause; in-flight edits remain rejected until execution'
+            ' fully returns.',
+            {},
+            self._pause,
+            mutation=True,
+        )
+    )
+    register(
+        ops.Operation(
+            'human.respond',
+            'Submit the pending coordinator action (fixture only).',
+            {
+                'request_id': ops.Parameter(
+                    'string', 'Current pending request ID'
+                ),
+                'response': ops.Parameter('string', 'Your action attempt'),
+            },
+            self._respond,
+            audiences=('player',),
+            mutation=True,
+        )
+    )
+
+  def _requested(self):
+    self.operations.publish({'kind': 'human.requested'})
+
+  def player_view(self):
+    return {
+        'scenario': copy.deepcopy(scenario.PUBLIC),
+        'human': self.inbox.snapshot(),
+        'phase': self.phase,
+        'fixture': True,
+    }
+
+  def developer_view(self):
+    return {
+        'phase': self.phase,
+        'quiescent': self._worker is None or not self._worker.is_alive(),
+        'initial': copy.deepcopy(scenario.INITIAL),
+        'target': self._account(),
+        'target_path': ['Mara', scenario.ACCOUNT, 'state'],
+        'components_at_last_boundary': copy.deepcopy(self._checkpoint),
+        'trace': (
+            self.simulation.get_raw_log() if self.phase == 'completed' else []
+        ),
+        'events': self.operations.events(),
+        'failure': self._failure,
+        'capability_gaps': [
+            'live residents',
+            'watch accounting',
+            'checkpoints/restore',
+            'branches/experiments',
+            'in-flight edits/cancellation',
+            'initial-project authoring',
+            'multi-field transactions',
+            'undo/redo',
+        ],
+    }
+
+  def _account(self):
+    mara = next(e for e in self.simulation.get_entities() if e.name == 'Mara')
+    assert isinstance(mara, entity_component.EntityWithComponents)
+    return mara.get_component(scenario.ACCOUNT).get_state()['state']
+
+  def _edit(self, args):
+    if self._worker is not None and self._worker.is_alive():
+      raise ops.OperationError(
+          'not_quiescent',
+          'Execution is still active (including pending human input); finish'
+          ' this fixture first.',
+      )
+    if not self.server.step_controller.is_paused:
+      raise ops.OperationError('not_paused', 'Pause before editing.')
+    before = self._account()
+    self.simulation.set_component_dynamic_state(
+        'Mara', scenario.ACCOUNT, 'state', args['value']
+    )
+    self._checkpoint = self.simulation.make_checkpoint_data()
+    self.operations.publish({
+        'kind': 'component.edited',
+        'target': ['Mara', scenario.ACCOUNT, 'state'],
+        'before': before,
+        'after': args['value'],
+        'effective': 'next entity act',
+        'informs': [],
+    })
+    return {'value': self._account()}
+
+  def _start(self, args):
+    del args
+    if self.phase != 'paused' or self._worker is not None:
+      raise ops.OperationError(
+          'run_exists',
+          'This run cannot be replaced/replayed; create a new service for a'
+          ' fresh fixture.',
+      )
+    self.phase = 'running'
+    self.server.step_controller.play()
+    self._worker = threading.Thread(target=self._execute, daemon=True)
+    self._worker.start()
+    self._monitor = threading.Thread(target=self._join, daemon=True)
+    self._monitor.start()
+    self.operations.publish({'kind': 'run.started', 'backend': 'fixture'})
+    return {'phase': self.phase}
+
+  def _execute(self):
+    try:
+      self._log = self.simulation.play(
+          max_steps=1,
+          step_controller=self.server.step_controller,
+          step_callback=self.server.broadcast_step,
+      )
+      self.output.mkdir(parents=True, exist_ok=True)
+      (self.output / 'simulation.json').write_text(
+          self._log.to_json(), encoding='utf-8'
+      )
+      (self.output / 'log.html').write_text(
+          self._log.to_html(), encoding='utf-8'
+      )
+    except Exception as error:  # pylint: disable=broad-exception-caught
+      self._failure = type(error).__name__
+
+  def _join(self):
+    assert self._worker is not None
+    self._worker.join()
+    with self.operations.lock:
+      self.phase = 'failed' if self._failure else 'completed'
+      self.server.broadcast_completion()
+      self._checkpoint = self.simulation.make_checkpoint_data()
+      if not self._failure:
+        self.inbox.add_observation(scenario.RESOLUTION)
+      self.inbox.finish(
+          'Fixture complete.'
+          if not self._failure
+          else 'Fixture stopped; inspect the developer surface.'
+      )
+      self.operations.publish(
+          {'kind': 'run.' + self.phase, 'backend': 'fixture'}
+      )
+
+  def _pause(self, args):
+    del args
+    self.server.step_controller.pause()
+    self.operations.publish({'kind': 'run.pause_requested'})
+    return {'quiescent': self._worker is None or not self._worker.is_alive()}
+
+  def _respond(self, args):
+    try:
+      changed = self.inbox.submit(args['request_id'], args['response'])
+    except (ValueError, TypeError) as error:
+      raise ops.OperationError('invalid_action', str(error)) from error
+    if changed:
+      self.operations.publish(
+          {'kind': 'human.accepted', 'action': args['response']}
+      )
+    return {'accepted': changed}
+
+  def close(self):
+    self.inbox.finish('Service closed.')
+    self.server.step_controller.stop()
+    if self._monitor is not None:
+      self._monitor.join(timeout=10)
+    self.server.stop()

--- a/concordia/examples/bellwether/service.py
+++ b/concordia/examples/bellwether/service.py
@@ -39,6 +39,9 @@ class Bellwether:
   """
 
   backend = 'fixture'
+  player_audiences = ('player',)
+  response_handlers = None
+  view_handlers = None
   initial_status = 'Ready for the Bellwether fixture'
   run_description = (
       'Run one fixture turn through standard Sequential. Cannot restart or'
@@ -110,7 +113,8 @@ class Bellwether:
             'Only the human coordinator’s delivered information.',
             {},
             lambda _: self.player_view(),
-            audiences=('player',),
+            audiences=self.player_audiences,
+            audience_handlers=self.view_handlers,
         )
     )
     register(
@@ -158,7 +162,8 @@ class Bellwether:
                 'response': ops.Parameter('string', 'Your action attempt'),
             },
             self._respond,
-            audiences=('player',),
+            audiences=self.player_audiences,
+            audience_handlers=self.response_handlers,
             mutation=True,
         )
     )

--- a/concordia/examples/bellwether/service_test.py
+++ b/concordia/examples/bellwether/service_test.py
@@ -1,0 +1,287 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Service integrity tests, without simulation or model execution."""
+
+# Private worker probes deliberately test the quiescence guard.
+# pylint: disable=protected-access
+
+import copy
+import json
+import subprocess
+import sys
+import threading
+from unittest import mock
+import urllib.error
+import urllib.request
+
+from concordia.examples.bellwether import scenario
+from concordia.examples.bellwether import service
+from concordia.utils import operation_service as ops
+from concordia.utils import simulation_server
+import pytest
+
+
+@pytest.fixture(name='game')
+def game_fixture(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No simulation in service tests'),
+  ):
+    value = service.Bellwether(tmp_path)
+    yield value
+    value.close()
+
+
+def request(
+    game, operation='component.edit', value='A revised account', key='edit1'
+):
+  current = game.operations.snapshot('developer')
+  return {
+      'operation': operation,
+      'arguments': {'value': value},
+      'references': current['references'],
+      'revision': current['revision'],
+      'retry_key': key,
+  }
+
+
+@pytest.mark.parametrize(
+    'text',
+    [
+        '',
+        '"quoted"\nnext line',
+        '<script>literal & inert</script>',
+        'Nell’s mémoire 🌧️',
+    ],
+)
+def test_exact_edit_isolated_and_initial_unchanged(game, text):
+  before = game.simulation.make_checkpoint_data()
+  initial = copy.deepcopy(game.config.instances)
+  result = game.operations.dispatch('developer', request(game, value=text))
+  after = game.simulation.make_checkpoint_data()
+  assert result['result']['value'] == text
+  assert before['game_masters'] == after['game_masters']
+  for name in ('Nell', 'Ivo', 'Sam', scenario.PLAYER):
+    assert before['entities'][name] == after['entities'][name]
+  assert game.config.instances == initial
+  event = game.operations.events()[-1]
+  assert event['informs'] == [] and event['after'] == text
+
+
+def test_retry_stale_and_key_conflict_are_atomic(game):
+  original = request(game)
+  first = game.operations.dispatch('developer', original)
+  state = game.operations.snapshot('developer')
+  assert game.operations.dispatch('developer', original) == first
+  assert game.operations.snapshot('developer') == state
+  stale = {**original, 'retry_key': 'other'}
+  with pytest.raises(ops.OperationError, match='State changed'):
+    game.operations.dispatch('developer', stale)
+  conflict = {**original, 'arguments': {'value': 'different'}}
+  with pytest.raises(ops.OperationError, match='different input'):
+    game.operations.dispatch('developer', conflict)
+  assert game.operations.snapshot('developer') == state
+
+
+@pytest.mark.parametrize(
+    'value', [None, 3, False, ['text'], {'text': 'bad'}, 'x' * 8193]
+)
+def test_invalid_type_or_size_leaves_state_unchanged(game, value):
+  before = game.operations.snapshot('developer')
+  with pytest.raises(ops.OperationError):
+    game.operations.dispatch('developer', request(game, value=value))
+  assert game.operations.snapshot('developer') == before
+
+
+def test_scope_and_read_only_operations(game):
+  before = game.operations.snapshot('developer')
+  bad = request(game)
+  bad['references']['branch_id'] = 'other'
+  with pytest.raises(ops.OperationError, match='Attach'):
+    game.operations.dispatch('developer', bad)
+  with pytest.raises(ops.OperationError):
+    game.operations.dispatch('player', request(game))
+  with pytest.raises(ops.OperationError):
+    game.operations.dispatch('developer', {'operation': 'checkpoint.restore'})
+  assert game.operations.snapshot('developer') == before
+
+
+def test_real_inflight_thread_rejects_even_when_paused(game):
+  release = threading.Event()
+  game._worker = threading.Thread(
+      target=release.wait
+  )  # boundary probe, NOT engine work
+  game._worker.start()
+  try:
+    assert game.server.step_controller.is_paused
+    before = game.operations.snapshot('developer')
+    with pytest.raises(ops.OperationError, match='still active'):
+      game.operations.dispatch('developer', request(game))
+    assert game.operations.snapshot('developer') == before
+  finally:
+    release.set()
+    game._worker.join()
+
+
+def test_snapshot_ownership_and_player_event_filter(game):
+  snapshot = game.operations.snapshot('developer')
+  snapshot['result']['initial']['reserve_fuel'] = 999
+  assert (
+      game.operations.snapshot('developer')['result']['initial']['reserve_fuel']
+      == 2
+  )
+  client = game.operations.subscribe('player')
+  first = client.get(timeout=1)
+  game.operations.dispatch(
+      'developer', request(game, value='PRIVATE_EDIT_NEVER_PLAYER')
+  )
+  second = client.get(timeout=1)
+  game.operations.unsubscribe(client)
+  for value in (first, second, game.operations.discover('player')):
+    text = json.dumps(value)
+    assert 'PRIVATE_' not in text
+    assert 'reserve_fuel' not in text
+    assert 'component.edit' not in text
+    assert 'components_at_last_boundary' not in text
+
+
+def test_fresh_component_ownership(game, tmp_path):
+  other = service.Bellwether(tmp_path / 'other')
+  try:
+    game.operations.dispatch('developer', request(game, value='only A'))
+    assert other.developer_view()['target'] != 'only A'
+    assert game.operations.references != other.operations.references
+  finally:
+    other.close()
+
+
+def test_player_http_boundary_blocks_all_legacy_routes(game):
+  player = simulation_server.SimulationServer(
+      port=0,
+      html_content='<html>public only</html>',
+      operation_service=game.operations,
+      audience='player',
+  )
+  player.start()
+  url = f'http://127.0.0.1:{player.bound_port}'
+  try:
+    for path in ('/', '/api/state', '/api/operations'):
+      with urllib.request.urlopen(url + path) as response:
+        assert 'PRIVATE_' not in response.read().decode()
+        assert response.headers.get('Access-Control-Allow-Origin') is None
+    for path in ('/events', '/status', '/cmd/play', '/runtime', '/project'):
+      with pytest.raises(urllib.error.HTTPError) as error:
+        urllib.request.urlopen(url + path)
+      assert error.value.code == 404
+    for path, payload in [
+        ('/cmd/set_component_state', {}),
+        ('/api/dispatch', request(game)),
+    ]:
+      req = urllib.request.Request(
+          url + path,
+          data=json.dumps(payload).encode(),
+          headers={'Content-Type': 'application/json'},
+      )
+      with pytest.raises(urllib.error.HTTPError) as error:
+        urllib.request.urlopen(req)
+      assert 'PRIVATE_' not in error.value.read().decode()
+  finally:
+    player.stop()
+
+
+def test_cli_and_direct_dispatch_same_semantic_state_and_events(game, tmp_path):
+  other = service.Bellwether(tmp_path / 'other')
+  other.server.start()
+  try:
+    direct = request(game, value='Shared exact edit', key='same')
+    attached = request(other, value='Shared exact edit', key='same')
+    game.operations.dispatch('developer', direct)
+    args = [
+        sys.executable,
+        '-m',
+        'concordia.command_line_interface.concordia_session',
+        '--url',
+        f'http://127.0.0.1:{other.server.bound_port}',
+        'call',
+    ]
+    result = subprocess.run(
+        args,
+        input=json.dumps(attached),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert game.developer_view() == other.developer_view()
+    before = other.operations.snapshot('developer')
+    retry = subprocess.run(
+        args,
+        input=json.dumps(attached),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert json.loads(retry.stdout) == json.loads(result.stdout)
+    assert other.operations.snapshot('developer') == before
+    bad = {**attached, 'retry_key': 'stale'}
+    path = tmp_path / 'request.json'
+    path.write_text(json.dumps(bad))
+    failure = subprocess.run(
+        [*args, '--input', str(path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert failure.returncode == 2 and 'stale_revision' in failure.stderr
+  finally:
+    other.close()
+
+
+def test_simultaneous_retry_has_one_effect(game):
+  from concurrent import futures  # pylint: disable=import-outside-toplevel
+
+  payload = request(game)
+  with futures.ThreadPoolExecutor(max_workers=8) as pool:
+    results = list(
+        pool.map(
+            lambda _: game.operations.dispatch('developer', payload), range(20)
+        )
+    )
+  assert all(result == results[0] for result in results)
+  assert len(game.operations.events()) == 1
+
+
+def test_fixture_observer_has_no_fallback_or_spurious_content(game):
+  from concordia.environment.engines import sequential  # pylint: disable=import-outside-toplevel
+
+  with mock.patch(
+      'concordia.language_model.no_language_model.NoLanguageModel.sample_text',
+      side_effect=AssertionError('No model call'),
+  ):
+    gm = game.simulation.get_game_masters()[0]
+    for actor in game.simulation.get_entities():
+      assert sequential.Sequential().make_observation(gm, actor) == ''
+
+
+def test_initial_safe_snapshot_includes_seeded_observations(game):
+  snapshot = game.operations.snapshot('developer')['result']
+  actual = game.simulation.make_checkpoint_data()
+  recorded = snapshot['components_at_last_boundary']
+  # Checkpoint creation increments its counter; compare entity state instead.
+  for field in ('entities', 'game_masters', 'raw_log'):
+    assert recorded[field] == actual[field]
+  assert scenario.PUBLIC['opening'] in json.dumps(actual, ensure_ascii=False)
+  assert 'PRIVATE_NELL' in json.dumps(actual, ensure_ascii=False)
+  assert 'PRIVATE_NELL' not in json.dumps(game.operations.snapshot('player'))

--- a/concordia/examples/bellwether/voice_browser_test.py
+++ b/concordia/examples/bellwether/voice_browser_test.py
@@ -1,0 +1,301 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real Chromium UI, explicitly mocked speech APIs; no audio or model calls."""
+
+import json
+import pathlib
+import threading
+from unittest import mock
+
+from concordia.examples.astral_canticle import human_io
+from concordia.examples.bellwether import game_service
+from concordia.examples.bellwether.multiplayer_browser_test import join
+from concordia.examples.bellwether.multiplayer_test import approve
+from concordia.examples.bellwether.multiplayer_test import envelope
+from concordia.examples.bellwether.multiplayer_test import hosted_fixture  # pylint: disable=unused-import
+from concordia.typing import entity as entity_lib
+from concordia.typing import human_input
+from concordia.utils import simulation_server
+import pytest
+
+pw = pytest.importorskip('playwright.sync_api')
+
+MOCK_SPEECH = """
+window.voiceTest={starts:0, installs:0, cancelled:0, utterances:[], available:'available'};
+class Recognition {
+ get processLocally(){return this.local===true}
+ set processLocally(value){this.local=value}
+ static async available(options){voiceTest.options=options;return voiceTest.available}
+ static async install(){voiceTest.installs++;return false}
+ start(){voiceTest.starts++;voiceTest.rec=this;if(!this.processLocally)throw Error('Remote!')}
+ stop(){this.onend?.()}
+ abort(){voiceTest.aborted=true}
+}
+Object.defineProperty(window,'SpeechRecognition',{value:Recognition,configurable:true});
+class Synthesis extends EventTarget {
+ getVoices(){return [
+  {name:'Remote',lang:'en-US',localService:false},
+  ...(voiceTest.cloudOnly?[]:[{name:'Local',lang:'en-US',localService:true}])
+ ]}
+ speak(utterance){voiceTest.utterances.push({text:utterance.text,voice:utterance.voice.name})}
+ cancel(){voiceTest.cancelled++}
+}
+Object.defineProperty(window,'speechSynthesis',{value:new Synthesis(),configurable:true});
+Object.defineProperty(window,'SpeechSynthesisUtterance',{value:class {
+ constructor(text){this.text=text}
+},configurable:true});
+window.finalTranscript=text=>{
+ const result=[{transcript:text}];result.isFinal=true;
+ voiceTest.rec.onresult?.({resultIndex:0,results:[result]});
+};
+"""
+
+
+def wait_for_input(inbox, request):
+  try:
+    inbox(request)
+  except human_io.InputClosed:
+    pass  # Expected shutdown of a synthetic, deliberately unanswered turn.
+
+
+@pytest.fixture(name='voice_host')
+def voice_host_fixture(tmp_path):
+  with mock.patch(
+      'concordia.prefabs.simulation.generic.Simulation.play',
+      side_effect=AssertionError('No simulation in voice UI tests'),
+  ):
+    game = game_service.Game(tmp_path)
+    game.world.emit(
+        'speech', 'The shelter keeper has arrived.', ['Coordinator']
+    )
+    game.world.emit('speech', 'SECRET_OTHER_ROLE', ['Nell'])
+    request = human_input.HumanInputRequest(
+        request_id='voice-input',
+        entity_name='Coordinator',
+        action_spec=entity_lib.free_action_spec(call_to_action='Your action'),
+        contexts={},
+        context='Your available text.',
+    )
+    reader = threading.Thread(target=wait_for_input, args=(game.inbox, request))
+    server = simulation_server.SimulationServer(
+        port=0,
+        operation_service=game.operations,
+        audience='player',
+        html_content=pathlib.Path(__file__)
+        .with_name('player.html')
+        .read_text(encoding='utf-8'),
+    )
+    server.start()
+    reader.start()
+    try:
+      yield game, f'http://127.0.0.1:{server.bound_port}'
+    finally:
+      game.close()
+      server.stop()
+      reader.join(2)
+
+
+def test_editable_transcript_local_reading_and_cancellation(voice_host):
+  _, url = voice_host
+  with pw.sync_playwright() as runner:
+    browser = runner.chromium.launch()
+    page = browser.new_page(
+        viewport={'width': 360, 'height': 800}, is_mobile=True
+    )
+    page.add_init_script(MOCK_SPEECH)
+    sent, errors = [], []
+    page.on(
+        'request',
+        lambda r: sent.append(r.url) if '/dispatch' in r.url else None,
+    )
+    page.on('pageerror', lambda e: errors.append(str(e)))
+    page.goto(url)
+    pw.expect(page.locator('#act')).to_be_enabled()
+    page.locator('#voice summary').click()
+    assert page.evaluate('voiceTest.starts') == 0
+    assert page.evaluate('voiceTest.utterances') == []
+    page.check('#voice-enabled')
+    page.fill('#action', 'My typed proposal.')
+    page.click('#dictate')
+    pw.expect(page.locator('#voice-status')).to_contain_text('Listening')
+    assert page.evaluate('voiceTest.options.processLocally') is True
+    page.fill('#action', 'My typed proposal, edited during dictation.')
+    page.evaluate(
+        "finalTranscript('Unedited words <img src=x onerror=alert(1)>')"
+    )
+    assert 'Unedited words' in page.locator('#transcript').input_value()
+    assert 'Unedited' not in page.locator('#action').input_value()
+    page.fill('#transcript', 'Edited speech 🌊')
+    page.click('#finish-dictation')
+    page.click('#use-transcript')
+    assert page.locator('#action').input_value() == (
+        'My typed proposal, edited during dictation. Edited speech 🌊'
+    )
+    assert not sent
+    page.click('#listen')
+    assert page.evaluate('voiceTest.utterances') == [
+        {'text': 'The shelter keeper has arrived.', 'voice': 'Local'}
+    ]
+    page.click('#stop-audio')
+    assert page.evaluate('voiceTest.cancelled') == 1
+    page.click('#dictate')
+    page.evaluate('() => {window.late=voiceTest.rec.onresult}')
+    page.click('#cancel-dictation')
+    page.evaluate("""() => {
+          const r=[{transcript:'LATE_PRIVATE'}];
+          r.isFinal=true;late({resultIndex:0,results:[r]});
+        }""")
+    assert page.locator('#transcript').input_value() == ''
+    assert 'LATE_PRIVATE' not in page.locator('#action').input_value()
+    page.click('#dictate')
+    page.evaluate("voiceTest.rec.onerror({error:'not-allowed'})")
+    pw.expect(page.locator('#voice-status')).to_contain_text(
+        'permission was declined'
+    )
+    page.evaluate(
+        '() => {SpeechRecognition.available=()=>new'
+        ' Promise(r=>voiceTest.resolve=r)}'
+    )
+    starts = page.evaluate('voiceTest.starts')
+    page.click('#dictate')
+    page.click('#cancel-dictation')
+    page.evaluate("voiceTest.resolve('available')")
+    assert page.evaluate('voiceTest.starts') == starts
+    assert page.locator('img').count() == 0
+    assert page.evaluate('document.documentElement.scrollWidth') <= 360
+    page.reload()
+    pw.expect(page.locator('#act')).to_be_enabled()
+    assert not page.locator('#voice-enabled').is_checked()
+    assert 'Edited speech' in page.locator('#action').input_value()
+    assert not errors
+    browser.close()
+
+
+@pytest.mark.parametrize('case', ['unsupported', 'downloadable', 'remote-only'])
+def test_unavailable_voice_keeps_text_without_remote_fallback(voice_host, case):
+  _, url = voice_host
+  with pw.sync_playwright() as runner:
+    browser = runner.chromium.launch()
+    page = browser.new_page()
+    page.add_init_script(MOCK_SPEECH)
+    page.goto(url)
+    pw.expect(page.locator('#act')).to_be_enabled()
+    page.locator('#voice summary').click()
+    if case == 'unsupported':
+      page.evaluate('delete SpeechRecognition.prototype.processLocally')
+    elif case == 'downloadable':
+      page.evaluate("voiceTest.available='downloadable'")
+    else:
+      page.evaluate('voiceTest.cloudOnly=true')
+    page.check('#voice-enabled')
+    page.fill('#action', 'wait')
+    if case == 'remote-only':
+      pw.expect(page.locator('#listen')).to_be_disabled()
+    else:
+      page.click('#dictate')
+      pw.expect(page.locator('#voice-status')).to_contain_text(
+          'Please type instead'
+      )
+    assert page.locator('#action').input_value() == 'wait'
+    assert page.evaluate('voiceTest.starts') == 0
+    assert page.evaluate('voiceTest.installs') == 0
+    assert page.evaluate('voiceTest.utterances') == []
+    browser.close()
+
+
+def test_role_revocation_cancels_audio_and_late_transcripts(hosted):
+  game, _, url = hosted
+  game.world.data['agenda'] = [{
+      'name': 'Nell',
+      'purpose': 'request: reserve',
+      'audience': ['Coordinator', 'Nell'],
+      'watch': 0,
+  }]
+  game.world.emit('speech', 'ONLY_NELL_OBSERVATION', ['Nell'])
+  request = human_input.HumanInputRequest(
+      request_id='nell-voice',
+      entity_name='Nell',
+      action_spec=entity_lib.free_action_spec(call_to_action='Respond'),
+      contexts={},
+      context='Only Nell context.',
+  )
+  reader = threading.Thread(
+      target=wait_for_input, args=(game.nell_inbox, request)
+  )
+  reader.start()
+  try:
+    with pw.sync_playwright() as runner:
+      browser = runner.chromium.launch()
+      page = browser.new_page()
+      page.add_init_script(MOCK_SPEECH)
+      join(page, url, 'N', 'Nell')
+      row = approve(game, 'N')
+      pw.expect(page.locator('#act')).to_be_enabled()
+      page.locator('#voice summary').click()
+      page.check('#voice-enabled')
+      page.click('#dictate')
+      page.evaluate('() => {window.late=voiceTest.rec.onresult}')
+      page.click('#listen')
+      game.operations.dispatch(
+          'developer', envelope(game, 'session.revoke', {'request_id': row})
+      )
+      pw.expect(page.locator('#join')).to_be_visible()
+      assert page.evaluate('voiceTest.aborted') is True
+      page.evaluate("""() => {
+          const r=[{transcript:'REVOKED'}];
+          r.isFinal=true;late({resultIndex:0,results:[r]});
+        }""")
+      assert page.locator('#transcript').input_value() == ''
+      assert 'ONLY_NELL_OBSERVATION' not in page.content()
+      assert page.evaluate('voiceTest.cancelled') == 1
+      assert page.evaluate('voiceTest.utterances') == [
+          {'text': 'ONLY_NELL_OBSERVATION', 'voice': 'Local'}
+      ]
+      browser.close()
+  finally:
+    game.nell_inbox.finish('done')
+    reader.join(2)
+
+
+def test_actual_browser_capabilities_do_not_start_audio(voice_host, tmp_path):
+  _, url = voice_host
+  with pw.sync_playwright() as runner:
+    browser = runner.chromium.launch()
+    page = browser.new_page(
+        viewport={'width': 412, 'height': 820}, is_mobile=True
+    )
+    requests = []
+    page.on('request', lambda r: requests.append(r.url))
+    page.goto(url)
+    pw.expect(page.locator('#act')).to_be_enabled()
+    page.locator('#voice summary').click()
+    data = page.evaluate("""() => {
+      const C=window.SpeechRecognition||window.webkitSpeechRecognition;
+      return {
+        recognition:!!C,onDeviceProperty:!!C&&('processLocally' in C.prototype),
+        availabilityCheck:typeof C?.available==='function',
+        localVoices:window.speechSynthesis?.getVoices().filter(v=>v.localService).length||0
+      };
+    }""")
+    data['browser'] = browser.version
+    (tmp_path / 'actual-capabilities.json').write_text(
+        json.dumps(data, indent=2)
+    )
+    assert not page.locator('#voice-enabled').is_checked()
+    pw.expect(page.locator('#dictate')).to_be_disabled()
+    page.fill('#action', 'My text fallback.')
+    assert page.locator('#action').input_value() == 'My text fallback.'
+    assert all(r.startswith(url) for r in requests)
+    browser.close()

--- a/concordia/prefabs/entity/acting_policy_injection_test.py
+++ b/concordia/prefabs/entity/acting_policy_injection_test.py
@@ -1,0 +1,118 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime policy injection retains prefab context, memory and default behavior."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.associative_memory import basic_associative_memory
+from concordia.components.agent import concat_act_component
+from concordia.components.agent import scripted_act
+from concordia.language_model import no_language_model
+from concordia.prefabs.entity import basic
+from concordia.prefabs.entity import minimal
+import numpy as np
+
+
+def _memory():
+  return basic_associative_memory.AssociativeMemoryBank(
+      sentence_embedder=lambda _: np.ones(8)
+  )
+
+
+class ActingPolicyInjectionTest(parameterized.TestCase):
+
+  @parameterized.parameters(basic, minimal)
+  def test_factory_preserves_order_context_memory_and_lifecycle(self, prefab):
+    config = prefab.Entity(params={'name': 'Player', 'goal': 'Find the door.'})
+    normal_model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+    normal_model.sample_text.return_value = 'considering the door.'
+    script_model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+    script_model.sample_text.return_value = (
+        normal_model.sample_text.return_value
+    )
+    normal = config.build(normal_model, _memory())
+    factory = mock.Mock(
+        side_effect=lambda order: scripted_act.ScriptedActComponent(
+            script_model,
+            [
+                {'name': 'Player', 'line': 'LOOK'},
+                {'name': 'Player', 'line': 'WAIT'},
+            ],
+            component_order=order,
+            prefix_entity_name=False,
+        )
+    )
+    with mock.patch.object(concat_act_component, 'ConcatActComponent') as ctor:
+      scripted = config.build(
+          script_model, _memory(), act_component_factory=factory
+      )
+    ctor.assert_not_called()
+    factory.assert_called_once_with(
+        tuple(normal.get_act_component().get_context_concat_order())
+    )
+    normal_context = normal.get_all_context_components()
+    script_context = scripted.get_all_context_components()
+    self.assertEqual(list(normal_context), list(script_context))
+    for key, component in normal_context.items():
+      self.assertIs(type(script_context[key]), type(component))
+      self.assertEqual(script_context[key].get_state(), component.get_state())
+    for observation, response in [
+        ('A silver door.', 'LOOK'),
+        ('The bell tolls.', 'WAIT'),
+    ]:
+      normal.observe(observation)
+      scripted.observe(observation)
+      normal.act()
+      self.assertEqual(scripted.act(), response)
+      # Only the final LLM acting call is replaced; basic perception prompts
+      # and their dependency chain, and minimal's non-LLM context, are retained.
+      self.assertEqual(
+          script_model.sample_text.call_args_list,
+          normal_model.sample_text.call_args_list[:-1],
+      )
+      self.assertIn(
+          observation, '\n'.join(scripted.get_last_log()['__act__']['Prompt'])
+      )
+      self.assertEqual(
+          scripted.get_component('__memory__').get_all_memories_as_text(),
+          normal.get_component('__memory__').get_all_memories_as_text(),
+      )
+      normal_model.reset_mock()
+      script_model.reset_mock()
+
+  @parameterized.parameters(basic, minimal)
+  def test_prebuilt_policy_identity_and_mutually_exclusive_arguments(
+      self, prefab
+  ):
+    model = no_language_model.NoLanguageModel()
+    config = prefab.Entity(params={'name': 'Player'})
+    policy = scripted_act.ScriptedActComponent(
+        model, [{'name': 'Player', 'line': 'LOOK'}]
+    )
+    entity = config.build(model, _memory(), act_component=policy)
+    self.assertIs(entity.get_act_component(), policy)
+    self.assertEqual(entity.act(), 'Player LOOK')
+    factory = mock.Mock()
+    with self.assertRaisesRegex(ValueError, 'not both'):
+      config.build(
+          model, _memory(), act_component=policy, act_component_factory=factory
+      )
+    factory.assert_not_called()
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/prefabs/entity/basic.py
+++ b/concordia/prefabs/entity/basic.py
@@ -21,6 +21,7 @@ from concordia.agents import entity_agent_with_logging
 from concordia.associative_memory import basic_associative_memory
 from concordia.components import agent as agent_components
 from concordia.language_model import language_model
+from concordia.prefabs.entity import component_options
 from concordia.typing import entity_component
 from concordia.typing import prefab as prefab_lib
 
@@ -32,7 +33,11 @@ _DEFAULT_PERSON_BY_SITUATION_HISTORY_LENGTH = 5
 
 @dataclasses.dataclass
 class Entity(prefab_lib.Prefab):
-  """A prefab implementing a basic actor entity."""
+  """A basic actor supporting the minimal prefab’s optional extra components.
+
+  Uses the same component extension semantics as the minimal prefab. Omitted
+  extensions leave the standard perception chain, memory and order unchanged.
+  """
 
   description: str = (  # pyrefly: ignore[bad-override]
       'An entity that makes decisions by asking '
@@ -185,7 +190,7 @@ class Entity(prefab_lib.Prefab):
         ),
     )
 
-    components_of_agent = {
+    components_of_agent: dict[str, entity_component.ContextComponent] = {
         instructions_key: instructions,
         observation_to_memory_key: observation_to_memory,
         self_perception_key: self_perception,
@@ -196,6 +201,9 @@ class Entity(prefab_lib.Prefab):
     }
 
     component_order = list(components_of_agent.keys())
+    component_options.add_extra_components(
+        components_of_agent, component_order, self.params
+    )
 
     if overarching_goal is not None:
       components_of_agent[goal_key] = overarching_goal  # pyrefly: ignore[unsupported-operation]

--- a/concordia/prefabs/entity/basic.py
+++ b/concordia/prefabs/entity/basic.py
@@ -14,13 +14,14 @@
 
 """A prefab containing the three key questions actor."""
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 import dataclasses
 
 from concordia.agents import entity_agent_with_logging
 from concordia.associative_memory import basic_associative_memory
 from concordia.components import agent as agent_components
 from concordia.language_model import language_model
+from concordia.typing import entity_component
 from concordia.typing import prefab as prefab_lib
 
 _DEFAULT_OBSERVATION_HISTORY_LENGTH = 1_000_000
@@ -61,16 +62,32 @@ class Entity(prefab_lib.Prefab):
       self,
       model: language_model.LanguageModel,
       memory_bank: basic_associative_memory.AssociativeMemoryBank,
+      *,
+      act_component: entity_component.ActingComponent | None = None,
+      act_component_factory: (
+          Callable[[Sequence[str]], entity_component.ActingComponent] | None
+      ) = None,
   ) -> entity_agent_with_logging.EntityAgentWithLogging:
     """Build an entity.
 
     Args:
       model: The language model to use.
       memory_bank: The memory bank to use.
+      act_component: Optional runtime acting policy, e.g. HumanActComponent.
+        All context components, including LLM-backed perceptions, memory and
+        logging, are unchanged. Omit to use the normal ConcatActComponent.
+      act_component_factory: Optional runtime factory receiving the exact
+        prefab context order. Use for an order-aware replacement policy.
+        Cannot be combined with act_component.
 
     Returns:
       An entity.
     """
+    if act_component is not None and act_component_factory is not None:
+      raise ValueError(
+          'Provide act_component or act_component_factory, not both.'
+      )
+
     entity_name = self.params.get('name', 'Alice')
     entity_goal = self.params.get('goal', '')
     randomize_choices = self.params.get('randomize_choices', True)
@@ -185,12 +202,15 @@ class Entity(prefab_lib.Prefab):
       # Place goal after the instructions.
       component_order.insert(1, goal_key)  # pyrefly: ignore[bad-argument-type]
 
-    act_component = agent_components.concat_act_component.ConcatActComponent(
-        model=model,
-        component_order=component_order,
-        randomize_choices=randomize_choices,  # pyrefly: ignore[bad-argument-type]
-        prefix_entity_name=prefix_entity_name,  # pyrefly: ignore[bad-argument-type]
-    )
+    if act_component_factory is not None:
+      act_component = act_component_factory(tuple(component_order))
+    elif act_component is None:
+      act_component = agent_components.concat_act_component.ConcatActComponent(
+          model=model,
+          component_order=component_order,
+          randomize_choices=randomize_choices,  # pyrefly: ignore[bad-argument-type]
+          prefix_entity_name=prefix_entity_name,  # pyrefly: ignore[bad-argument-type]
+      )
 
     agent = entity_agent_with_logging.EntityAgentWithLogging(
         agent_name=entity_name,

--- a/concordia/prefabs/entity/basic_test.py
+++ b/concordia/prefabs/entity/basic_test.py
@@ -1,0 +1,202 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Acting-policy injection preserves the basic prefab's context and lifecycle."""
+
+from typing import Any, cast
+from unittest import mock
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.associative_memory import basic_associative_memory
+from concordia.components.agent import concat_act_component
+from concordia.components.agent import human_act_component
+from concordia.components.agent import memory
+from concordia.language_model import no_language_model
+from concordia.prefabs.entity import basic
+from concordia.prefabs.entity import minimal
+from concordia.utils import measurements
+import numpy as np
+
+
+def _memory():
+  return basic_associative_memory.AssociativeMemoryBank(
+      sentence_embedder=lambda _: np.ones(8)
+  )
+
+
+class BasicTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      ('defaults', {}),
+      ('goal', {'name': 'Ilyra', 'goal': 'Repair the loom.'}),
+      (
+          'custom_history',
+          {
+              'name': 'Ilyra',
+              'goal': 'Repair the loom.',
+              'observation_history_length': 2,
+              'situation_perception_history_length': 1,
+              'self_perception_history_length': 3,
+              'person_by_situation_history_length': 2,
+          },
+      ),
+  )
+  def test_only_act_changes_and_perception_lifecycle_is_identical(self, params):
+    prefab = basic.Entity(params=params)
+    model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+    model.sample_text.return_value = 'considering the cradle.'
+    automated = prefab.build(model=model, memory_bank=_memory())
+    human_model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+    human_model.sample_text.return_value = model.sample_text.return_value
+    reader = mock.Mock(return_value='EXAMINE the tuning fork')
+    factory = mock.Mock(
+        side_effect=lambda order: human_act_component.HumanActComponent(
+            reader, component_order=order
+        )
+    )
+    with mock.patch.object(concat_act_component, 'ConcatActComponent') as ctor:
+      human = prefab.build(
+          model=human_model,
+          memory_bank=_memory(),
+          act_component_factory=factory,
+      )
+    ctor.assert_not_called()
+    expected_order = cast(
+        concat_act_component.ConcatActComponent, automated.get_act_component()
+    ).get_context_concat_order()
+    assert expected_order is not None
+    factory.assert_called_once_with(tuple(expected_order))
+    self.assertIsInstance(
+        human.get_act_component(), human_act_component.HumanActComponent
+    )
+    self.assertIsInstance(
+        automated.get_act_component(), concat_act_component.ConcatActComponent
+    )
+    human_context = human.get_all_context_components()
+    automated_context = automated.get_all_context_components()
+    self.assertEqual(list(human_context), list(automated_context))
+    for key, component in human_context.items():
+      self.assertIs(type(component), type(automated_context[key]))
+      self.assertEqual(
+          component.get_state(), automated_context[key].get_state()
+      )
+
+    # Across two turns, all three perception calls and memory updates remain
+    # exactly those of the ordinary prefab. Only its fourth (acting) call goes.
+    for observation in ('The cradle is cracked.', 'A silver thread is loose.'):
+      automated.observe(observation)
+      human.observe(observation)
+      self.assertEqual(
+          automated.act(), automated.name + ' considering the cradle.'
+      )
+      self.assertEqual(human.act(), 'EXAMINE the tuning fork')
+      self.assertEqual(model.sample_text.call_count, 4)
+      self.assertEqual(human_model.sample_text.call_count, 3)
+      self.assertEqual(
+          human_model.sample_text.call_args_list,
+          model.sample_text.call_args_list[:3],
+      )
+      human_model.sample_choice.assert_not_called()
+      request = reader.call_args.args[0]
+      self.assertEqual(set(request.contexts), set(human_context))
+      self.assertEqual(
+          request.context,
+          cast(
+              concat_act_component.ConcatActComponent,
+              automated.get_act_component(),
+          )._context_for_action(request.contexts),
+      )
+      for key in ('SituationPerception', 'SelfPerception', 'PersonBySituation'):
+        self.assertIn('considering the cradle.', request.contexts[key])
+        self.assertEqual(
+            human.get_last_log()[key], automated.get_last_log()[key]
+        )
+      self.assertIn(observation, request.contexts['__observation__'])
+      self.assertEqual(
+          human.get_component(
+              '__memory__', type_=memory.AssociativeMemory
+          ).get_all_memories_as_text(),
+          automated.get_component(
+              '__memory__', type_=memory.AssociativeMemory
+          ).get_all_memories_as_text(),
+      )
+      self.assertEqual(human.get_last_log()['__act__']['Source'], 'human')
+      model.reset_mock()
+      human_model.reset_mock()
+    self.assertEqual(reader.call_count, 2)
+
+  @parameterized.parameters(True, False)
+  def test_default_concat_flags_order_and_measurements_unchanged(self, flags):
+    model = mock.Mock(wraps=no_language_model.NoLanguageModel())
+    model.sample_text.return_value = 'LOOK'
+    channels = measurements.Measurements()
+    with mock.patch.object(
+        concat_act_component,
+        'ConcatActComponent',
+        wraps=concat_act_component.ConcatActComponent,
+    ) as constructor:
+      entity = basic.Entity(
+          params={
+              'name': 'Ilyra',
+              'goal': 'Repair the loom.',
+              'randomize_choices': flags,
+              'prefix_entity_name': flags,
+              'measurements': cast(Any, channels),
+          }
+      ).build(model=model, memory_bank=_memory())
+    self.assertEqual(constructor.call_count, 1)
+    self.assertIs(constructor.call_args.kwargs['randomize_choices'], flags)
+    self.assertIs(constructor.call_args.kwargs['prefix_entity_name'], flags)
+    order = cast(
+        concat_act_component.ConcatActComponent, entity.get_act_component()
+    ).get_context_concat_order()
+    assert order is not None
+    self.assertEqual(order[:2], ('Instructions', 'Goal'))
+    self.assertCountEqual(order, entity.get_all_context_components())
+    self.assertIs(entity.measurements, channels)
+    self.assertEqual(entity.act(), 'Ilyra LOOK' if flags else 'LOOK')
+    self.assertEqual(model.sample_text.call_count, 4)
+
+  @parameterized.parameters(basic, minimal)
+  def test_factory_receives_prefab_order_and_cannot_mix_with_instance(
+      self, prefab
+  ):
+    model = no_language_model.NoLanguageModel()
+    config = prefab.Entity(params={'name': 'Ilyra', 'goal': 'Repair the loom.'})
+    default = config.build(model, _memory())
+    factory = mock.Mock(
+        side_effect=lambda order: human_act_component.HumanActComponent(
+            lambda request: 'LOOK', component_order=order
+        )
+    )
+    human = config.build(model, _memory(), act_component_factory=factory)
+    factory.assert_called_once_with(
+        tuple(default.get_act_component().get_context_concat_order())
+    )
+    self.assertEqual(
+        human.get_act_component().get_context_concat_order(),
+        default.get_act_component().get_context_concat_order(),
+    )
+    with self.assertRaisesRegex(ValueError, 'not both'):
+      config.build(
+          model,
+          _memory(),
+          act_component=human.get_act_component(),
+          act_component_factory=factory,
+      )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/prefabs/entity/component_options.py
+++ b/concordia/prefabs/entity/component_options.py
@@ -1,0 +1,49 @@
+# Copyright 2024 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared optional context assembly for standard entity prefabs."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from concordia.typing import entity_component
+
+
+def add_extra_components(
+    components_of_agent: dict[str, entity_component.ContextComponent],
+    component_order: list[str],
+    params: Mapping[str, Any],
+) -> None:
+  """Apply minimal's existing extra-components and index semantics in place."""
+  # Add the extra components to the end of the component order.
+  extra_components = params.get('extra_components', {})
+  extra_components_index = params.get('extra_components_index', {})
+
+  # Check that extra_components_index is a dict.
+  if not isinstance(extra_components_index, dict) or not isinstance(
+      extra_components, dict
+  ):
+    raise ValueError(
+        'extra_components_index and extra_components must be dict. Got'
+        f' {type(extra_components_index)} and {type(extra_components)}'
+    )
+
+  if extra_components:
+    if not extra_components_index:
+      extra_components_index = {
+          component_name: -1 for component_name in extra_components.keys()
+      }
+    for component_name, index in extra_components_index.items():
+      components_of_agent[component_name] = extra_components[component_name]
+      component_order.insert(index, component_name)

--- a/concordia/prefabs/entity/minimal.py
+++ b/concordia/prefabs/entity/minimal.py
@@ -21,6 +21,7 @@ from concordia.agents import entity_agent_with_logging
 from concordia.associative_memory import basic_associative_memory
 from concordia.components import agent as agent_components
 from concordia.language_model import language_model
+from concordia.prefabs.entity import component_options
 from concordia.typing import entity_component
 from concordia.typing import prefab as prefab_lib
 
@@ -107,7 +108,7 @@ class Entity(prefab_lib.Prefab):
         history_length=100, pre_act_label=observation_label
     )
 
-    components_of_agent = {
+    components_of_agent: dict[str, entity_component.ContextComponent] = {
         DEFAULT_INSTRUCTIONS_COMPONENT_KEY: instructions,
         'observation_to_memory': observation_to_memory,
         agent_components.observation.DEFAULT_OBSERVATION_COMPONENT_KEY: (
@@ -120,27 +121,9 @@ class Entity(prefab_lib.Prefab):
 
     component_order = list(components_of_agent.keys())
 
-    # Add the extra components to the end of the component order.
-    extra_components = self.params.get('extra_components', {})
-    extra_components_index = self.params.get('extra_components_index', {})
-
-    # Check that extra_components_index is a dict.
-    if not isinstance(extra_components_index, dict) or not isinstance(
-        extra_components, dict
-    ):
-      raise ValueError(
-          'extra_components_index and extra_components must be dict. Got'
-          f' {type(extra_components_index)} and {type(extra_components)}'
-      )
-
-    if extra_components:
-      if not extra_components_index:
-        extra_components_index = {
-            component_name: -1 for component_name in extra_components.keys()
-        }
-      for component_name, index in extra_components_index.items():
-        components_of_agent[component_name] = extra_components[component_name]
-        component_order.insert(index, component_name)
+    component_options.add_extra_components(
+        components_of_agent, component_order, self.params
+    )
 
     if self.params.get('goal', ''):
       goal_key = DEFAULT_GOAL_COMPONENT_KEY

--- a/concordia/prefabs/entity/minimal.py
+++ b/concordia/prefabs/entity/minimal.py
@@ -14,13 +14,14 @@
 
 """A prefab implementing an entity with a minimal set of components."""
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping, Sequence
 import dataclasses
 
 from concordia.agents import entity_agent_with_logging
 from concordia.associative_memory import basic_associative_memory
 from concordia.components import agent as agent_components
 from concordia.language_model import language_model
+from concordia.typing import entity_component
 from concordia.typing import prefab as prefab_lib
 
 DEFAULT_INSTRUCTIONS_COMPONENT_KEY = 'Instructions'
@@ -57,16 +58,32 @@ class Entity(prefab_lib.Prefab):
       self,
       model: language_model.LanguageModel,
       memory_bank: basic_associative_memory.AssociativeMemoryBank,
+      *,
+      act_component: entity_component.ActingComponent | None = None,
+      act_component_factory: (
+          Callable[[Sequence[str]], entity_component.ActingComponent] | None
+      ) = None,
   ) -> entity_agent_with_logging.EntityAgentWithLogging:
     """Build an agent.
 
     Args:
       model: The language model to use.
       memory_bank: The agent's memory_bank object.
+      act_component: Optional runtime acting policy, e.g. HumanActComponent.
+        Context components and logging are unchanged. Omitted by default,
+        preserving the normal LLM policy.
+      act_component_factory: Optional runtime factory receiving the exact
+        prefab context order. Use for an order-aware replacement policy.
+        Cannot be combined with act_component.
 
     Returns:
       An entity.
     """
+
+    if act_component is not None and act_component_factory is not None:
+      raise ValueError(
+          'Provide act_component or act_component_factory, not both.'
+      )
 
     agent_name = self.params.get('name', 'Alice')
     randomize_choices = self.params.get('randomize_choices', True)
@@ -119,8 +136,7 @@ class Entity(prefab_lib.Prefab):
     if extra_components:
       if not extra_components_index:
         extra_components_index = {
-            component_name: -1
-            for component_name in extra_components.keys()
+            component_name: -1 for component_name in extra_components.keys()
         }
       for component_name, index in extra_components_index.items():
         components_of_agent[component_name] = extra_components[component_name]
@@ -136,11 +152,14 @@ class Entity(prefab_lib.Prefab):
       # Place goal after the instructions.
       component_order.insert(1, goal_key)
 
-    act_component = agent_components.concat_act_component.ConcatActComponent(
-        model=model,
-        component_order=component_order,
-        randomize_choices=randomize_choices,  # pyrefly: ignore[bad-argument-type]
-    )
+    if act_component_factory is not None:
+      act_component = act_component_factory(tuple(component_order))
+    elif act_component is None:
+      act_component = agent_components.concat_act_component.ConcatActComponent(
+          model=model,
+          component_order=component_order,
+          randomize_choices=randomize_choices,  # pyrefly: ignore[bad-argument-type]
+      )
 
     agent = entity_agent_with_logging.EntityAgentWithLogging(
         agent_name=agent_name,

--- a/concordia/typing/human_input.py
+++ b/concordia/typing/human_input.py
@@ -1,0 +1,73 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transport-neutral requests for human-controlled entities.
+
+A reader may use a terminal, a GUI, or a blocking queue serviced by a web
+adapter. No transport, session, or network dependency belongs in this module.
+"""
+
+from collections.abc import Mapping
+import dataclasses
+from typing import Protocol
+
+from concordia.typing import entity as entity_lib
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class HumanInputRequest:
+  """One action request, including any feedback from an invalid response.
+
+  Attributes:
+    request_id: Opaque identifier, stable across validation retries and unique
+      for each action. Adapters should reject responses to stale requests.
+    entity_name: Entity being controlled. Adapters may route by this name or use
+      a separate reader instance per entity; no global input queue is required.
+    action_spec: The actual specification, with {name} replaced in its prompt.
+      NEXT_ACTION_SPEC requires a JSON action specification for a player.
+    contexts: Read-only snapshot of this entity's pre-act contexts. These may
+      contain private information: only show them to its human controller.
+    context: This entity's complete pre-act context assembled by the acting
+      component in its configured order, with labels and line breaks intact.
+      Transports should display this string, not reassemble the contexts map.
+    error: Human-readable validation feedback, or None on the first attempt.
+    previous_response: The invalid response, retained so a UI can allow editing.
+  """
+
+  request_id: str
+  entity_name: str
+  action_spec: entity_lib.ActionSpec
+  contexts: Mapping[str, str]
+  context: str = ''
+  error: str | None = None
+  previous_response: str | None = None
+
+
+class HumanInput(Protocol):
+  """Blocking input boundary used by HumanActComponent.
+
+  Return a string once the human submits an answer. The component retries
+  invalid responses using the same request_id and updated feedback. Do not
+  automatically resubmit an invalid answer. EOF, cancellation, and transport
+  failures should raise; they are deliberately not converted into game actions.
+
+  Transport adapters own timeouts, disconnect/reconnect behavior, and
+  cancellation. A mobile disconnect need not cancel a pending request. If an
+  exception aborts an EntityAgent action, callers should end that run rather
+  than assume the agent lifecycle has reset.
+  """
+
+  def __call__(self, request: HumanInputRequest) -> str:
+    """Wait for a response from the controller of the requested entity."""
+    ...

--- a/concordia/utils/browser_sessions.py
+++ b/concordia/utils/browser_sessions.py
@@ -1,0 +1,171 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host-approved browser roles using standard opaque HTTP cookie sessions.
+
+This is a process-lifetime session store, not an account service. Approval is
+explicit on a separate trusted host surface. Browser labels are NOT identity
+proof: hosts must verify the intended participant before approving a request.
+No role, invitation, session credential or private state belongs in a URL/log.
+"""
+
+from dataclasses import dataclass
+from http import cookies
+import secrets
+import threading
+import uuid
+
+from concordia.utils import operation_service as ops
+
+
+@dataclass
+class Browser:
+  principal: str
+  label: str = ''
+  requested_role: str = ''
+  role: str = ''
+
+
+class BrowserSessions:
+  """Bounded sessions: retain reloads, fail closed on process restart."""
+
+  def __init__(self, roles, *, capacity=128, secure=True, cookie_path='/'):
+    if not cookie_path.startswith('/') or any(
+        c in cookie_path for c in ';\r\n'
+    ):
+      raise ValueError('Invalid cookie path')
+    self.roles = tuple(roles)
+    self.secure = secure
+    self.path = cookie_path
+    self.cookie_name = 'concordia_' + uuid.uuid4().hex
+    self._sessions: dict[str, str] = {}
+    self._browsers: dict[str, Browser] = {}
+    self._capacity = capacity
+    self._lock = threading.RLock()
+
+  def identify(self, cookie_header, *, create=False):
+    """Return the internal principal and optional Set-Cookie, never a role."""
+    jar = cookies.SimpleCookie()
+    try:
+      jar.load(cookie_header or '')
+    except cookies.CookieError:
+      pass
+    morsel = jar.get(self.cookie_name)
+    with self._lock:
+      token = morsel.value if morsel else ''
+      if token in self._sessions:
+        return self._sessions[token], None
+      if not create:
+        raise ops.OperationError(
+            'unauthorized', 'Open the join page in this browser first.'
+        )
+      if len(self._sessions) >= self._capacity:
+        raise ops.OperationError(
+            'session_capacity', 'The host must start a new session.'
+        )
+      token = secrets.token_urlsafe(32)
+      principal = 'browser:' + uuid.uuid4().hex
+      self._sessions[token] = principal
+      self._browsers[principal] = Browser(principal)
+      jar = cookies.SimpleCookie()
+      jar[self.cookie_name] = token
+      jar[self.cookie_name]['path'] = self.path
+      jar[self.cookie_name]['httponly'] = True
+      jar[self.cookie_name]['samesite'] = 'Strict'
+      if self.secure:
+        jar[self.cookie_name]['secure'] = True
+      return principal, jar[self.cookie_name].OutputString()
+
+  def audience(self, principal):
+    with self._lock:
+      browser = self._browsers.get(principal)
+      if browser is None:
+        # Only the trusted local listener supplies fixed developer identity.
+        return principal if principal == 'developer' else 'visitor'
+      return 'role:' + browser.role if browser.role else 'visitor'
+
+  def request(self, principal, label, role):
+    with self._lock:
+      browser = self._browsers.get(principal)
+      if browser is None:
+        raise ops.OperationError('unauthorized', 'Open the join page first.')
+      if browser.role:
+        raise ops.OperationError(
+            'already_joined', 'This browser already holds a role.'
+        )
+      if role not in self.roles or not label.strip() or len(label) > 80:
+        raise ops.OperationError(
+            'invalid_join', 'Choose an available role and a short name.'
+        )
+      if any(b.role == role for b in self._browsers.values()):
+        raise ops.OperationError(
+            'role_taken', 'That role is already held; ask the host.'
+        )
+      browser.label, browser.requested_role = label.strip(), role
+      return {'requested_role': role, 'label': browser.label}
+
+  def approve(self, principal):
+    with self._lock:
+      browser = self._browsers.get(principal)
+      if browser is None or not browser.requested_role:
+        raise ops.OperationError(
+            'invalid_join', 'Select a pending join request.'
+        )
+      if browser.role:
+        return {'role': browser.role}
+      role = browser.requested_role
+      if any(b.role == role for b in self._browsers.values()):
+        raise ops.OperationError(
+            'role_taken', 'Role already held; no state changed.'
+        )
+      browser.role = role
+      return {'role': role}
+
+  def revoke(self, principal):
+    with self._lock:
+      browser = self._browsers.get(principal)
+      if browser is None:
+        raise ops.OperationError('invalid_join', 'Unknown join request.')
+      browser.role = browser.requested_role = ''
+      return {'revoked': True}
+
+  def own(self, principal):
+    with self._lock:
+      browser = self._browsers.get(principal)
+      return {
+          'label': browser.label if browser else '',
+          'requested_role': browser.requested_role if browser else '',
+          'roles': [
+              r
+              for r in self.roles
+              if not any(b.role == r for b in self._browsers.values())
+          ],
+      }
+
+  def pending(self):
+    with self._lock:
+      return [
+          {
+              'id': b.principal,
+              'label': b.label,
+              'requested_role': b.requested_role,
+              'role': b.role,
+          }
+          for b in self._browsers.values()
+          if b.requested_role
+      ]
+
+  def ready(self, roles):
+    with self._lock:
+      return set(roles) <= {b.role for b in self._browsers.values()}

--- a/concordia/utils/operation_service.py
+++ b/concordia/utils/operation_service.py
@@ -1,0 +1,266 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared, in-process operation registry for attached editor/CLI transports.
+
+This is not a scheduler or checkpoint manager. Registered handlers own domain
+validation and must fail before mutation. A service serializes dispatch and
+publishes audience-specific snapshots. Never register an unguarded engine edit.
+"""
+
+from collections.abc import Callable, Mapping
+import copy
+import dataclasses
+import json
+import queue
+import threading
+from typing import Any
+import uuid
+
+
+class OperationError(ValueError):
+  """A stable, actionable API error."""
+
+  def __init__(self, code: str, message: str):
+    super().__init__(message)
+    self.code = code
+
+
+@dataclasses.dataclass(frozen=True)
+class Parameter:
+  """Required scalar input; schema and validation come from this definition."""
+
+  kind: str
+  description: str
+  max_length: int = 8192
+
+  def __post_init__(self):
+    if self.kind not in ('string', 'integer'):
+      raise ValueError('Only scalar string/integer parameters are supported.')
+
+  def schema(self) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        'type': self.kind,
+        'description': self.description,
+    }
+    if self.kind == 'string':
+      result['maxLength'] = self.max_length
+    return result
+
+  def validate(self, name: str, value: Any) -> None:
+    valid = (
+        isinstance(value, str) and len(value) <= self.max_length
+        if self.kind == 'string'
+        else isinstance(value, int) and not isinstance(value, bool)
+    )
+    if not valid:
+      raise OperationError('invalid_argument', f'{name}: expected {self.kind}.')
+
+
+@dataclasses.dataclass(frozen=True)
+class Operation:
+  """One shared query/mutation definition, not a separate CLI implementation."""
+
+  name: str
+  description: str
+  parameters: Mapping[str, Parameter]
+  handler: Callable[[dict[str, Any]], Any]
+  audiences: tuple[str, ...] = ('developer',)
+  mutation: bool = False
+
+  def schema(self) -> dict[str, Any]:
+    return {
+        'name': self.name,
+        'description': self.description,
+        'mutation': self.mutation,
+        'input': {
+            'type': 'object',
+            'additionalProperties': False,
+            'required': list(self.parameters),
+            'properties': {k: v.schema() for k, v in self.parameters.items()},
+        },
+    }
+
+
+class OperationService:
+  """Authoritative scope/revision/retry ledger shared by attached transports.
+
+  Identity references denote this process lifetime, not restorable checkpoints.
+  Successful mutation retries return the original result, before stale checks.
+  A key cannot be reused for different input, audience or scope. Failure does
+  not consume a key or revision. Retry records last for the service lifetime;
+  once capacity is reached reject new mutations (never evict replay protection).
+  """
+
+  def __init__(
+      self,
+      *,
+      project_id: str,
+      branch_id: str = 'initial',
+      session_id: str | None = None,
+      retry_capacity: int = 4096,
+  ):
+    self.lock = threading.RLock()
+    self.references = {
+        'project_id': project_id,
+        'branch_id': branch_id,
+        'session_id': session_id or str(uuid.uuid4()),
+        'run_id': str(uuid.uuid4()),
+    }
+    self.revision = 0
+    self._operations: dict[str, Operation] = {}
+    self._views: dict[str, Callable[[], Any]] = {}
+    self._clients: dict[queue.Queue, str] = {}
+    self._retries: dict[str, tuple[str, dict]] = {}
+    self._retry_capacity = retry_capacity
+    self._events: list[dict] = []
+    self._origin: dict = {}
+
+  def register(self, operation: Operation) -> None:
+    if operation.name in self._operations:
+      raise ValueError(f'Duplicate operation: {operation.name}')
+    self._operations[operation.name] = operation
+
+  def set_view(self, audience: str, view: Callable[[], Any]) -> None:
+    self._views[audience] = view
+
+  def discover(self, audience: str) -> dict:
+    with self.lock:
+      return self._envelope({
+          'operations': [
+              op.schema()
+              for op in self._operations.values()
+              if audience in op.audiences
+          ]
+      })
+
+  def _envelope(self, result: Any) -> dict:
+    return copy.deepcopy({
+        'references': self.references,
+        'revision': self.revision,
+        'result': result,
+    })
+
+  def snapshot(self, audience: str) -> dict:
+    with self.lock:
+      if audience not in self._views:
+        raise OperationError('forbidden', 'No view for this audience.')
+      return self._envelope(self._views[audience]())
+
+  def events(self) -> list[dict]:
+    with self.lock:
+      return copy.deepcopy(self._events)
+
+  def publish(self, event: dict) -> None:
+    """Record a domain event; player clients get only their explicit view."""
+    with self.lock:
+      self.revision += 1
+      self._events.append(
+          {'revision': self.revision, **self._origin, **copy.deepcopy(event)}
+      )
+      for client, audience in list(self._clients.items()):
+        # Retained snapshots let slow clients recover the current state.
+        try:
+          client.put_nowait(self.snapshot(audience))
+        except queue.Full:
+          try:
+            client.get_nowait()
+          except queue.Empty:
+            pass  # A concurrent consumer freed the queue.
+          client.put_nowait(self.snapshot(audience))
+
+  def subscribe(self, audience: str) -> queue.Queue:
+    with self.lock:
+      client = queue.Queue(maxsize=16)
+      client.put(self.snapshot(audience))
+      self._clients[client] = audience
+      return client
+
+  def unsubscribe(self, client: queue.Queue) -> None:
+    with self.lock:
+      self._clients.pop(client, None)
+
+  def dispatch(self, audience: str, request: dict) -> dict:
+    """Validate before execution; the listener fixes the audience."""
+    with self.lock:
+      if not isinstance(request, dict) or set(request) - {
+          'operation',
+          'arguments',
+          'references',
+          'revision',
+          'retry_key',
+      }:
+        raise OperationError(
+            'invalid_request', 'Use the discovered operation envelope.'
+        )
+      name = request.get('operation')
+      if not isinstance(name, str):
+        raise OperationError('invalid_request', 'operation must be a string.')
+      op = self._operations.get(name)
+      if op is None or audience not in op.audiences:
+        raise OperationError(
+            'unsupported_operation',
+            'Operation unavailable for this capability; use discovery.',
+        )
+      args = request.get('arguments', {})
+      if not isinstance(args, dict) or set(args) != set(op.parameters):
+        raise OperationError(
+            'invalid_argument',
+            'Arguments must match the discovered schema exactly.',
+        )
+      for name, parameter in op.parameters.items():
+        parameter.validate(name, args[name])
+      if not op.mutation:
+        return self._envelope(op.handler(copy.deepcopy(args)))
+      key = request.get('retry_key')
+      if not isinstance(key, str) or not 1 <= len(key) <= 128:
+        raise OperationError(
+            'retry_key_required',
+            'Provide a unique retry_key (1–128 characters).',
+        )
+      fingerprint = json.dumps(
+          [audience, request], sort_keys=True, ensure_ascii=False
+      )
+      if key in self._retries:
+        original, result = self._retries[key]
+        if fingerprint != original:
+          raise OperationError(
+              'retry_conflict', 'Retry key already identifies different input.'
+          )
+        return copy.deepcopy(result)
+      if request.get('references') != self.references:
+        raise OperationError(
+            'wrong_scope', 'Attach to this session/project/run/branch first.'
+        )
+      if (
+          not isinstance(request.get('revision'), int)
+          or isinstance(request.get('revision'), bool)
+          or request['revision'] != self.revision
+      ):
+        raise OperationError(
+            'stale_revision',
+            'State changed; query current state and review your edit.',
+        )
+      if len(self._retries) >= self._retry_capacity:
+        raise OperationError(
+            'retry_capacity',
+            'Retry ledger full; export evidence and start a new service.',
+        )
+      self._origin = {'origin': audience, 'operation_id': key}
+      try:
+        result = self._envelope(op.handler(copy.deepcopy(args)))
+      finally:
+        self._origin = {}
+      self._retries[key] = (fingerprint, result)
+      return copy.deepcopy(result)

--- a/concordia/utils/operation_service.py
+++ b/concordia/utils/operation_service.py
@@ -78,6 +78,12 @@ class Operation:
   handler: Callable[[dict[str, Any]], Any]
   audiences: tuple[str, ...] = ('developer',)
   mutation: bool = False
+  audience_handlers: Mapping[str, Callable[[dict[str, Any]], Any]] | None = None
+
+  def invoke(self, audience: str, arguments: dict[str, Any]) -> Any:
+    """Select a server-bound handler; arguments cannot select another actor."""
+    handler = (self.audience_handlers or {}).get(audience, self.handler)
+    return handler(arguments)
 
   def schema(self) -> dict[str, Any]:
     return {
@@ -110,8 +116,10 @@ class OperationService:
       branch_id: str = 'initial',
       session_id: str | None = None,
       retry_capacity: int = 4096,
+      audience_resolver: Callable[[str], str] | None = None,
   ):
     self.lock = threading.RLock()
+    self.audience_resolver = audience_resolver or (lambda principal: principal)
     self.references = {
         'project_id': project_id,
         'branch_id': branch_id,
@@ -137,6 +145,7 @@ class OperationService:
 
   def discover(self, audience: str) -> dict:
     with self.lock:
+      audience = self.audience_resolver(audience)
       return self._envelope({
           'operations': [
               op.schema()
@@ -154,6 +163,7 @@ class OperationService:
 
   def snapshot(self, audience: str) -> dict:
     with self.lock:
+      audience = self.audience_resolver(audience)
       if audience not in self._views:
         raise OperationError('forbidden', 'No view for this audience.')
       return self._envelope(self._views[audience]())
@@ -194,6 +204,8 @@ class OperationService:
   def dispatch(self, audience: str, request: dict) -> dict:
     """Validate before execution; the listener fixes the audience."""
     with self.lock:
+      principal = audience
+      audience = self.audience_resolver(principal)
       if not isinstance(request, dict) or set(request) - {
           'operation',
           'arguments',
@@ -222,7 +234,7 @@ class OperationService:
       for name, parameter in op.parameters.items():
         parameter.validate(name, args[name])
       if not op.mutation:
-        return self._envelope(op.handler(copy.deepcopy(args)))
+        return self._envelope(op.invoke(audience, copy.deepcopy(args)))
       key = request.get('retry_key')
       if not isinstance(key, str) or not 1 <= len(key) <= 128:
         raise OperationError(
@@ -230,7 +242,7 @@ class OperationService:
             'Provide a unique retry_key (1–128 characters).',
         )
       fingerprint = json.dumps(
-          [audience, request], sort_keys=True, ensure_ascii=False
+          [principal, audience, request], sort_keys=True, ensure_ascii=False
       )
       if key in self._retries:
         original, result = self._retries[key]
@@ -259,7 +271,7 @@ class OperationService:
         )
       self._origin = {'origin': audience, 'operation_id': key}
       try:
-        result = self._envelope(op.handler(copy.deepcopy(args)))
+        result = self._envelope(op.invoke(audience, copy.deepcopy(args)))
       finally:
         self._origin = {}
       self._retries[key] = (fingerprint, result)

--- a/concordia/utils/simulation_server.py
+++ b/concordia/utils/simulation_server.py
@@ -66,6 +66,8 @@ class SimulationServer:
     self._current_step_data: dict[str, Any] = {}
     self._cached_entity_info: dict[str, Any] | None = None
     self._simulation: Any = None
+    self._completed = False
+    self._status_revision = 0
     self._server: socketserver.TCPServer | None = None
     self._server_thread: threading.Thread | None = None
     print(f'[SERVER INIT] SimulationServer initialized on port {port}')
@@ -131,7 +133,7 @@ class SimulationServer:
     self._html_content = html_content
 
   def set_simulation(self, simulation: Any) -> None:
-    """Set the simulation instance for dynamic state editing.
+    """Bind the simulation instance for run controls and dynamic state editing.
 
     This must be called after the Simulation object is created so that
     the server can forward edit requests to it.
@@ -139,12 +141,90 @@ class SimulationServer:
     Args:
       simulation: The Simulation instance.
     """
-    self._simulation = simulation
+    with self._server_sent_events_lock:
+      self._simulation = simulation
+      self._status_revision += 1
+      self._broadcast_locked(self._status_event_locked())
 
   @property
   def simulation(self) -> Any:
     """Get the simulation instance."""
     return self._simulation
+
+  def _status_locked(self) -> dict[str, Any]:
+    """Build a status snapshot while holding the SSE lock."""
+    running = self._step_controller.is_running
+    if self._completed:
+      state = 'completed'
+    elif self._step_controller.should_stop():
+      state = 'stopped'
+    elif self._simulation is None:
+      state = 'empty'
+    else:
+      state = 'running' if running else 'paused'
+    return {
+        'state': state,
+        'is_running': state == 'running',
+        'is_paused': not running,
+        'is_completed': self._completed,
+        'current_step': self._current_step_data.get('step', 0),
+        'revision': self._status_revision,
+    }
+
+  def get_status(self) -> dict[str, Any]:
+    """Return authoritative controls, completion and last observed step.
+
+    Bind a simulation with set_simulation() before accepting run commands.
+    A step command requests permission; only broadcast_step() updates the
+    observed counter. Call broadcast_completion() when the run finishes.
+    """
+    with self._server_sent_events_lock:
+      return self._status_locked()
+
+  def _status_event_locked(self) -> dict[str, Any]:
+    event: dict[str, Any] = {'control_status': self._status_locked()}
+    if self._completed:
+      event.update(completion=True, message='Simulation completed!')
+    return event
+
+  def _broadcast_locked(self, data: dict[str, Any]) -> None:
+    message = f'data: {json.dumps(data)}\n\n'
+    for client in list(self._server_sent_events_queues):
+      try:
+        client.put_nowait(message)
+      except queue.Full:
+        self._server_sent_events_queues.remove(client)
+
+  def execute_command(self, command: str) -> dict[str, Any]:
+    """Apply a run-control command and publish its authoritative result."""
+    actions = {
+        'play': (self._step_controller.play, 'playing'),
+        'pause': (self._step_controller.pause, 'paused'),
+        'step': (self._step_controller.step, 'stepping'),
+        'stop': (self._step_controller.stop, 'stopped'),
+    }
+    if command not in actions:
+      raise ValueError(f'Unknown command: {command}')
+    with self._server_sent_events_lock:
+      status = self._status_locked()
+      if status['state'] in ('empty', 'completed', 'stopped'):
+        return {
+            'status': 'error',
+            'message': f"Cannot {command}: simulation is {status['state']}.",
+            'control_status': status,
+        }
+      if command == 'step' and status['is_running']:
+        return {
+            'status': 'error',
+            'message': 'Pause before requesting a single step.',
+            'control_status': status,
+        }
+      action, result = actions[command]
+      action()
+      self._status_revision += 1
+      event = self._status_event_locked()
+      self._broadcast_locked(event)
+      return {'status': result, **event}
 
   def broadcast_step(self, step_data: step_controller_lib.StepData) -> None:
     """Broadcast step data to all connected Server-Sent Events clients.
@@ -152,7 +232,7 @@ class SimulationServer:
     Args:
       step_data: The step data to broadcast.
     """
-    self._current_step_data = {
+    current_step_data = {
         'step': step_data.step,
         'acting_entity': step_data.acting_entity,
         'action': step_data.action,
@@ -160,30 +240,21 @@ class SimulationServer:
         'entity_logs': step_data.entity_logs,
         'game_master': step_data.game_master,
     }
-    message = f'data: {json.dumps(self._current_step_data)}\n\n'
     with self._server_sent_events_lock:
-      dead_queues = []
-      for q in self._server_sent_events_queues:
-        try:
-          q.put_nowait(message)
-        except queue.Full:
-          dead_queues.append(q)
-      for q in dead_queues:
-        self._server_sent_events_queues.remove(q)
+      self._current_step_data = current_step_data
+      self._status_revision += 1
+      self._broadcast_locked({
+          **current_step_data,
+          'control_status': self._status_locked(),
+      })
 
   def broadcast_completion(self) -> None:
-    """Broadcast simulation completion to all connected SSE clients."""
-    completion_data = {
-        'completion': True,
-        'message': 'Simulation completed!',
-    }
-    message = f'data: {json.dumps(completion_data)}\n\n'
+    """Retain completion for status/reconnect and notify connected clients."""
     with self._server_sent_events_lock:
-      for q in self._server_sent_events_queues:
-        try:
-          q.put_nowait(message)
-        except queue.Full:
-          pass
+      self._completed = True
+      self._step_controller.pause()
+      self._status_revision += 1
+      self._broadcast_locked(self._status_event_locked())
 
   def broadcast_entity_info(self, checkpoint_data: dict[str, Any]) -> None:
     """Broadcast entity component info to all connected SSE clients.
@@ -208,6 +279,21 @@ class SimulationServer:
         except queue.Full:
           pass
 
+  def subscribe_to_events(self) -> queue.Queue[str]:
+    """Subscribe with an atomic retained snapshot, including completion."""
+    client: queue.Queue[str] = queue.Queue(maxsize=100)
+    with self._server_sent_events_lock:
+      self._server_sent_events_queues.append(client)
+      initial_events = []
+      if self._current_step_data:
+        initial_events.append(self._current_step_data)
+      if self._cached_entity_info:
+        initial_events.append(self._cached_entity_info)
+      initial_events.append(self._status_event_locked())
+      for event in initial_events:
+        client.put_nowait(f'data: {json.dumps(event)}\n\n')
+    return client
+
   def _create_handler(self):
     """Create a request handler class with access to server state."""
     server = self
@@ -230,51 +316,16 @@ class SimulationServer:
           self._serve_server_sent_events()
         elif self.path == '/status':
           self._serve_status()
-        # GET-based command endpoints for testing
-        elif self.path == '/cmd/step':
-          print('[SERVER] GET /cmd/step - calling step()')
-          sys.stdout.flush()
-          server.step_controller.step()
-          self._send_json({'status': 'stepping', 'method': 'GET'})
-        elif self.path == '/cmd/play':
-          print('[SERVER] GET /cmd/play - calling play()')
-          sys.stdout.flush()
-          server.step_controller.play()
-          self._send_json({'status': 'playing', 'method': 'GET'})
-        elif self.path == '/cmd/pause':
-          print('[SERVER] GET /cmd/pause - calling pause()')
-          sys.stdout.flush()
-          server.step_controller.pause()
-          self._send_json({'status': 'paused', 'method': 'GET'})
+        elif self.path in ('/cmd/step', '/cmd/play', '/cmd/pause'):
+          result = server.execute_command(self.path.rsplit('/', 1)[1])
+          self._send_json({**result, 'method': 'GET'})
         else:
           self.send_error(404)
 
       def do_POST(self) -> None:  # pylint: disable=invalid-name
         """Handle POST requests for simulation control commands."""
-        if self.path == '/play':
-          print('[SERVER] Calling step_controller.play()...')
-          server.step_controller.play()
-          print('[SERVER] play() completed, sending response...')
-          self._send_json({'status': 'playing'})
-          print('[SERVER] Response sent for /play')
-        elif self.path == '/pause':
-          print('[SERVER] Calling step_controller.pause()...')
-          server.step_controller.pause()
-          print('[SERVER] pause() completed, sending response...')
-          self._send_json({'status': 'paused'})
-          print('[SERVER] Response sent for /pause')
-        elif self.path == '/step':
-          print('[SERVER] Calling step_controller.step()...')
-          server.step_controller.step()
-          print('[SERVER] step() completed, sending response...')
-          self._send_json({'status': 'stepping'})
-          print('[SERVER] Response sent for /step')
-        elif self.path == '/stop':
-          print('[SERVER] Calling step_controller.stop()...')
-          server.step_controller.stop()
-          print('[SERVER] stop() completed, sending response...')
-          self._send_json({'status': 'stopped'})
-          print('[SERVER] Response sent for /stop')
+        if self.path in ('/play', '/pause', '/step', '/stop'):
+          self._send_json(server.execute_command(self.path[1:]))
         elif self.path == '/cmd/set_component_state':
           self._handle_set_component_state()
         else:
@@ -290,12 +341,7 @@ class SimulationServer:
 
       def _serve_status(self) -> None:
         """Serve current simulation status."""
-        status = {
-            'is_running': server.step_controller.is_running,
-            'is_paused': server.step_controller.is_paused,
-            'current_step': server.current_step_data.get('step', 0),
-        }
-        self._send_json(status)
+        self._send_json(server.get_status())
 
       def _serve_server_sent_events(self) -> None:
         """Serve Server-Sent Events stream."""
@@ -306,22 +352,8 @@ class SimulationServer:
         self.send_header('Access-Control-Allow-Origin', '*')
         self.end_headers()
 
-        server_sent_events_queue: queue.Queue[str] = queue.Queue(maxsize=100)
-        with server.server_sent_events_lock:
-          server.server_sent_events_queues.append(server_sent_events_queue)
-
-        if server.current_step_data:
-          initial = f'data: {json.dumps(server.current_step_data)}\n\n'
-          self.wfile.write(initial.encode('utf-8'))
-          self.wfile.flush()
-
-        # Send cached entity info if available
-        if server.cached_entity_info:
-          entity_info_msg = (
-              f'data: {json.dumps(server.cached_entity_info)}\n\n'
-          )
-          self.wfile.write(entity_info_msg.encode('utf-8'))
-          self.wfile.flush()
+        # Retained state and subsequent broadcasts share the same ordered queue.
+        server_sent_events_queue = server.subscribe_to_events()
 
         try:
           while True:

--- a/concordia/utils/simulation_server.py
+++ b/concordia/utils/simulation_server.py
@@ -25,8 +25,10 @@ import socketserver
 import sys
 import threading
 from typing import Any
+from urllib.parse import urlsplit
 
 from concordia.environment import step_controller as step_controller_lib
+from concordia.utils import browser_sessions as browser_sessions_lib
 from concordia.utils import operation_service as operation_service_lib
 
 
@@ -46,6 +48,8 @@ class SimulationServer:
       host: str = '127.0.0.1',
       operation_service: operation_service_lib.OperationService | None = None,
       audience: str = 'developer',
+      browser_sessions: browser_sessions_lib.BrowserSessions | None = None,
+      public_origin: str | None = None,
   ):
     """Initialize the simulation server.
 
@@ -60,7 +64,44 @@ class SimulationServer:
       operation_service: Optional shared operation registry. When set, only the
         capability-bound API is exposed; legacy endpoints are disabled.
       audience: Fixed audience for this listener, never supplied by a request.
+      browser_sessions: Optional host-approved cookies instead of a fixed
+        audience. Only the trusted developer listener may approve roles.
+      public_origin: Exact HTTPS proxy origin for same-origin checks.
+        Forwarded headers are not trusted to choose it; never proxy the editor.
     """
+    if (
+        browser_sessions is not None
+        and not browser_sessions.secure
+        and host not in ('127.0.0.1', '::1', 'localhost')
+    ):
+      raise ValueError(
+          'Remote browser sessions require Secure cookies and HTTPS.'
+      )
+    if (
+        browser_sessions is not None
+        and browser_sessions.secure
+        and public_origin is None
+    ):
+      raise ValueError(
+          'Secure browser sessions require an exact HTTPS public_origin.'
+      )
+    if browser_sessions is not None and operation_service is None:
+      raise ValueError('Browser sessions require a capability-bound service.')
+    if public_origin is not None:
+      origin = urlsplit(public_origin)
+      if (
+          origin.scheme != 'https'
+          or not origin.netloc
+          or origin.path
+          or origin.query
+          or origin.fragment
+          or origin.username
+      ):
+        raise ValueError(
+            'public_origin must be an exact HTTPS origin without a path.'
+        )
+    self._browser_sessions = browser_sessions
+    self._public_origin = public_origin
     self._operation_service = operation_service
     self._audience = audience
     self._port = port
@@ -312,6 +353,8 @@ class SimulationServer:
     server = self
     operation_service = self._operation_service
     audience = self._audience
+    browser_sessions = self._browser_sessions
+    public_origin = self._public_origin
 
     class Handler(http.server.BaseHTTPRequestHandler):
       """HTTP request handler for simulation server."""
@@ -320,12 +363,45 @@ class SimulationServer:
         """Suppress HTTP request logging."""
         del format, args  # Unused
 
+      def handle(self):
+        try:
+          super().handle()
+        except (ConnectionResetError, BrokenPipeError):
+          # Normal browser disconnect, including an abandoned SSE connection.
+          # An accepted mutation remains protected by the service retry ledger.
+          pass
+
+      def end_headers(self):
+        if getattr(self, '_session_cookie', None):
+          self.send_header('Set-Cookie', self._session_cookie)
+        self.send_header('Cache-Control', 'no-store')
+        super().end_headers()
+
+      def _identify(self):
+        self._request_audience = audience
+        if browser_sessions is not None:
+          try:
+            self._request_audience, self._session_cookie = (
+                browser_sessions.identify(
+                    self.headers.get('Cookie'),
+                    create=self.command == 'GET' and self.path == '/',
+                )
+            )
+          except operation_service_lib.OperationError as error:
+            self._send_json(
+                {'error': {'code': error.code, 'message': str(error)}}, 403
+            )
+            return False
+        return True
+
       def do_GET(self) -> None:  # pylint: disable=invalid-name
-        """Handle GET requests for HTML, Server-Sent Events, status, and commands."""
+        """Handle HTML, events, status and command requests."""
         print(f'[SERVER] GET request received: {self.path}')
 
         sys.stdout.flush()
         if operation_service is not None:
+          if not self._identify():
+            return
           self._handle_operation_get()
           return
         if self.path == '/':
@@ -343,6 +419,26 @@ class SimulationServer:
       def do_POST(self) -> None:  # pylint: disable=invalid-name
         """Handle POST requests for simulation control commands."""
         if operation_service is not None:
+          self.close_connection = True
+          try:
+            length = int(self.headers.get('Content-Length', 0))
+            if not 0 < length <= 1024 * 1024:
+              raise ValueError('Invalid body size')
+            self.connection.settimeout(10)
+            self._operation_body = self.rfile.read(length)
+          except (ValueError, TimeoutError, OSError):
+            self._send_json(
+                {
+                    'error': {
+                        'code': 'invalid_request',
+                        'message': 'Body must be 1 byte to 1 MiB.',
+                    }
+                },
+                400,
+            )
+            return
+          if not self._identify():
+            return
           self._handle_operation_post()
           return
         if self.path in ('/play', '/pause', '/step', '/stop'):
@@ -360,10 +456,12 @@ class SimulationServer:
         assert service is not None
         if self.path == '/':
           self._serve_html()
+        elif self.path == '/api/session' and browser_sessions is not None:
+          self._send_json(browser_sessions.own(self._request_audience))
         elif self.path == '/api/operations':
-          self._send_json(service.discover(audience))
+          self._send_json(service.discover(self._request_audience))
         elif self.path == '/api/state':
-          self._send_json(service.snapshot(audience))
+          self._send_json(service.snapshot(self._request_audience))
         elif self.path == '/api/events':
           self._serve_server_sent_events()
         else:
@@ -382,7 +480,8 @@ class SimulationServer:
         assert service is not None
         # Consume or close rejected bodies; never leave unread bytes on reuse.
         self.close_connection = True
-        if self.path != '/api/dispatch':
+        joining = self.path == '/api/join' and browser_sessions is not None
+        if self.path != '/api/dispatch' and not joining:
           self._send_json(
               {
                   'error': {
@@ -394,7 +493,12 @@ class SimulationServer:
           )
           return
         origin = self.headers.get('Origin')
-        if origin and origin != 'http://' + self.headers.get('Host', ''):
+        expected_origin = public_origin or 'http://' + self.headers.get(
+            'Host', ''
+        )
+        if (origin and origin != expected_origin) or (
+            browser_sessions is not None and origin != expected_origin
+        ):
           self._send_json(
               {
                   'error': {
@@ -411,8 +515,23 @@ class SimulationServer:
             raise ValueError('Body must be 1 byte to 1 MiB.')
           if self.headers.get_content_type() != 'application/json':
             raise ValueError('Send application/json.')
-          body = json.loads(self.rfile.read(length).decode('utf-8'))
-          self._send_json(service.dispatch(audience, body))
+          body = json.loads(self._operation_body.decode('utf-8'))
+          if joining:
+            assert browser_sessions is not None
+            if (
+                not isinstance(body, dict)
+                or set(body) != {'label', 'role'}
+                or not all(isinstance(x, str) for x in body.values())
+            ):
+              raise ValueError('Join requires label and role strings.')
+            with service.lock:
+              result = browser_sessions.request(
+                  self._request_audience, body['label'], body['role']
+              )
+              service.publish({'kind': 'browser.join_requested'})
+            self._send_json(result)
+          else:
+            self._send_json(service.dispatch(self._request_audience, body))
         except operation_service_lib.OperationError as error:
           self._send_json(
               {'error': {'code': error.code, 'message': str(error)}}, 409
@@ -444,7 +563,7 @@ class SimulationServer:
         self.close_connection = True
         service = operation_service
         client = (
-            service.subscribe(audience)
+            service.subscribe(self._request_audience)
             if service is not None
             else server.subscribe_to_events()
         )
@@ -460,7 +579,13 @@ class SimulationServer:
             try:
               message = client.get(timeout=1)
               if service is not None:
-                message = 'data: ' + json.dumps(message) + '\n\n'
+                # Re-resolve the principal at delivery, not just subscribe time.
+                # Queued snapshots must not outlive role revocation.
+                message = (
+                    'data: '
+                    + json.dumps(service.snapshot(self._request_audience))
+                    + '\n\n'
+                )
               self.wfile.write(message.encode('utf-8'))
             except queue.Empty:
               self.wfile.write(b': keepalive\n\n')

--- a/concordia/utils/simulation_server.py
+++ b/concordia/utils/simulation_server.py
@@ -27,6 +27,7 @@ import threading
 from typing import Any
 
 from concordia.environment import step_controller as step_controller_lib
+from concordia.utils import operation_service as operation_service_lib
 
 
 class SimulationServer:
@@ -43,6 +44,8 @@ class SimulationServer:
       port: int = 8080,
       html_content: str = '',
       host: str = '127.0.0.1',
+      operation_service: operation_service_lib.OperationService | None = None,
+      audience: str = 'developer',
   ):
     """Initialize the simulation server.
 
@@ -54,7 +57,12 @@ class SimulationServer:
         `/cmd/set_component_state`, which can overwrite arbitrary simulation
         state) are unauthenticated. Pass '0.0.0.0' explicitly to accept
         connections from other machines on the network.
+      operation_service: Optional shared operation registry. When set, only the
+        capability-bound API is exposed; legacy endpoints are disabled.
+      audience: Fixed audience for this listener, never supplied by a request.
     """
+    self._operation_service = operation_service
+    self._audience = audience
     self._port = port
     self._html_content = html_content
     self._host = host
@@ -72,6 +80,11 @@ class SimulationServer:
     self._server_thread: threading.Thread | None = None
     print(f'[SERVER INIT] SimulationServer initialized on port {port}')
     sys.stdout.flush()
+
+  @property
+  def is_serving(self) -> bool:
+    """Whether this listener is serving requests."""
+    return self._server is not None
 
   @property
   def host(self) -> str:
@@ -297,6 +310,8 @@ class SimulationServer:
   def _create_handler(self):
     """Create a request handler class with access to server state."""
     server = self
+    operation_service = self._operation_service
+    audience = self._audience
 
     class Handler(http.server.BaseHTTPRequestHandler):
       """HTTP request handler for simulation server."""
@@ -310,6 +325,9 @@ class SimulationServer:
         print(f'[SERVER] GET request received: {self.path}')
 
         sys.stdout.flush()
+        if operation_service is not None:
+          self._handle_operation_get()
+          return
         if self.path == '/':
           self._serve_html()
         elif self.path == '/events':
@@ -324,6 +342,9 @@ class SimulationServer:
 
       def do_POST(self) -> None:  # pylint: disable=invalid-name
         """Handle POST requests for simulation control commands."""
+        if operation_service is not None:
+          self._handle_operation_post()
+          return
         if self.path in ('/play', '/pause', '/step', '/stop'):
           self._send_json(server.execute_command(self.path[1:]))
         elif self.path == '/cmd/set_component_state':
@@ -331,6 +352,81 @@ class SimulationServer:
         else:
           print(f'[SERVER] Unknown path: {self.path}')
           self.send_error(404)
+
+      def _handle_operation_get(self) -> None:
+        # Dedicated capability-bound listeners NEVER fall through to legacy
+        # checkpoint, status or mutation routes, including developer listeners.
+        service = operation_service
+        assert service is not None
+        if self.path == '/':
+          self._serve_html()
+        elif self.path == '/api/operations':
+          self._send_json(service.discover(audience))
+        elif self.path == '/api/state':
+          self._send_json(service.snapshot(audience))
+        elif self.path == '/api/events':
+          self._serve_server_sent_events()
+        else:
+          self._send_json(
+              {
+                  'error': {
+                      'code': 'not_found',
+                      'message': 'Use /api/operations.',
+                  }
+              },
+              404,
+          )
+
+      def _handle_operation_post(self) -> None:
+        service = operation_service
+        assert service is not None
+        # Consume or close rejected bodies; never leave unread bytes on reuse.
+        self.close_connection = True
+        if self.path != '/api/dispatch':
+          self._send_json(
+              {
+                  'error': {
+                      'code': 'not_found',
+                      'message': 'Use /api/operations.',
+                  }
+              },
+              404,
+          )
+          return
+        origin = self.headers.get('Origin')
+        if origin and origin != 'http://' + self.headers.get('Host', ''):
+          self._send_json(
+              {
+                  'error': {
+                      'code': 'origin',
+                      'message': 'Same-origin requests only.',
+                  }
+              },
+              403,
+          )
+          return
+        try:
+          length = int(self.headers.get('Content-Length', 0))
+          if not 0 < length <= 1024 * 1024:
+            raise ValueError('Body must be 1 byte to 1 MiB.')
+          if self.headers.get_content_type() != 'application/json':
+            raise ValueError('Send application/json.')
+          body = json.loads(self.rfile.read(length).decode('utf-8'))
+          self._send_json(service.dispatch(audience, body))
+        except operation_service_lib.OperationError as error:
+          self._send_json(
+              {'error': {'code': error.code, 'message': str(error)}}, 409
+          )
+        except (ValueError, TypeError, UnicodeError, RecursionError):
+          self._send_json(
+              {
+                  'error': {
+                      'code': 'invalid_request',
+                      'message': 'Invalid JSON operation request.',
+                  }
+              },
+              400,
+          )
 
       def _serve_html(self) -> None:
         """Serve the visualization HTML."""
@@ -344,32 +440,40 @@ class SimulationServer:
         self._send_json(server.get_status())
 
       def _serve_server_sent_events(self) -> None:
-        """Serve Server-Sent Events stream."""
+        """Stream retained updates using the configured audience."""
+        self.close_connection = True
+        service = operation_service
+        client = (
+            service.subscribe(audience)
+            if service is not None
+            else server.subscribe_to_events()
+        )
         self.send_response(200)
         self.send_header('Content-type', 'text/event-stream')
         self.send_header('Cache-Control', 'no-cache')
         self.send_header('Connection', 'keep-alive')
-        self.send_header('Access-Control-Allow-Origin', '*')
+        if service is None:
+          self.send_header('Access-Control-Allow-Origin', '*')
         self.end_headers()
-
-        # Retained state and subsequent broadcasts share the same ordered queue.
-        server_sent_events_queue = server.subscribe_to_events()
-
         try:
-          while True:
+          while server.is_serving:
             try:
-              message = server_sent_events_queue.get(timeout=30)
+              message = client.get(timeout=1)
+              if service is not None:
+                message = 'data: ' + json.dumps(message) + '\n\n'
               self.wfile.write(message.encode('utf-8'))
-              self.wfile.flush()
             except queue.Empty:
               self.wfile.write(b': keepalive\n\n')
-              self.wfile.flush()
+            self.wfile.flush()
         except (BrokenPipeError, ConnectionResetError):
           pass
         finally:
-          with server.server_sent_events_lock:
-            if server_sent_events_queue in server.server_sent_events_queues:
-              server.server_sent_events_queues.remove(server_sent_events_queue)
+          if service is not None:
+            service.unsubscribe(client)
+          else:
+            with server.server_sent_events_lock:
+              if client in server.server_sent_events_queues:
+                server.server_sent_events_queues.remove(client)
 
       def _handle_set_component_state(self) -> None:
         """Handle POST /cmd/set_component_state for dynamic editing."""
@@ -420,11 +524,13 @@ class SimulationServer:
           print(f'[SERVER] Error setting component state: {e}')
           self._send_json({'status': 'error', 'message': str(e)})
 
-      def _send_json(self, data: dict[str, Any]) -> None:
+      def _send_json(self, data: dict[str, Any], status: int = 200) -> None:
         """Send JSON response."""
-        self.send_response(200)
+        self.send_response(status)
         self.send_header('Content-type', 'application/json')
-        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Cache-Control', 'no-store')
+        if operation_service is None:
+          self.send_header('Access-Control-Allow-Origin', '*')
         self.end_headers()
         self.wfile.write(json.dumps(data).encode('utf-8'))
 

--- a/concordia/utils/simulation_server_lifecycle_test.py
+++ b/concordia/utils/simulation_server_lifecycle_test.py
@@ -1,0 +1,218 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lifecycle HTTP/SSE regressions; no simulation or model is launched."""
+
+import json
+import queue
+import threading
+import urllib.request
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from concordia.environment import step_controller
+from concordia.utils import simulation_server
+
+
+def _request(server, path, method='GET'):
+  request = urllib.request.Request(
+      f'http://127.0.0.1:{server.bound_port}{path}', method=method
+  )
+  with urllib.request.urlopen(request, timeout=5) as response:
+    return json.load(response)
+
+
+def _step_data(step):
+  return step_controller.StepData(
+      step=step,
+      acting_entity='Alice',
+      action='Mock callback',
+      entity_actions={},
+      entity_logs={},
+  )
+
+
+class LifecycleTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.server = simulation_server.SimulationServer(port=0)
+    self.server.start()
+    self.addCleanup(self.server.stop)
+
+  @parameterized.parameters('/cmd/step', '/cmd/play', '/cmd/pause')
+  def test_empty_commands_are_rejected_without_permission(self, path):
+    response = _request(self.server, path)
+    self.assertEqual(response['status'], 'error')
+    self.assertEqual(response['control_status']['state'], 'empty')
+    self.assertTrue(self.server.step_controller.is_paused)
+    self.assertEqual(_request(self.server, '/status')['current_step'], 0)
+
+  def test_commands_publish_authoritative_status_to_all_clients(self):
+    self.server.set_simulation(object())  # Binding only; no mock engine.
+    queues = [queue.Queue(), queue.Queue()]
+    self.server.server_sent_events_queues.extend(queues)
+    revision = -1
+    for path, method, state in [
+        ('/cmd/play', 'GET', 'running'),
+        ('/pause', 'POST', 'paused'),
+        ('/play', 'POST', 'running'),
+        ('/cmd/pause', 'GET', 'paused'),
+        ('/step', 'POST', 'paused'),
+    ]:
+      response = _request(self.server, path, method)
+      status = _request(self.server, '/status')
+      self.assertEqual(status['state'], state)
+      self.assertEqual(response['control_status'], status)
+      self.assertGreater(status['revision'], revision)
+      revision = status['revision']
+      for client in queues:
+        event = json.loads(client.get(timeout=2).removeprefix('data: '))
+        self.assertEqual(event['control_status'], status)
+    # A requested step is not a completed step.
+    self.assertEqual(status['current_step'], 0)
+    self.assertTrue(self.server.step_controller.wait_for_step_permission())
+    self.assertTrue(self.server.step_controller.is_paused)
+
+  def test_completion_retains_final_step_and_rejects_resume(self):
+    self.server.set_simulation(object())
+    _request(self.server, '/play', 'POST')
+    self.server.broadcast_step(_step_data(7))
+    self.server.broadcast_completion()
+    status = _request(self.server, '/status')
+    self.assertEqual(status['state'], 'completed')
+    self.assertEqual(status['current_step'], 7)
+    self.assertTrue(status['is_completed'])
+    self.assertFalse(status['is_running'])
+    self.assertTrue(self.server.step_controller.is_paused)
+    for path, method in [
+        ('/cmd/step', 'GET'),
+        ('/play', 'POST'),
+        ('/pause', 'POST'),
+        ('/stop', 'POST'),
+    ]:
+      response = _request(self.server, path, method)
+      self.assertEqual(response['status'], 'error')
+      self.assertEqual(response['control_status'], status)
+
+  def test_sse_replays_completion_after_last_step_for_new_clients(self):
+    self.server.set_simulation(object())
+    self.server.broadcast_step(_step_data(3))
+    self.server.broadcast_completion()
+    expected = _request(self.server, '/status')
+    url = f'http://127.0.0.1:{self.server.bound_port}/events'
+    with urllib.request.urlopen(url, timeout=5) as response:
+      events = []
+      while len(events) < 2:
+        line = response.readline().decode()
+        if line.startswith('data: '):
+          events.append(json.loads(line[6:]))
+      self.assertEqual(events[0]['step'], 3)
+      self.assertEqual(events[1]['control_status'], expected)
+      self.assertTrue(events[1]['completion'])
+    # Wake the closed stream so its handler can detect disconnect promptly.
+    for _ in range(3):
+      self.server.broadcast_completion()
+
+  def test_stopped_is_not_reported_as_running(self):
+    self.server.set_simulation(object())
+    response = _request(self.server, '/stop', 'POST')
+    self.assertEqual(response['control_status']['state'], 'stopped')
+    self.assertFalse(response['control_status']['is_running'])
+    self.assertFalse(self.server.step_controller.wait_for_step_permission())
+    self.assertEqual(_request(self.server, '/cmd/play')['status'], 'error')
+
+  def test_completion_and_concurrent_command_have_ordered_terminal_status(self):
+    self.server.set_simulation(object())
+    client = self.server.subscribe_to_events()
+    client.get_nowait()  # Initial paused snapshot.
+    barrier = threading.Barrier(3)
+
+    def complete():
+      barrier.wait()
+      self.server.broadcast_completion()
+
+    def play():
+      barrier.wait()
+      self.server.execute_command('play')
+
+    threads = [threading.Thread(target=complete), threading.Thread(target=play)]
+    for thread in threads:
+      thread.start()
+    barrier.wait()
+    for thread in threads:
+      thread.join(2)
+      self.assertFalse(thread.is_alive())
+    events = []
+    while not client.empty():
+      events.append(json.loads(client.get_nowait().removeprefix('data: ')))
+    statuses = [event['control_status'] for event in events]
+    revisions = [status['revision'] for status in statuses]
+    self.assertEqual(revisions, sorted(set(revisions)))
+    self.assertEqual(statuses[-1]['state'], 'completed')
+    self.assertEqual(self.server.get_status(), statuses[-1])
+
+  def test_step_while_playing_does_not_claim_a_step(self):
+    self.server.set_simulation(object())
+    _request(self.server, '/play', 'POST')
+    response = _request(self.server, '/cmd/step')
+    self.assertEqual(response['status'], 'error')
+    self.assertTrue(self.server.step_controller.is_running)
+    self.assertEqual(response['control_status']['current_step'], 0)
+
+
+class ControllerSemanticsTest(absltest.TestCase):
+  """Exercise real permission waits, not a simulated run loop."""
+
+  def test_one_step_grants_one_permission_then_blocks_until_play(self):
+    controller = step_controller.StepController()
+    first = threading.Event()
+    second = threading.Event()
+
+    def wait_twice():
+      self.assertTrue(controller.wait_for_step_permission())
+      first.set()
+      self.assertTrue(controller.wait_for_step_permission())
+      second.set()
+
+    waiter = threading.Thread(target=wait_twice, daemon=True)
+    waiter.start()
+    try:
+      self.assertFalse(first.wait(0.05))
+      controller.step()
+      self.assertTrue(first.wait(2))
+      self.assertTrue(controller.is_paused)
+      self.assertFalse(second.wait(0.05))
+      controller.play()
+      self.assertTrue(second.wait(2))
+    finally:
+      controller.stop()
+      waiter.join(2)
+    self.assertFalse(waiter.is_alive())
+
+  def test_stop_releases_paused_waiter_without_permission(self):
+    controller = step_controller.StepController()
+    results = []
+    waiter = threading.Thread(
+        target=lambda: results.append(controller.wait_for_step_permission()),
+        daemon=True,
+    )
+    waiter.start()
+    controller.stop()
+    waiter.join(2)
+    self.assertEqual(results, [False])
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/concordia/utils/simulation_server_test.py
+++ b/concordia/utils/simulation_server_test.py
@@ -148,12 +148,14 @@ class HttpEndpointsTest(absltest.TestCase):
     self.assertFalse(payload['is_running'])
 
   def test_post_play_resumes_and_get_status_reflects_it(self):
+    self.server.set_simulation(_FakeSimulation())
     status, payload = _request(self.base_url + '/play', method='POST')
     self.assertEqual(status, 200)
     self.assertEqual(payload['status'], 'playing')
     self.assertTrue(self.server.step_controller.is_running)
 
   def test_post_pause(self):
+    self.server.set_simulation(_FakeSimulation())
     self.server.step_controller.play()
     status, payload = _request(self.base_url + '/pause', method='POST')
     self.assertEqual(status, 200)
@@ -161,6 +163,7 @@ class HttpEndpointsTest(absltest.TestCase):
     self.assertTrue(self.server.step_controller.is_paused)
 
   def test_get_based_cmd_endpoints_mirror_post_endpoints(self):
+    self.server.set_simulation(_FakeSimulation())
     status, payload = _request(self.base_url + '/cmd/play')
     self.assertEqual(status, 200)
     self.assertEqual(payload['status'], 'playing')

--- a/concordia/utils/visual_interface.py
+++ b/concordia/utils/visual_interface.py
@@ -1476,3 +1476,85 @@ def visualize_config_to_html(
 </html>"""
 
   return html
+
+
+def visualize_operations_to_html(config, *, title="Attached editor") -> str:
+  """Extend the standard diagram/inspector with discovered service operations.
+
+  Legacy controls are read-only here: all mutations use the shared registry.
+  The service supplies current state; text drafts are not an engine state store.
+  """
+  page = visualize_config_to_html(config, title=title)
+  page = page.replace("if (window.location.protocol !== 'file:')", "if (false)")
+  panel = r"""
+  <section id="operations-panel" style="position:fixed;inset:0 0 0 55%;
+  background:#20232b;color:#eee;padding:24px;overflow:auto;z-index:20">
+  <h1>Attached editor</h1><p>Runtime operations · initial prefab configuration unchanged</p>
+  <p id="op-status" role="status">Connecting…</p>
+  <label>Operation <select id="op-name"></select></label>
+  <p id="op-description"></p><form id="op-form"><div id="op-fields"></div>
+  <button id="op-submit" disabled>Apply operation</button></form>
+  <p id="op-error" role="alert"></p><h2>Current authoritative state</h2>
+  <pre id="op-state" style="white-space:pre-wrap;overflow-wrap:anywhere"></pre>
+  <details><summary>Last operation result</summary><pre id="op-result" style="white-space:pre-wrap"></pre></details>
+  </section><script>
+  (() => {
+    let current, definitions = [], dirty = false, draftRevision, draftRefs;
+    let connected = false, sending = false;
+    const $ = id => document.getElementById(id);
+    const show = state => {
+      if (current && state.revision < current.revision) return;
+      current = state;
+      $('op-state').textContent = JSON.stringify(state, null, 2);
+      $('op-status').textContent = `Connected · revision ${state.revision}`;
+      $('op-submit').disabled = sending;
+      for (const field of $('op-fields').querySelectorAll('[data-key]')) field.disabled = false;
+    };
+    function fields() {
+      dirty = false;
+      const op = definitions.find(x => x.name === $('op-name').value);
+      $('op-description').textContent = op.description;
+      $('op-fields').replaceChildren();
+      for (const [key, spec] of Object.entries(op.input.properties)) {
+        const label = document.createElement('label'); label.textContent = `${key}: ${spec.description}`;
+        const input = document.createElement(spec.type === 'string' ? 'textarea' : 'input');
+        input.dataset.key = key; input.dataset.type = spec.type; input.disabled = !connected;
+        if (spec.type !== 'string') input.type = 'number';
+        input.style.cssText = 'display:block;width:95%;min-height:60px;margin:8px 0;background:#131820;color:#eee';
+        input.addEventListener('input', () => {
+          if (!dirty) { draftRevision = current.revision; draftRefs = current.references; dirty = true; }
+        });
+        label.append(input); $('op-fields').append(label);
+      }
+    }
+    $('op-name').onchange = fields;
+    $('op-form').onsubmit = async e => {
+      e.preventDefault(); if (!current || !connected || sending) return;
+      $('op-error').textContent = '';
+      const arguments_ = {};
+      for (const field of $('op-fields').querySelectorAll('[data-key]'))
+        arguments_[field.dataset.key] = field.dataset.type === 'integer' ? Number(field.value) : field.value;
+      const request = {operation: $('op-name').value, arguments: arguments_,
+        references: dirty ? draftRefs : current.references, revision: dirty ? draftRevision : current.revision,
+        retry_key: crypto.randomUUID()};
+      sending = true; $('op-submit').disabled = true;
+      try {
+        const response = await fetch('/api/dispatch', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(request)});
+        const value = await response.json();
+        if (!response.ok) throw new Error(value.error.message);
+        $('op-result').textContent = JSON.stringify(value, null, 2); dirty = false;
+      } catch(error) { $('op-error').textContent = error.message; }
+      finally { sending = false; $('op-submit').disabled = !connected; }
+    };
+    fetch('/api/operations').then(r=>r.json()).then(value=>{
+      definitions = value.result.operations;
+      for (const op of definitions) { const option=document.createElement('option'); option.value=op.name;option.textContent=op.name;$('op-name').append(option); }
+      fields();
+    }).catch(error=>{$('op-error').textContent=error.message});
+    const events = new EventSource('/api/events');
+    events.onmessage = e => {connected = true; show(JSON.parse(e.data));};
+    events.onerror = () => {connected = false; $('op-submit').disabled = true;
+      $('op-status').textContent='Disconnected · reconnecting; drafts kept'};
+  })();
+  </script>"""
+  return page.replace("</body>", panel + "</body>")

--- a/concordia/utils/visual_interface.py
+++ b/concordia/utils/visual_interface.py
@@ -24,7 +24,6 @@ from typing import Any
 
 from concordia.typing import prefab as prefab_lib
 
-
 # Color schemes for different roles
 _COLORS = {
     prefab_lib.Role.ENTITY: {
@@ -966,6 +965,7 @@ def visualize_config_to_html(
       </div>
       <div class="sim-controls">
         <div class="status-indicator" id="status-indicator"></div>
+        <span id="run-status" role="status">Connecting</span>
         <button id="btn-play" onclick="simPlay()" title="Play">▶</button>
         <button id="btn-pause" onclick="simPause()" title="Pause">⏸</button>
         <button id="btn-step" onclick="simStep()" title="Step one timestep">1▶</button>
@@ -1240,28 +1240,40 @@ def visualize_config_to_html(
     // Simulation control functions
     let isRunning = false;
     let eventSource = null;
+    let controlStatus = null;
+    let statusRevision = -1;
+    let isConnected = false;
+
+    function applyControlStatus(status) {{
+      // HTTP replies may arrive after a newer SSE transition.
+      if (status.revision < statusRevision) return;
+      const wasCompleted = controlStatus && controlStatus.is_completed;
+      statusRevision = status.revision;
+      controlStatus = status;
+      isConnected = true;
+      isRunning = status.is_running;
+      updateStepCounter(status.current_step);
+      updateControlState();
+      if (status.is_completed && !wasCompleted) {{
+        logConsole('✓ Simulation completed', 'success');
+      }}
+    }}
 
     function simPlay() {{
       sendCommand('/cmd/play', function(response) {{
-        logConsole('▶ Simulation playing', 'success');
-        isRunning = true;
-        updateControlState();
+        logConsole('▶ Continuous execution requested', 'success');
       }});
     }}
 
     function simPause() {{
       sendCommand('/cmd/pause', function(response) {{
-        logConsole('⏸ Simulation paused', 'success');
-        isRunning = false;
-        updateControlState();
+        logConsole('⏸ Pause requested (after the current step)', 'success');
       }});
     }}
 
     function simStep() {{
       sendCommand('/cmd/step', function(response) {{
-        logConsole('⏭ Step executed', 'success');
-        isRunning = false;
-        updateControlState();
+        logConsole('⏭ Single step requested', 'success');
       }});
     }}
 
@@ -1271,7 +1283,19 @@ def visualize_config_to_html(
       xhr.onreadystatechange = function() {{
         if (xhr.readyState === 4) {{
           if (xhr.status === 200) {{
-            successCallback(xhr.responseText);
+            try {{
+              const response = JSON.parse(xhr.responseText);
+              if (response.control_status) {{
+                applyControlStatus(response.control_status);
+              }}
+              if (response.status === 'error') {{
+                logConsole(response.message, 'error');
+              }} else {{
+                successCallback(response);
+              }}
+            }} catch (err) {{
+              logConsole('Invalid server response', 'error');
+            }}
           }} else {{
             logConsole('Command failed (status ' + xhr.status + ')', 'error');
           }}
@@ -1301,17 +1325,20 @@ def visualize_config_to_html(
       const btnPause = document.getElementById('btn-pause');
       const btnStep = document.getElementById('btn-step');
 
-      if (isRunning) {{
-        indicator.className = 'status-indicator running';
-        btnPlay.classList.add('active');
-        btnPause.classList.remove('active');
-        btnStep.disabled = true;
-      }} else {{
-        indicator.className = 'status-indicator paused';
-        btnPlay.classList.remove('active');
-        btnPause.classList.add('active');
-        btnStep.disabled = false;
-      }}
+      const state = isConnected && controlStatus
+          ? controlStatus.state : 'disconnected';
+      const labels = {{
+        running: 'Running', paused: 'Paused', completed: 'Completed',
+        stopped: 'Stopped', empty: 'No simulation', disconnected: 'Disconnected'
+      }};
+      document.getElementById('run-status').textContent = labels[state];
+      indicator.className = 'status-indicator ' + state;
+      indicator.title = labels[state];
+      btnPlay.classList.toggle('active', state === 'running');
+      btnPause.classList.toggle('active', state === 'paused');
+      btnPlay.disabled = state !== 'paused';
+      btnPause.disabled = state !== 'running';
+      btnStep.disabled = state !== 'paused';
     }}
 
     function updateStepCounter(step) {{
@@ -1342,14 +1369,10 @@ def visualize_config_to_html(
       eventSource.onmessage = function(event) {{
         const data = JSON.parse(event.data);
 
-        // Handle simulation completion
-        if (data.completion) {{
-          logConsole('✓ Simulation completed', 'success');
-          document.querySelector('.step-counter').textContent = 'COMPLETE';
-          document.querySelector('.step-counter').style.color = '#00ff00';
-          isPlaying = false;
-          return;
+        if (data.control_status) {{
+          applyControlStatus(data.control_status);
         }}
+        if (data.completion) return;
 
         // Handle entity info update (component data from simulation)
         if (data.entity_info) {{
@@ -1377,6 +1400,7 @@ def visualize_config_to_html(
           return;
         }}
 
+        if (typeof data.step !== 'number') return;
         updateStepCounter(data.step);
         logConsole(`Step ${{data.step}}`, 'info');
 
@@ -1406,6 +1430,8 @@ def visualize_config_to_html(
       }};
 
       eventSource.onerror = function(err) {{
+        isConnected = false;
+        updateControlState();
         console.log('SSE connection error, reconnecting...');
       }};
     }}
@@ -1434,6 +1460,7 @@ def visualize_config_to_html(
           return r.json();
         }})
         .then(data => {{
+          applyControlStatus(data);
           logConsole('Connected to simulation server', 'success');
         }})
         .catch(err => {{

--- a/concordia/utils/visual_interface_lifecycle_browser_test.py
+++ b/concordia/utils/visual_interface_lifecycle_browser_test.py
@@ -1,0 +1,256 @@
+# Copyright 2026 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional real Chromium lifecycle checks with explicitly synthetic callbacks.
+
+Install Playwright and Chromium, then run this module with pytest -n 0.
+Uses the standard server, controller, renderer and bound minimal entities.
+No Simulation.play, engine run loop or model calls are allowed.
+"""
+
+import json
+from unittest import mock
+
+from concordia.environment import step_controller
+from concordia.environment.engines import sequential
+from concordia.language_model import no_language_model
+from concordia.prefabs.entity import minimal
+from concordia.prefabs.simulation import generic
+from concordia.typing import prefab
+from concordia.utils import simulation_server
+from concordia.utils import visual_interface
+import numpy as np
+import pytest
+
+browser_api = pytest.importorskip('playwright.sync_api')
+
+
+@pytest.fixture(scope='module', name='browser')
+def browser_fixture():
+  with browser_api.sync_playwright() as playwright:
+    chromium = playwright.chromium.launch()
+    yield chromium
+    chromium.close()
+
+
+@pytest.fixture(name='server')
+def server_fixture():
+  config = prefab.Config(
+      prefabs={'minimal': minimal.Entity()},
+      instances=[
+          prefab.InstanceConfig(
+              prefab='minimal',
+              role=prefab.Role.ENTITY,
+              params={'name': 'Alice'},
+          )
+      ],
+  )
+  with (
+      mock.patch.object(generic.Simulation, 'play', side_effect=AssertionError),
+      mock.patch.object(
+          sequential.Sequential, 'run_loop', side_effect=AssertionError
+      ),
+      mock.patch.object(
+          no_language_model.NoLanguageModel,
+          'sample_text',
+          side_effect=AssertionError,
+      ),
+      mock.patch.object(
+          no_language_model.NoLanguageModel,
+          'sample_choice',
+          side_effect=AssertionError,
+      ),
+  ):
+    simulation = generic.Simulation(
+        config=config,
+        model=no_language_model.NoLanguageModel(),
+        embedder=lambda _: np.ones(3),
+        engine=sequential.Sequential(),
+    )
+    checkpoint = simulation.make_checkpoint_data()
+    app = simulation_server.SimulationServer(
+        port=0,
+        html_content=visual_interface.visualize_config_to_html(
+            config,
+            title='Lifecycle verification — synthetic callbacks',
+            checkpoint_data=checkpoint,
+        ),
+    )
+    app.set_simulation(simulation)
+    app.broadcast_entity_info(checkpoint)
+    app.start()
+    try:
+      yield app
+    finally:
+      app.stop()
+
+
+def _assert_controls(page, state):
+  browser_api.expect(page.locator('#run-status')).to_have_text(
+      state, timeout=10000
+  )
+  for selector, enabled in [
+      ('#btn-play', state == 'Paused'),
+      ('#btn-pause', state == 'Running'),
+      ('#btn-step', state == 'Paused'),
+  ]:
+    expect = browser_api.expect(page.locator(selector))
+    if enabled:
+      expect.to_be_enabled()
+    else:
+      expect.to_be_disabled()
+  browser_api.expect(page.locator('#step-counter')).to_have_count(1)
+
+
+def _mock_step(server, step):
+  server.broadcast_step(
+      step_controller.StepData(
+          step=step,
+          acting_entity='Alice',
+          action='Synthetic callback',
+          entity_actions={'Alice': 'Synthetic callback'},
+          entity_logs={},
+      )
+  )
+
+
+def test_multitab_completion_reload_and_reconnect(browser, server, tmp_path):
+  context = browser.new_context(viewport={'width': 1440, 'height': 1000})
+  first = context.new_page()
+  second = context.new_page()
+  errors = []
+  for page in [first, second]:
+    page.on('pageerror', lambda error: errors.append(str(error)))
+  url = f'http://127.0.0.1:{server.bound_port}/'
+  try:
+    first.goto(url)
+    second.goto(url)
+    for page in [first, second]:
+      _assert_controls(page, 'Paused')
+    first.locator('#btn-play').click()
+    for page in [first, second]:
+      _assert_controls(page, 'Running')
+    # A new document while playing must use authoritative initial status.
+    second.reload()
+    _assert_controls(second, 'Running')
+    running_snapshot = second.request.get(url + 'status').json()
+    second.locator('#btn-pause').click()
+    for page in [first, second]:
+      _assert_controls(page, 'Paused')
+    with first.expect_response('**/cmd/step') as response:
+      first.locator('#btn-step').click()
+    assert response.value.json()['status'] == 'stepping'
+    assert server.step_controller.wait_for_step_permission()
+    for page in [first, second]:
+      _assert_controls(page, 'Paused')
+      browser_api.expect(page.locator('#step-counter')).to_have_text('0')
+    browser_api.expect(first.locator('#console-output')).to_contain_text(
+        'Single step requested'
+    )
+    assert 'Step executed' not in first.locator('#console-output').inner_text()
+    _mock_step(server, 1)
+    for page in [first, second]:
+      browser_api.expect(page.locator('#step-counter')).to_have_text('1')
+    first.locator('#btn-play').click()
+    _assert_controls(second, 'Running')
+    _mock_step(server, 2)
+    server.broadcast_completion()
+    for page in [first, second]:
+      _assert_controls(page, 'Completed')
+      browser_api.expect(page.locator('#step-counter')).to_have_text('2')
+    first.screenshot(path=str(tmp_path / 'completed.png'))
+    # A delayed HTTP snapshot must not resurrect an older running state.
+    first.evaluate('status => applyControlStatus(status)', running_snapshot)
+    _assert_controls(first, 'Completed')
+    second.reload()
+    _assert_controls(second, 'Completed')
+    browser_api.expect(second.locator('#step-counter')).to_have_text('2')
+    # Exercise a real failed EventSource connection and automatic reconnect.
+    context.set_offline(True)
+    first.evaluate('eventSource.close(); connectSSE();')
+    _assert_controls(first, 'Disconnected')
+    context.set_offline(False)
+    _assert_controls(first, 'Completed')
+    browser_api.expect(first.locator('#step-counter')).to_have_text('2')
+    # Subsequent/replayed step events must not reference a deleted counter.
+    _mock_step(server, 2)
+    _assert_controls(first, 'Completed')
+    browser_api.expect(first.locator('#step-counter')).to_have_text('2')
+    first.screenshot(path=str(tmp_path / 'reconnected.png'))
+    assert not errors
+    (tmp_path / 'journey.json').write_text(
+        json.dumps(
+            {
+                'tabs': 2,
+                'play_pause_synchronized': True,
+                'reload_and_reconnect_completed': True,
+                'final_step': 2,
+                'counter_nodes': first.locator('#step-counter').count(),
+                'page_errors': errors,
+                'synthetic_callbacks': 3,
+                'simulation_steps': 0,
+                'model_calls': 0,
+            },
+            indent=2,
+        ),
+        encoding='utf-8',
+    )
+  finally:
+    context.close()
+
+
+def test_empty_controls_and_rejected_command(browser, server, tmp_path):
+  server.set_simulation(None)
+  server.set_html_content(
+      visual_interface.visualize_config_to_html(
+          prefab.Config(prefabs={}, instances=[]), title='Empty configuration'
+      )
+  )
+  page = browser.new_page()
+  errors = []
+  page.on('pageerror', lambda error: errors.append(str(error)))
+  try:
+    page.goto(f'http://127.0.0.1:{server.bound_port}/')
+    _assert_controls(page, 'No simulation')
+    assert page.locator('.entity-card').count() == 0
+    # Bypass disabled button to exercise the real rejection/error UI.
+    page.evaluate('simStep()')
+    browser_api.expect(page.locator('#console-output')).to_contain_text(
+        'Cannot step: simulation is empty.'
+    )
+    assert 'Step executed' not in page.locator('#console-output').inner_text()
+    browser_api.expect(page.locator('#step-counter')).to_have_text('0')
+    assert not server.current_step_data
+    assert server.step_controller.is_paused
+    page.reload()
+    _assert_controls(page, 'No simulation')
+    assert not errors
+    page.screenshot(path=str(tmp_path / 'empty.png'))
+  finally:
+    page.close()
+
+
+def test_stopped_controls_survive_reload(browser, server):
+  page = browser.new_page()
+  try:
+    url = f'http://127.0.0.1:{server.bound_port}/'
+    page.goto(url)
+    _assert_controls(page, 'Paused')
+    response = page.request.post(url + 'stop').json()
+    assert response['status'] == 'stopped'
+    _assert_controls(page, 'Stopped')
+    page.reload()
+    _assert_controls(page, 'Stopped')
+  finally:
+    page.close()

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
             'player.html',
             'README.md',
             'GAME.md',
+            'MULTIPLAYER.md',
         ],
         'concordia.examples.astral_canticle': [
             'static/*',

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setuptools.setup(
             'README.md',
             'GAME.md',
             'MULTIPLAYER.md',
+            'VOICE.md',
         ],
         'concordia.examples.astral_canticle': [
             'static/*',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setuptools.setup(
             'VOICE.md',
             'RESEARCHER.md',
             'ENGINES.md',
+            'PUBLIC-ACCOUNT.md',
         ],
         'concordia.examples.astral_canticle': [
             'static/*',

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,11 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(include=['concordia', 'concordia.*']),
     package_data={
-        'concordia.examples.bellwether': ['player.html', 'README.md'],
+        'concordia.examples.bellwether': [
+            'player.html',
+            'README.md',
+            'GAME.md',
+        ],
         'concordia.examples.astral_canticle': [
             'static/*',
             'README.md',

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setuptools.setup(
             'GAME.md',
             'MULTIPLAYER.md',
             'VOICE.md',
+            'RESEARCHER.md',
         ],
         'concordia.examples.astral_canticle': [
             'static/*',

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(include=['concordia', 'concordia.*']),
     package_data={
+        'concordia.examples.bellwether': ['player.html', 'README.md'],
         'concordia.examples.astral_canticle': [
             'static/*',
             'README.md',
@@ -85,6 +86,7 @@ setuptools.setup(
     ),
     entry_points={
         'console_scripts': [
+            'concordia-session=concordia.command_line_interface.concordia_session:main',
             'concordia-log=concordia.command_line_interface.concordia_log:main',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,13 @@ setuptools.setup(
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ],
     packages=setuptools.find_packages(include=['concordia', 'concordia.*']),
-    package_data={},
+    package_data={
+        'concordia.examples.astral_canticle': [
+            'static/*',
+            'README.md',
+            'requirements*.txt',
+        ],
+    },
     python_requires='>=3.12',
     install_requires=(
         'absl-py',

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setuptools.setup(
             'MULTIPLAYER.md',
             'VOICE.md',
             'RESEARCHER.md',
+            'ENGINES.md',
         ],
         'concordia.examples.astral_canticle': [
             'static/*',


### PR DESCRIPTION
> **Consolidated into [#372](https://github.com/google-deepmind/concordia/pull/372).** Closed only as a superseded review thread, following [Joel Z. Leibo’s category guidance](https://github.com/google-deepmind/concordia/issues/373#issuecomment-5621250114). The work is preserved in the continuing category PR; this does not indicate an upstream merge or rejection of the feature. Continuing issue: #371; continuing PR: #372. 

---

## Summary

Closes #333.

- Make single-player/shared modes and human vs scripted/live-AI resident roles explicit.
- Add optional role-specific first-play guidance and Coordinator **Check interpretation · free** control using the existing read-only `game.preview` operation. No parser, server, engine or model change.
- Clarifications preserve drafts. Successful interpretation does not send, spend a choice, forecast consent or guarantee effects. Send remains separate/manual.
- Typed draft, turn/role and connection changes invalidate pending queries; delayed replies cannot describe a new draft. Draft recovery waits for session/role identification.
- Nell retains structured own-turn decisions; spectator gets public guidance with no preview/action control. Messages to everyone are labelled public; literal words remain inert.

## Dependency and review

Draft dependent on #330 and its existing game stack. Feature-only three-file diff: https://github.com/concordia-claw/concordia/compare/feat/bellwether-public-account-008...feat/bellwether-first-play-010 . Feature commit `1b6b6d4ed085f35aa0567d7233560832f2686f86`. No merges requested. Independent HTTP/checkpoint repairs#328/#332 are not bundled.

## Verification

- **104 Bellwether checks passed** including four new actual Chromium journeys on standard services, all old voice/export/multiplayer checks.
- New checks cover HTTP parser request shape, unchanged developer snapshot, invalid/literal input, public-everyone semantics, deliberately delayed real query delivery, draft/reconnect recovery, and actual host-approved Nell/spectator views.
- Simulation.play hard-fails in these new tests; no simulation/model launch, human/physical-Android usability claim or production action.
- 360px visual/overflow review and packaged player/guide verified; focused screenshot rerun four passed.
- Pylint[], pyrefly zero errors, formatting/import/diff checks pass.

`python -m pytest -o addopts='' concordia/examples/bellwether/guidance_browser_test.py -q`

Both hosted fresh phone nights remain unchanged; this source-only improvement is not hot-deployed or a reset. Private screenshots, local logs and recovery state excluded. Prior full-workflow acceptance denominators unchanged.
